### PR TITLE
Bugfix for writesite utility

### DIFF
--- a/POST/writesite/src/writesite.F
+++ b/POST/writesite/src/writesite.F
@@ -375,7 +375,7 @@ C****************************************************************************
         return
         endif
 
-      Call m3err ('writeSite', 0, 0, 'Map projection setup error', .TRUE.)
+      Call m3err ('writeSite', 0, 0, 'Unsupported map projection', .TRUE.)
 
       end Subroutine SetProj
 
@@ -393,6 +393,7 @@ C****************************************************************************
 
       ! external functions
       logical LL2LAM
+      logical LL2POL
 
       !  check for LAT/LON projection
       if( gdtype .eq. 1 ) then
@@ -409,7 +410,16 @@ C****************************************************************************
         return
         endif
 
-      Call m3err ('writeSite', 0, 0, 'Map projection setup error', .TRUE.)
+      !  check for polar stereographic projection
+      if( gdtype .eq. 6 ) then
+        if(.NOT.LL2POL(longitude, latitude, x, y) ) then
+          Call m3err('writesite', 0, 0, 'Lat/Lon to polar stereographic error', .TRUE.)
+          endif
+        return
+        endif
+
+
+      Call m3err ('writeSite', 0, 0, 'Unsupported map projection', .TRUE.)
 
       end Subroutine ToProj
 
@@ -452,7 +462,7 @@ C****************************************************************************
         return
         endif
 
-      Call m3err ('writeSite', 0, 0, 'Map projection setup error', .TRUE.)
+      Call m3err ('writeSite', 0, 0, 'Unsupported map projection', .TRUE.)
 
       end Subroutine ToLL   
 


### PR DESCRIPTION
	modified:   writesite.F

The original version of writesite (released with CMAQv5.2) did not support polar stereographic projections except when SITE_FILE was set to “ALL” (or not set at all, since the default behavior seems to be to internally set SITE_FILE to ALL if not set to a different value in the script).

This revised version added polar stereographic projection support to the “ToProj” subroutine in writesite.F which is called by module_site.F if SITE_FILE is set to a value different than ALL (and the corresponding SITE_FILE contains valid lon/lat entries).

In addition, the error messages at the end of the SetProj, ToProj, and ToLL subroutines in writesite.F were updated to say “Unsupported map projection” instead of “Map projection setup error”