### PR TITLE
Turn on Seasonality of Biogenic Emissions

### DIFF
--- a/CCTM/scripts/run_cctm.csh
+++ b/CCTM/scripts/run_cctm.csh
@@ -298,11 +298,10 @@ while ($TODAYJ <= $STOP_DAY )  #>Compare dates in terms of YYYYJJJ
      setenv GSPRO      $GSPROpath/gspro_biogenics_1mar2017.txt
      setenv B3GRD      $IN_BEISpath/b3grd_bench.nc
      setenv BIOG_SPRO  B10C6 #> speciation profile to use for biogenics
-     setenv BIOSW_YN   N     #> use frost date switch [ default: Y ]
-     setenv BIOSEASON  $IN_BEISpath/bioseason.12US1.2006.09apr2012_bench.nc #> ignore season switch file if BIOSW_YN = N
-     setenv SUMMER_YN  N     #> Use summer normalized emissions? [ default: Y ]
+     setenv BIOSW_YN   Y     #> use frost date switch [ default: Y ]
+     setenv BIOSEASON  $IN_BEISpath/bioseason.cmaq.2011_12US1_wetland100.ghrsst_bench.ncf #> ignore season switch file if BIOSW_YN = N
+     setenv SUMMER_YN  Y     #> Use summer normalized emissions? [ default: Y ]
      setenv PX_VERSION Y     #> MCIP is PX version? [ default: N ]
-     setenv INITIAL_RUN Y    #> non-existent or not using SOILINP [ default: N ]; default uses SOILINP
      setenv SOILINP    $OUTDIR/CCTM_SOILOUT_${RUNID}_${YESTERDAY}.nc
                              #> Biogenic NO soil input file; ignore if INITIAL_RUN = Y
   endif

--- a/DOCS/Known_Issues/README.md
+++ b/DOCS/Known_Issues/README.md
@@ -26,12 +26,29 @@ Date: 2017-8-30
 Contact: Daiwen Kang (kang.daiwen@epa.gov)
 
 ### Description  
-
+To be added.
 
 ### Scope and Impact
-
+To be added.
 
 ### Solution
 Replace CCTM/src/emis/emis/LTNG_DEFN.F file in repository with the version located in the folder CMAQv5.2-i2
  
+## *CMAQv5.2-i3:* Turn on Biogenic Emissions Seasonality By Default  
+Date: 2017-8-31  
+Contact: Ben Murphy (murphy.benjamin@epa.gov)  
+
+### Description  
+The release version of the CCTM runscript (CCTM/scripts/run_cttm.csh) instructed the model to ignore switching between summer and winter biogenic emission factors as a function of space and day. Because the default emission factor was set to winter, very little biogenic emissions from decidus plants were introduced by the model. 
+
+### Scope and Impact
+This problem must be fixed by anyone running the model for spring, summer or fall conditions. It will affect VOC, oxidant, ozone and PM predictions substantially in forrested areas.
+
+### Solution
+The runscript is currently up to date in the repository. If you are starting from scratch after Sep 1, 2017, you will not need to do anything. If you can replace your run script with the new one, it is encouraged. Otherwise simply set the following environment variables:  
+    BIOSW_YN   Y   #Will invoke the seasonality as read from the bioseason file
+    SUMMER_YN  Y   #Will default to summertime emission factors if BIOSW_YN is set to no ("N") or false ("F").  
+
+We have also updated the bioseason file for the benchmark case (Southeast US for July 1-14, 2011). This must be updated or the model will crash when attempting to read it. Please simply redownload the tarball from the CMAS center.  
+
 


### PR DESCRIPTION
The original run script in the repository did not instruct the CCTM to turn on seasonality of biogenic emissions. This PR corrects the default behavior of the run script and points to an updated bioseason file that is more consistent with the benchmark case. 

Users who have already downloaded the benchmark data should replace the previous bioseason file with the new one:
bioseason.cmaq.2011_12US1_wetland100.ghrsst_bench.ncf
It is available in the current benchmark data package,