### PR TITLE
Document resolution for consistency in treating aerosol properties

### DIFF
--- a/DOCS/Known_Issues/CMAQv5.2-i5/AEROSOL_CHEMISTRY.F
+++ b/DOCS/Known_Issues/CMAQv5.2-i5/AEROSOL_CHEMISTRY.F
@@ -1,0 +1,2267 @@
+!------------------------------------------------------------------------!
+!  The Community Multiscale Air Quality (CMAQ) system software is in     !!
+!  continuous development by various groups and is based on information  !
+!  from these groups: Federal Government employees, contractors working  !
+!  within a United States Government contract, and non-Federal sources   !
+!  including research institutions.  These groups give the Government    !
+!  permission to use, prepare derivative works of, and distribute copies !
+!  of their work in the CMAQ system to the public and to permit others   !
+!  to do so.  The United States Environmental Protection Agency          !
+!  therefore grants similar permission to use the CMAQ system software,  !
+!  but users are requested to provide copies of derivative works or      !
+!  products designed to operate in the CMAQ system to the United States  !
+!  Government without restrictions as to use by others.  Software        !
+!  that is used with the CMAQ system but distributed under the GNU       !
+!  General Public License or the GNU Lesser General Public License is    !
+!  subject to their copyright restrictions.                              !
+!------------------------------------------------------------------------!
+
+       MODULE AEROSOL_CHEMISTRY
+!-----------------------------------------------------------------------
+! Revision history
+!
+! 26 Sep 14 H. Pye: Heterogeneous uptake of IEPOX added 
+! 27 Feb 15 J. Bash:
+! 17 March 15 D. Luecken:  Added NTR heterogeneous hydrolysis as per
+!    the CB6r3 chemical mechanism used by the Environ CAMX model consult 
+!    references 8 and 9., 
+! 22 Feb 16 B.Hutzell: Added Flag stating whether module is initialized
+! 24 March 16 D. Luecken: removed the references to F_NTR2_ON so that all 
+!  nitrates have the potential to partition to aerosol.  
+! 24 Mar 16 G. Sarwar: Added heterogeneous uptake of BRONO2 on aerosols
+! 10 May 16 H. Pye: Merged with AEROSOL_CHEMISTRY.F from aero6i
+!                   Size of NAMES_AERO_RATES reduced to match RXN_DATA_MODULE
+!    May 16 H. Pye, B. Murphy: Updated treatment of aerosol moments
+! 23 May 16 C. Nolte: Allow for writing APMDIAG even if PMDIAG file turned off.
+! 23 May 16 D. Wong: Allow for calculation for APMDIAG even if PMDIAG is turned off.
+! 10 Jun 16 B.Hutzell: reduce occurrences of numerical underflow
+!-----------------------------------------------------------------------
+
+       IMPLICIT NONE
+       
+       REAL( 8 ), ALLOCATABLE :: KHETERO( :,:,:,: ) ! heterogeneous rx rates, 
+                                                    ! [ppm**(RXN Order-1)*min]**-1
+       REAL,      ALLOCATABLE :: GAMMA_N2O5IJ( :,:,:  ) ! Fine modes N2O5 rx effic.
+       REAL,      ALLOCATABLE :: GAMMA_N2O5K(  :,:,:  ) ! Coarse mode N2O5 rx effic.
+       REAL,      ALLOCATABLE :: KPARTIEPOX (  :,:,:  ) ! IEPOX particle-phase reaction rate constant (sec-1)
+       REAL,      ALLOCATABLE :: GAMMA_IEPOX(  :,:,:  ) ! IEPOX uptake coeff
+       REAL,      ALLOCATABLE :: GAMMA_IMAE (  :,:,:  ) ! IMAE uptake coeff
+       REAL,      ALLOCATABLE :: YCLNO2IJ   (  :,:,:  ) ! Yield CLNO2 in Fine modes 
+       REAL,      ALLOCATABLE :: YCLNO2K    (  :,:,:  ) ! Yield CLNO2 in coarse mode 
+
+       LOGICAL                :: AERO_CHEM_SET = .FALSE.
+      
+       PUBLIC  KHETERO, GAMMA_N2O5IJ, GAMMA_N2O5K, KPARTIEPOX, GAMMA_IEPOX, GAMMA_IMAE, 
+     &         YCLNO2IJ, YCLNO2K, HETCHEM_RATES, AERO_CHEM_SET, HETCHEM_UPDATE_AERO
+       
+       PRIVATE 
+
+       INTEGER, PARAMETER :: NUMB_AERO_RATES = 31
+       
+       CHARACTER( 16 ), PARAMETER :: NAMES_AERO_RATES( NUMB_AERO_RATES ) = 
+     &                    (/ 'HETERO_N2O5IJ   ', 'HETERO_N2O5K    ', 
+     &                       'HETERO_N2O5IJY  ', 'HETERO_N2O5KY   ', 
+     &                       'HETERO_NO2      ', 'HETERO_H2NO3PAIJ',
+     &                       'HETERO_H2NO3PBIJ', 'HETERO_H2NO3PAK ',
+     &                       'HETERO_H2NO3PBK ', 'HETERO_H2NO3PAI ',
+     &                       'HETERO_H2NO3PBI ', 'HETERO_H2NO3PAJ ',
+     &                       'HETERO_H2NO3PBJ ', 'HETERO_N2O5I    ', 
+     &                       'HETERO_N2O5J    ', 'HETERO_PNCOMLI  ',
+     &                       'HETERO_PNCOMLJ  ', 'HETERO_IEPOX    ',
+     &                       'HETERO_TETROL   ', 'HETERO_IEPOXOS  ',
+     &                       'HETERO_TETROLDIM', 'HETERO_IEPOXOSDI',
+     &                       'HETERO_IMAE     ', 'HETERO_2MG      ',
+     &                       'HETERO_IMAEOS   ', 'HETERO_NO3      ',
+     &                       'HETERO_GLY      ', 'HETERO_MGLY     ',
+     &                       'HETERO_NTR2     ', 'HETERO_BRONO2IJ ',
+     &                       'HETERO_BRONO2K  '/)
+
+       INTEGER, PARAMETER  :: IA_N2O5IJ         =   1
+       INTEGER, PARAMETER  :: IA_N2O5K          =   2
+       INTEGER, PARAMETER  :: IA_N2O5IJY        =   3
+       INTEGER, PARAMETER  :: IA_N2O5KY         =   4
+       INTEGER, PARAMETER  :: IA_NO2            =   5
+       INTEGER, PARAMETER  :: IA_H2NO3PAIJ      =   6
+       INTEGER, PARAMETER  :: IA_H2NO3PBIJ      =   7
+       INTEGER, PARAMETER  :: IA_H2NO3PAK       =   8
+       INTEGER, PARAMETER  :: IA_H2NO3PBK       =   9
+       INTEGER, PARAMETER  :: IA_H2NO3PAI       =   10
+       INTEGER, PARAMETER  :: IA_H2NO3PBI       =   11
+       INTEGER, PARAMETER  :: IA_H2NO3PAJ       =   12
+       INTEGER, PARAMETER  :: IA_H2NO3PBJ       =   13
+       INTEGER, PARAMETER  :: IA_N2O5I          =   14
+       INTEGER, PARAMETER  :: IA_N2O5J          =   15
+       INTEGER, PARAMETER  :: IA_PNCOMLI        =   16
+       INTEGER, PARAMETER  :: IA_PNCOMLJ        =   17
+       INTEGER, PARAMETER  :: IA_IEPOX          =   18
+       INTEGER, PARAMETER  :: IA_TETROL         =   19
+       INTEGER, PARAMETER  :: IA_IEPOXOS        =   20
+       INTEGER, PARAMETER  :: IA_TETROLDIM      =   21
+       INTEGER, PARAMETER  :: IA_IEPOXOSDI      =   22
+       INTEGER, PARAMETER  :: IA_IMAE           =   23
+       INTEGER, PARAMETER  :: IA_2MG            =   24
+       INTEGER, PARAMETER  :: IA_IMAEOS         =   25
+       INTEGER, PARAMETER  :: IA_NO3            =   26
+       INTEGER, PARAMETER  :: IA_GLY            =   27
+       INTEGER, PARAMETER  :: IA_MGLY           =   28
+       INTEGER, PARAMETER  :: IA_NTR2           =   29
+       INTEGER, PARAMETER  :: IA_BRONO2IJ       =   30
+       INTEGER, PARAMETER  :: IA_BRONO2K        =   31
+
+
+       INTEGER, PARAMETER :: INDEX_AERO_RATES( NUMB_AERO_RATES ) = 
+     &                    (/ IA_N2O5IJ   , IA_N2O5K    , 
+     &                       IA_N2O5IJY  , IA_N2O5KY   , 
+     &                       IA_NO2      , IA_H2NO3PAIJ,
+     &                       IA_H2NO3PBIJ, IA_H2NO3PAK ,
+     &                       IA_H2NO3PBK , IA_H2NO3PAI ,
+     &                       IA_H2NO3PBI , IA_H2NO3PAJ ,
+     &                       IA_H2NO3PBJ , IA_N2O5I    , 
+     &                       IA_N2O5J    , IA_PNCOMLI  ,
+     &                       IA_PNCOMLJ  , IA_IEPOX    ,
+     &                       IA_TETROL   , IA_IEPOXOS  ,
+     &                       IA_TETROLDIM, IA_IEPOXOSDI,
+     &                       IA_IMAE     , IA_2MG      ,
+     &                       IA_IMAEOS   , IA_NO3      ,
+     &                       IA_GLY      , IA_MGLY     ,
+     &                       IA_NTR2     ,IA_BRONO2IJ ,
+     &                       IA_BRONO2K  /)
+
+       INTEGER               :: SELECTED_AERO_RATES
+       INTEGER, ALLOCATABLE  :: WHICH_AERO_RATE( : )
+       
+       INTEGER              :: LOGDEV
+
+C *** Molecular weight
+      REAL( 8 ), SAVE        :: MWTIEPOX      ! molecular weight of IEPOX [g/mol]
+      REAL( 8 ), SAVE        :: CFACTOR_IEPOX ! factor used for the mean molecular speed of IEPOX [m/(s^1*(deg K)^0.5)]
+      REAL( 8 ), SAVE        :: MWTIMAE       ! molecular weight of IMAE [g/mol]
+      REAL( 8 ), SAVE        :: CFACTOR_IMAE  ! factor used for the mean molecular speed of IMAE [m/(s^1*(deg K)^0.5)]
+      REAL( 8 ), SAVE        :: MWTNO3        ! molecular weight of NO3 [g/mol]
+      REAL( 8 ), SAVE        :: CFACTOR_NO3   ! factor used for the mean molecular speed of NO3 [m/(s^1*(deg K)^0.5)]
+      REAL( 8 ), SAVE        :: MWTGLY        ! molecular weight of GLY [g/mol]
+      REAL( 8 ), SAVE        :: CFACTOR_GLY   ! factor used for the mean molecular speed of GLY [m/(s^1*(deg K)^0.5)]
+      REAL( 8 ), SAVE        :: MWTMGLY       ! molecular weight of MGLY [g/mol]
+      REAL( 8 ), SAVE        :: CFACTOR_MGLY  ! factor used for the mean molecular speed of MGLY [m/(s^1*(deg K)^0.5)]
+
+C *** 2nd and 3rd moments with wet species
+      REAL( 8 ), ALLOCATABLE :: WET_M3( : ) ! WET_M3_I,  WET_M3_J, WET_M3_K   ! M3 w.H2O, svOA
+      REAL( 8 ), ALLOCATABLE :: WET_M2( : ) ! WET_M2_I,  WET_M2_J, WET_M2_K   ! M2 w.H2O, svOA
+      REAL( 8 ), ALLOCATABLE :: DE_WET( : ) ! DE_AT_WET, DE_AC_WET, DE_CO_WET ! Initial effective diameter w.H2O
+      REAL( 8 ), ALLOCATABLE, SAVE :: CHEM_M3DRY_INIT( :,:,:,: ) ! Gridded M3 without H2O, svOA
+      REAL( 8 ), ALLOCATABLE, SAVE :: CHEM_M2DRY_INIT( :,:,:,: ) ! Gridded M2 without H2O, svOA
+
+
+C Isoprene product particle phase reaction rates (Eddingsaas et al. 2010) [1/(M^2 s)]
+      REAL ( 8 ), PARAMETER :: K_H_WATER    = 9.0D-4
+      REAL ( 8 ), PARAMETER :: K_H_NUC      = 2.0D-4
+      REAL ( 8 ), PARAMETER :: K_H_SO4      = 8.83D-3 ! Piletic et al. 2013, Budisulistiorini et al. in prep
+      REAL ( 8 ), PARAMETER :: K_HSO4_WATER = 1.31D-5
+      REAL ( 8 ), PARAMETER :: K_HSO4_NUC   = 2.92D-6
+
+C Acid catalyzed particle phase reactions
+      TYPE ACID_CAT
+         CHARACTER( 16 ) :: PARENT     ! gas-phase parent species
+         CHARACTER( 16 ) :: NUC        ! aerosol-phase nucleophile that adds to epoxide ring
+         CHARACTER( 16 ) :: ACID       ! acid that catalyzes epoxide ring opening
+         INTEGER         :: IDX_ACID   ! array index for acid concentration
+         INTEGER         :: IDX_REMOVE ! array index denoting whether to correct nucleophile for acid
+         REAL( 8 )       :: KCHEM      ! particle phase rate constant [1/(M^2 s)]
+         CHARACTER( 16 ) :: PROD       ! product of nucleophile+parent
+      END TYPE ACID_CAT
+
+C IEPOX uptake parameters 
+      INTEGER, SAVE                       :: N_NUCPAIRS          ! NUMBER OF ACID/NUCLEOPHILE PAIRS 
+      TYPE( ACID_CAT ), ALLOCATABLE, SAVE :: ACID_NUC_PAIRS( : )
+      INTEGER, SAVE                       :: NUMVOC              ! number of VOCs treated (IEPOX, IMAE)
+
+C IEPOX uptake parameters for standard AERO6
+      INTEGER, PARAMETER       :: N_NUCPAIRS_AE6 = 6      ! NUMBER OF ACID/NUCLEOPHILE PAIRS 
+
+C IEPOX uptake based on Eddingsaas et al. 2010 parameters
+      TYPE( ACID_CAT ), PARAMETER :: ACID_NUC_PAIRS_AE6( N_NUCPAIRS_AE6 ) = (/
+C                  Parent   Nucleophile     Acid     Acid    Remove   Rate Constant  Product
+C                 (parent)    (nuc)        (acid)    Index   Index       (kchem)      (prod)
+C                 --------  -----------  ----------  -----   ------   -------------  --------
+     &   ACID_CAT('IEPOX',  'AH2OJ    ', 'HPLUS   ',   1,     0,       K_H_WATER,    'AISO3J' ),
+     &   ACID_CAT('IEPOX',  'ASO4J    ', 'HPLUS   ',   1,     2,       K_H_SO4,      'AISO3J'  ),
+     &   ACID_CAT('IEPOX',  'ANO3J    ', 'HPLUS   ',   1,     0,       K_H_NUC,      'AISO3J'  ),
+     &   ACID_CAT('IEPOX',  'AH2OJ    ', 'HSO4    ',   2,     0,       K_HSO4_WATER, 'AISO3J' ),
+     &   ACID_CAT('IEPOX',  'ASO4J    ', 'HSO4    ',   2,     2,       K_HSO4_NUC,   'AISO3J'  ),
+     &   ACID_CAT('IEPOX',  'ANO3J    ', 'HSO4    ',   2,     0,       K_HSO4_NUC,   'AISO3J'  )/)
+
+C IEPOX + MAE uptake parameters for AERO6i
+      INTEGER, PARAMETER :: N_NUCPAIRS_AE6I = 12      ! NUMBER OF ACID/NUCLEOPHILE PAIRS
+
+C IEPOX uptake based on Eddingsaas et al. 2010 parameters. Uptake follows the implementation
+C in Pye et al. 2013 ES&T base simulation except epoxide-derived organonitrates are no longer
+C considered due to their predicted small contribution to ambient PM. In addition,
+C oligomerization of MAE/HMML-derived aerosol is not considered also due to its predicted
+C small contribution and desire to have the model "dimer" species be only IEPOX derived.
+      TYPE( ACID_CAT ), PARAMETER :: ACID_NUC_PAIRS_AE6I( N_NUCPAIRS_AE6I ) = (/
+C                  Parent   Nucleophile     Acid     Acid    Remove   Rate Constant  Product
+C                 (parent)    (nuc)        (acid)    Index   Index       (kchem)      (prod)
+C                 --------  -----------  ----------  -----   ------   -------------  --------
+     &   acid_cat('IEPOX',  'AH2OJ    ', 'HPLUS   ',   1,     0,       k_H_water,    'AIETETJ' ),
+     &   acid_cat('IEPOX',  'ASO4J    ', 'HPLUS   ',   1,     2,       k_H_SO4,      'AIEOSJ'  ),
+     &   acid_cat('IEPOX',  'AIEOSJ   ', 'HPLUS   ',   1,     0,       k_H_nuc,      'ADIMJ'   ),
+     &   acid_cat('IEPOX',  'AIETETJ  ', 'HPLUS   ',   1,     0,       k_H_nuc,      'ADIMJ'   ),
+     &   acid_cat('IEPOX',  'AH2OJ    ', 'HSO4    ',   2,     0,       k_HSO4_water, 'AIETETJ' ),
+     &   acid_cat('IEPOX',  'ASO4J    ', 'HSO4    ',   2,     2,       k_HSO4_nuc,   'AIEOSJ'  ),
+     &   acid_cat('IEPOX',  'AIEOSJ   ', 'HSO4    ',   2,     0,       k_HSO4_nuc,   'ADIMJ'   ),
+     &   acid_cat('IEPOX',  'AIETETJ  ', 'HSO4    ',   2,     0,       k_HSO4_nuc,   'ADIMJ'   ),
+     &   acid_cat('IMAE',   'AH2OJ    ', 'HPLUS   ',   1,     0,       k_H_water,    'AIMGAJ'  ),
+     &   acid_cat('IMAE',   'ASO4J    ', 'HPLUS   ',   1,     2,       k_H_nuc,      'AIMOSJ'  ),
+     &   acid_cat('IMAE',   'AH2OJ    ', 'HSO4    ',   2,     0,       k_HSO4_water, 'AIMGAJ'  ),
+     &   acid_cat('IMAE',   'ASO4J    ', 'HSO4    ',   2,     2,       k_HSO4_nuc,   'AIMOSJ'  )/)
+
+
+C Mapping array for location of acid enhanced products and nucleophiles in aerospc_conc 
+      INTEGER, ALLOCATABLE, SAVE :: ACID_PRODMAP_IDX( : )
+      INTEGER, ALLOCATABLE, SAVE ::  ACID_NUCMAP_IDX( : )
+
+      CONTAINS
+
+      SUBROUTINE HETCHEM_RATES( TEMP, PRESS, WVAPOR, CGRID, DENS )
+
+c Calculates the heterogeneous reactions for N2O5, NO2, CLNO2, and IEPOX. 
+c
+c Key Subroutines Called: EXTRACT_AERO, EXTRACT_SOA, PATPAR
+c                         N2O5_GAMMA
+c
+c 09/18/13 - B.Hutzell - initial version adapted from the hetchem.F file
+c            in aero6 module of CMAQ version 5.01. The adaptation includes
+c            heterogeneous nitryl chloride production used for Sarwar et al.
+c            (2012).
+c 09/12/14 - G. Sarwar - revised the heterogeneous nitryl chloride production
+c 09/26/14 - H. Pye - Heterogeneous uptake of IEPOX on acidic aerosol added
+c            following Pye et al. (2013).
+c 10/01/14 - B.Hutzell - change STP value for N205 diffusivity based on
+c            review paper: 1)   M. J. Tang, R. A. Cox, and M. Kalberer.
+c            Compilation and evaluation of gas-phase diffusion coefficients 
+c            of inorganic reactive trace gases in the atmosphere. Atmos. Chem.
+c            Phys. Discuss., 14, 15645–15682, 2014. 
+c            www.atmos-chem-phys-discuss.net/14/15645/2014/doi:10.5194/acpd-14-15645-2014.pdf
+c 09/12/14 - G. Sarwar - revised the heterogeneous nitryl chloride production
+C 10/01/14 - B.Hutzell - change STP value for N205 diffusivity based on
+C            review paper: 1)   M. J. Tang, R. A. Cox, and M. Kalberer.
+C            Compilation and evaluation of gas-phase diffusion coefficients 
+C            of inorganic reactive trace gases in the atmosphere. Atmos. Chem.
+C            Phys. Discuss., 14, 15645–15682, 2014. 
+C            www.atmos-chem-phys-discuss.net/14/15645/2014/doi:10.5194/acpd-14-15645-2014.pdf
+c 01/02/15 - H. Pye - Heterogeneous uptake of MAE added to saprc07tic_ae6i version
+C            heterogeneous nitryl chloride production used for Sarwar et al.
+c            (2012).
+C 02/09/15 - B.Hutzell - corrected NO2 rate by a factor of two based consulting the stoiciometery for 
+c            reaction published in Sarwar et al. (2008) and its analytical solution
+C 05/06/2015 H Pye - Added NO3 heterogeneous reaction using low end of
+C            range from Mao et al 2013 
+C 06/2015    H Pye - Added SOA from GLY and MGLY uptake onto particles
+C 09/2015    B.Hutzell - Added data and varaibles to calculate pseudo-first order rate constant 
+C            for heterogeneous hydrolysis that converts organic nitrate to nitric acid. Both are
+C            assumed gas phase species. The reaction comes the CB6r3 chemical mechanism used by 
+C            the Environ CAMX model consult references 9 and 10.
+c 03/24/16 - G. Sarwar - Heterogeneous uptake of BRONO2 on aerosols
+C 5/2016     H Pye - merged with AERO6i version (added NO3, GLY, MGLY, IMAE het rxn)
+
+c
+c  REFERENCES:
+c   1. Pleim, J.E., F.S. Binkowski, J.K.S. Ching, R.L. Dennis, and N.V.
+c      Gallani, An improved representation of the reaction of N2O5 on
+c      aerosols for mesoscale air quality models.  In "Regional
+c      Photochemical Measurement and Modeling Studies, Vol 2 - Results
+c      and Status of Modeling," Eds A.J. Ranzieri and P.A. Solomon, pp
+c      904-913, 1995.
+c
+c   2. Davis, J.M., P.V. Bhave, and K.M. Foley, Parameterization of N2O5
+c      reaction probabilities on the surface of particles containing
+c      ammonium, sulfate, and nitrate.  Atmos. Chem. Phys., 2008, in
+c      press.
+c
+c   3. Vogel, B., H. Vogel, J. Kleffman, and R. Kurtenbach, Measured and
+c      simulated vertical profiles of nitrous acid - Part II. Model
+c      simulations and indications for a photolytic source, Atmospheric
+c      Environment, 37, 2957-2966, 2003.
+c
+c   4. Sarwar, G., S.J. Roselle, R. Mathur, W. Appel, R.L. Dennis, and
+c      B. Vogel, A comparison of CMAQ HONO predictions with observations
+c      from the Northeast Oxidant and Particle Study, Atmospheric
+c      Environment, 2008, in press.
+C
+C   5. Bertram, T. H. and J.A. Thornton, Toward a general parameterization
+C      of N2O5 reactivity on aqueous particles: the competing effects of 
+C      particle liquid water, nitrate, and chloride, ACP, 9, 8351-8363, 2009 
+C
+C   6. Sarwar, G., H. Simon2, P. Bhave1, and G. Yarwood. Examining the impact of 
+C      heterogeneous nitryl chloride production on air quality across the United
+C      States. Atmos. Chem. Phys., 12, 6455-6473, 2012.
+C
+C   7. Pye et al., Epoxide pathways improve model predictions of isoprene
+C      markers and reveal key role of acidity in aerosol formation,
+C      Environ. Sci. Technol., doi: 10.1021/es402106h, 2013.
+C
+C   8. Rollins, A.W., S. Pusede, P.Wooldridge, K.-E.Min, D.R. Gentner, A.H. 
+C      Goldstein, S. Liu, D.A. Day, L.M. Russell, C.L. Rubitschun, J.D. Surratt,
+C      and R.C. Cohen, Gas/particle partitioning of total alkyl nitrates 
+C      observed with TD-LIF in Bakersfield.J.Geophys.Res., 118, 6651-6662, 2013.
+C
+C   9. Liu, S., J.E. Shilling, C. Song, N. Hiranuma, R.A. Zaveri, L.M. Russell,
+C      Hydrolysis of Organonitrate Functional Groups in Aerosol Particles.
+C      Aerosol Sci. Technol., 46, 1359-1369, 2012.
+C
+C  10. Yang, X., R. A. Cox, N. J. Warwick, J. A. Pyle, G. D. Carver, F. M.
+C      O'Connor, and N. H. Savage, Tropospheric bromine chemistry
+C      and its impacts on ozone: A model study, J. Geophys. Res., 110, D23311,
+C      doi:10.1029/2005JD006244, 2005.
+C
+C  11. Mao et al. Ozone and organic nitrates over the eastern United
+C      States: Sensitivity to isoprene chemistry, J. Geophys. Res. doi:
+C      10.1002/jgrd.50817, 2013.
+C-----------------------------------------------------------------------
+
+      USE UTILIO_DEFN
+      USE GRID_CONF             ! horizontal & vertical domain specifications
+      USE RXNS_DATA
+      USE AERO_DATA
+      USE AEROMET_DATA, ONLY: f6dpi
+      USE PRECURSOR_DATA
+      USE SOA_DEFN
+
+      IMPLICIT NONE
+
+      INCLUDE SUBST_CONST       ! CMAQ constants
+
+C *** Arguments
+      REAL,           POINTER       :: CGRID ( :,:,:,: )  ! pointer of model concentrations
+      REAL,           INTENT( IN )  :: TEMP  ( :,:,: )    ! temperature [K]
+      REAL,           INTENT( IN )  :: PRESS ( :,:,: )    ! pressure [Pa]
+      REAL,           INTENT( IN )  :: WVAPOR( :,:,: )    ! water vapor mass mixing ratio(Kg/Kg air)
+      REAL, OPTIONAL, INTENT( IN )  :: DENS ( :,:,: )     ! air density(Kg/m3 air)
+
+      CHARACTER(16), SAVE ::  PNAME = 'HETCHEM_RATES'
+      
+C *** Parameters
+      REAL( 8 ), PARAMETER :: AQUEOUS_FREQUENCY = 1.0D+9
+      REAL( 8 ), PARAMETER :: INV_SQRT_MWNO2  = 1.47425932467825D-1
+      REAL( 8 ), PARAMETER :: INV_SQRT_MWN2O5 = 9.62161363758323D-2
+      REAL( 8 ), PARAMETER :: INV_SQRT_MWBRONO2 = 8.394770000000D-2
+
+      REAL( 8 ), PARAMETER :: UGM3_CONV_FAC   = 8.31251724585556D00 ! =1.0E-3*AIRDENS_STD*(PRESS_STD/TEMP_STD)
+      REAL( 8 ), PARAMETER :: COEF1           = 7.24382926227485D10 ! Molec/cc to ppm conv factor 
+      REAL( 8 ), PARAMETER :: COEF2           = 2.14805198392421D13 ! convert air density [kg/m3] to number density [ppm]
+
+      REAL( 8 ), PARAMETER :: GAMMA_NO3       = 1.0D-4 ! Mao et al. 2013
+      REAL( 8 ), PARAMETER :: GAMMA_GLY       = 2.9D-3 ! Liggio et al. 2005
+
+      REAL( 8 ), PARAMETER :: STD_DIFF_N2O5 = 0.0855D-4  ! N2O5 molecular diffusivity at 101325 Pa and 273.15 K [m2/sec]
+      REAL( 8 ), PARAMETER :: STD_DIFF_BRONO2 = 0.0855D-4  ! BRONO2 molecular diffusivity at 101325 Pa and 273.15 K [m2/sec]
+
+      REAL,      PARAMETER :: GPKG        = 1.0E+03                      ! g/kg unit conversion
+      REAL,      PARAMETER :: CFACTOR     = 8.0 * GPKG  * RGASUNIV / PI  ! factor in cbar_coeff
+      REAL,      PARAMETER :: PA2ATM      = 1.0 / STDATMPA               ! Pascal to atm conv fac
+      REAL,      PARAMETER :: WMASS2PPM   = 1.0E6 * MWAIR / MWWAT        ! H20 mixing ratio to ppm
+      REAL,      PARAMETER :: MAOMV       = MWAIR / MWWAT
+      REAL,      PARAMETER :: CONCOFM     = 1.0E+06        ! conc. of M = 1E+06 ppm
+      REAL,      PARAMETER :: INV_STDTEMP = 1.0 / STDTEMP
+      REAL,      PARAMETER :: EPSWATER    = MWWAT / MWAIR
+C *** parameters for heterogeneous hydrolysis of NTR2
+      REAL,      PARAMETER :: ON_ALPHA1   = 0.34,     ! Organic nitrate (ON) partitioning parameters
+     &                        ON_ALPHA2   = 0.66,     ! based on Rollins et al., 2013
+     &                        ON_CSTAR1   = 0.73,
+     &                        ON_CSTAR2   = 1000.0
+
+      REAL,      PARAMETER :: MIN_TOA     = 0.0001       ! Min. conc. of total OA for partitioning to occur [ug/m3]
+      REAL,      PARAMETER :: KHON        = 2.7778E-03   ! heterogeneous ON hydrolysis rate [1/min] ~ 4/day
+
+C *** Local Variables
+      REAL( 8 )    :: AIRTEMP          ! air temperature [K]
+      REAL( 8 )    :: GAMMA            ! fine mode N2O5->NO3 rxn probability
+      REAL( 8 )    :: GAMMAIEPOX       ! IEPOX uptake coefficient
+      REAL( 8 )    :: GAMMAIMAE        ! IMAE uptake coefficient
+      REAL( 8 )    :: KPIEPOX          ! IEPOX particle-phase reaction rate const (pseudo 1st order, sec-1)
+      REAL( 8 )    :: KN2O5( N_MODE  ) ! pseudo-first order rate constant, sec-1
+      REAL( 8 )    :: KNO3(  N_MODE  ) ! pseudo-first order rate constant, sec-1
+      REAL( 8 )    :: KGLY(  N_MODE  ) ! pseudo-first order rate constant, sec-1
+      REAL( 8 )    :: KMGLY( N_MODE  ) ! pseudo-first order rate constant, sec-1
+      REAL( 8 )    :: KNO2             ! pseudo-first order rate constant, sec-1
+      REAL( 8 )    :: KBRONO2          ! pseudo-first order rate constant, sec-1
+      REAL( 8 )    :: KIEPOX           ! pseudo-first order rate constant for IEPOX uptake, sec-1
+      REAL( 8 )    :: KIMAE            ! pseudo-first order rate constant for MAE uptake, sec-1
+
+      REAL( 8 )    :: CBAR_COEFF       ! cell coefficient for mean molecular speed
+      REAL( 8 )    :: ADJUST_DIFF      ! Cell temp and press correction to diffusivity
+      REAL( 8 )    :: INV_DIFFUSIVITY  ! reciprocal molecular diffusivity [m2/sec] 
+
+      REAL( 8 )    :: XXF( N_MODE )         ! XXF_AT,    XXF_AC,    XXF_CO    ! modal factors to calculate KN2O5
+      REAL( 8 )    :: CL_PPM( N_MODE )      ! aerosol chlorine in ppm
+      REAL( 8 )    :: YIELD_CLNO2( N_MODE ) ! model reactions yields of CLNO2
+      
+      REAL( 8 )    :: H2OVP    ! ambient water vapor pressure [Atm]
+      REAL( 8 )    :: AIRRH    ! Relative Humidity            [Fractional]
+      REAL( 8 )    :: YIELDIJ  ! fine mode reaction yield, dimensionaless
+      REAL( 8 )    :: TOTSURFA ! aerosol surface area (m**2/m**3)
+      REAL( 8 )    :: FACTOR   ! scratch multiplicative factor
+      REAL( 8 )    :: RFACTOR  ! factor converting rate constant from cm3/molec/sec to 1/ppm/min
+      REAL( 8 )    :: RADIUS   ! effective particle radius [m]
+      
+      REAL( 8 )       :: CBAR             ! molecular velocity of N2O5 (m/s)
+      REAL( 8 )       :: CBARIEPOX        ! molecular velocity of IEPOX (m/s)
+      REAL( 8 )       :: CBARIMAE         ! molecular velocity of IMAE (m/s)
+      REAL( 8 )       :: CBARNO3          ! molecular velocity of NO3 (m/s)
+      REAL( 8 )       :: CBARGLY          ! molecular velocity of GLY (m/s)
+      REAL( 8 )       :: CBARMGLY         ! molecular velocity of MGLY (m/s)
+      REAL( 8 )       :: TETROL_PPM       ! accumulation mode aerosol tetrol in ppm
+      REAL( 8 )       :: IEPOXOS_PPM      ! accumulation mode iepox organosulfate in ppm
+      REAL( 8 )       :: FH2O(2)          ! fraction of epoxide aerosol from  hydrolysis, index: IEPOX(1) and MAE(2)
+      REAL( 8 )       :: FOS(2)           ! fraction of epoxide aerosol as organosulfate, index: IEPOX(1) and MAE(2)
+      REAL( 8 )       :: FDIM1(2)         ! fraction of epoxide aerosol as dimer, index: IEPOX(1) and MAE(2)
+      REAL( 8 )       :: FDIM2(2)         ! fraction of epoxide aerosol as organosulfate dimer, index: IEPOX(1) and MAE(2)
+      REAL( 8 ), SAVE :: INV_MWIETET, INV_MWIEOS  ! reciprocal of molecular weight for tetrol, iepoxos [mol/g]
+      REAL( 8 )       :: CBAR_BRONO2      ! molecular velocity of BRONO2 (m/s)
+      REAL( 8 )       :: BRONO2_RXN_TIME  ! BRONO2 reaction time per aerosol surface area density (s/m)
+
+      REAL( 8 )       :: INV_DIFF_BRONO2  ! reciprocal molecular diffusivity [m2/sec]
+      INTEGER, SAVE   :: IMAE_IDX
+      !INTEGER, SAVE   :: IHMML_IDX
+      INTEGER, SAVE   :: NO3_IDX
+      INTEGER, SAVE   :: GLY_IDX
+      INTEGER, SAVE   :: MGLY_IDX
+
+C *** variables for parameterization by Bertram and Thornton 
+      REAL         :: ACL           ! i+j or k mode chloride, ug/m3 
+      REAL         :: AH2O          ! i+j or k mode water, ug/m3          
+      REAL         :: POC           ! i or j mode primary organic carbon, ug/m3 
+      REAL         :: PNCOM         ! i or j mode primary noncarbon organic matter, ug/m3          
+      REAL,      SAVE :: MWCLH2O       ! ratio of MWCL/MWH2O 
+      REAL,      SAVE :: MWH2OCL       ! ratio of MWH20/MWCL 
+      REAL,      SAVE :: MWCLCLNO2     ! ratio of MWCL/MWCLNO2
+      REAL( 8 ), SAVE :: INV_MWCL      ! ratio of 1.0D0/MWCL 
+      REAL( 8 )       :: PPM_FACTOR    ! conversion factor to umoles/m3 to ppm
+C *** variables for heterogeneous hydrolysis of NTR2
+      REAL            :: CON_TOA       ! Conc. of total OA [ug/m3]
+      REAL            :: F_PART_NTR2   ! NTR2 fraction in the particle phase
+      
+      
+      LOGICAL, SAVE     :: FIRSTIME = .TRUE.
+      INTEGER, EXTERNAL :: SETUP_LOGDEV
+
+      INTEGER           :: IRATE        ! loop counter
+      INTEGER           :: INDX         ! found array index
+      INTEGER, SAVE     :: CLNO2_IDX
+      INTEGER, SAVE     :: IEPOX_IDX
+
+      INTEGER           :: C
+      INTEGER           :: R
+      INTEGER           :: L
+      INTEGER           :: N
+      INTEGER           :: I
+      
+C *** variables for getting aerosol diagnostic file flag
+      INTEGER           :: STATUS                      ! ENV... status
+      CHARACTER( 80 )   :: VARDESC                     ! environment variable description
+      CHARACTER( 16 )   :: CTM_PMDIAG = 'CTM_PMDIAG'   ! environment variable for PMDIAG file
+      CHARACTER( 16 )   :: CTM_APMDIAG = 'CTM_APMDIAG' ! environment variable for APMDIAG file
+      LOGICAL, SAVE     :: PMDIAG                      ! flag for PMDIAG file [F], default
+      LOGICAL, SAVE     :: APMDIAG                     ! flag for APMDIAG file [F], default
+      
+      CHARACTER( 132 )  :: XMSG
+      
+C *** Statement Function **************
+      REAL( 8 )            :: INV_ESATL ! arithmetic statement function for reciprocal vapor pressure [Pa]
+      REAL( 8 )            :: TT
+
+! reciprocal of rxn probability for BRONO2 on aerosol, Yang et al., JGR, 2005
+      REAL( 8 ), PARAMETER :: INV_GAMMA_BRONO2 = 1.0D0 / 0.3D0
+
+C *** Coefficients for the equation, ESATL defining saturation vapor pressure
+      REAL( 8 ), PARAMETER :: AL = 610.94D0 
+      REAL( 8 ), PARAMETER :: BL = 17.625D0
+      REAL( 8 ), PARAMETER :: CL = 243.04D0
+      REAL( 8 ), PARAMETER :: DL = 1.0D0 / AL
+
+
+#ifdef verbose_aerosol_chemistry
+       LOGICAL              :: DUMP_CELL
+#endif
+
+C *** values of AL, BL, and CL are from:
+C     Alduchov and Eskridge, "Improved Magnus Form Approximations of
+C                            Saturation Vapor Pressure,"
+C                            Jour. of Applied Meteorology, vol. 35,
+C                            pp 601-609, April, 1996.
+
+      INV_ESATL( TT ) = DL * DEXP( BL * ( 273.15D0 - TT ) / ( TT - 273.15D0 + CL ) )
+      
+      INTERFACE
+         SUBROUTINE GETPAR( FIXED_sg  )
+           LOGICAL, INTENT( IN ) :: FIXED_sg    ! fix coarse and accum Sg's to the input value?
+         END SUBROUTINE GETPAR
+      END INTERFACE 
+  
+C-----------------------------------------------------------------------
+
+      IF ( NHETERO .LT. 1 )RETURN
+
+C *** compute only on first pass
+
+      IF ( FIRSTIME ) THEN
+      
+        FIRSTIME = .FALSE.
+
+        LOGDEV = INIT3()
+         
+C *** Get PM diagnostic file flag.
+        PMDIAG = .TRUE.         ! default
+        VARDESC = 'Flag for writing the aerosol diagnostic file'
+        PMDIAG = ENVYN( CTM_PMDIAG, VARDESC, PMDIAG, STATUS )
+!       STATUS = 0
+        IF ( STATUS .NE. 0 ) WRITE( LOGDEV, '(5X, A)' ) VARDESC
+        IF ( STATUS .EQ. 1 ) THEN
+           XMSG = 'Environment variable improperly formatted'
+           CALL M3EXIT( PNAME, 0, 0, XMSG, XSTAT2 )
+        ELSE IF ( STATUS .EQ. -1 ) THEN
+           XMSG = 'Environment variable set, but empty ... Using default:'
+           WRITE( LOGDEV, '(5X, A, I9)' ) XMSG
+        ELSE IF ( STATUS .EQ. -2 ) THEN
+           XMSG = 'Environment variable not set ... Using default:'
+           WRITE( LOGDEV, '(5X, A, I9)' ) XMSG
+        END IF
+
+C *** Get flag for average PM diagnostic file.
+        APMDIAG = .FALSE.         ! default
+        VARDESC = 'Flag for writing the average aerosol diagnostic file'
+        APMDIAG = ENVYN( CTM_APMDIAG, VARDESC, APMDIAG, STATUS )
+!       STATUS = 0
+        IF ( STATUS .NE. 0 ) WRITE( LOGDEV, '(5X, A)' ) VARDESC
+        IF ( STATUS .EQ. 1 ) THEN
+           XMSG = 'Environment variable improperly formatted'
+           CALL M3EXIT( PNAME, 0, 0, XMSG, XSTAT2 )
+        ELSE IF ( STATUS .EQ. -1 ) THEN
+           XMSG = 'Environment variable set, but empty ... Using default:'
+           WRITE( LOGDEV, '(5X, A, I9)' ) XMSG
+        ELSE IF ( STATUS .EQ. -2 ) THEN
+           XMSG = 'Environment variable not set ... Using default:'
+           WRITE( LOGDEV, '(5X, A, I9)' ) XMSG
+        END IF
+
+        CALL MAP_AERO()
+        CALL MAP_PRECURSOR()
+
+        ALLOCATE( WHICH_AERO_RATE( NHETERO ) )
+        
+C *** 2nd and 3rd moments (w. H2O and svOA)
+        ALLOCATE(  WET_M3( N_MODE ), 
+     &             WET_M2( N_MODE ), 
+     &             DE_WET( N_MODE ) )
+C *** Allocate Gridded Dry Initial Moments so they can be saved for the
+C     end of the gas-phase chemical driver
+        ALLOCATE( CHEM_M2DRY_INIT( NCOLS,NROWS,NLAYS,N_MODE ) )
+        ALLOCATE( CHEM_M3DRY_INIT( NCOLS,NROWS,NLAYS,N_MODE ) )
+        
+        WHICH_AERO_RATE = -1
+        
+        SELECTED_AERO_RATES = 0
+        DO IRATE = 1, NHETERO
+           INDX = INDEX1( HETERO( IRATE ), NUMB_AERO_RATES, NAMES_AERO_RATES )
+           IF ( INDX .LT. 1 ) THEN
+               XMSG = 'Heterogeneous Reaction Label '// TRIM ( HETERO( IRATE ) )
+     &             // ' is not in list of available Reaction Rates.'
+               CALL M3EXIT( 'HETCHEM_RATES', 0, 0, XMSG, XSTAT3 )
+           END IF 
+           SELECTED_AERO_RATES = SELECTED_AERO_RATES + 1
+           WHICH_AERO_RATE( SELECTED_AERO_RATES ) = INDEX_AERO_RATES( INDX )
+       END DO
+
+       ALLOCATE( KHETERO( SELECTED_AERO_RATES, NCOLS,NROWS,NLAYS ) )
+       
+       IF ( PMDIAG .OR. APMDIAG ) THEN
+          ALLOCATE( GAMMA_N2O5IJ( NCOLS,NROWS,NLAYS ) )
+          ALLOCATE(  GAMMA_N2O5K( NCOLS,NROWS,NLAYS ) )
+          ALLOCATE(  GAMMA_IEPOX( NCOLS,NROWS,NLAYS ) )
+          ALLOCATE(   GAMMA_IMAE( NCOLS,NROWS,NLAYS ) )
+          ALLOCATE(   KPARTIEPOX( NCOLS,NROWS,NLAYS ) )
+          ALLOCATE(     YCLNO2IJ( NCOLS,NROWS,NLAYS ) )
+          ALLOCATE(      YCLNO2K( NCOLS,NROWS,NLAYS ) )
+       END IF
+
+C ***  Determine molecular weights
+       INV_MWCL  = REAL( 1.0 / aerospc_mw( ACL_IDX ), 8 )
+       MWCLH2O   = aerospc_mw( ACL_IDX ) / aerospc_mw( AH2O_IDX )
+       MWH2OCL   = 1.0 / MWCLH2O
+       CLNO2_IDX = INDEX1( 'CLNO2', NUMB_MECH_SPC, CHEMISTRY_SPC )
+       
+       IF ( CLNO2_IDX .GT. 0 ) THEN
+          MWCLCLNO2 = aerospc_mw( ACL_IDX) / SPECIES_MOLWT( CLNO2_IDX )
+       ELSE
+          MWCLCLNO2 = 0.0
+       END IF
+
+       IEPOX_IDX = INDEX1( 'IEPOX', NUMB_MECH_SPC, CHEMISTRY_SPC )
+       IF ( IEPOX_IDX .GT. 0 ) THEN
+          MWTIEPOX  = REAL( SPECIES_MOLWT( IEPOX_IDX ), 8 ) 
+       ELSE
+          MWTIEPOX  = 118.1D0
+       END IF
+       CFACTOR_IEPOX = DSQRT( 8.0D3 * REAL( RGASUNIV, 8 ) / ( MWTIEPOX * DPI ) )
+
+       IMAE_IDX = INDEX1( 'IMAE', NUMB_MECH_SPC, CHEMISTRY_SPC )
+       IF( IMAE_IDX .GT. 0 )THEN
+           MWTIMAE  = REAL( SPECIES_MOLWT( IMAE_IDX ), 8 )
+       ELSE
+           MWTIMAE  = 102.0D0
+       END IF
+       CFACTOR_IMAE = DSQRT( 8.0D3 * REAL( RGASUNIV, 8 ) / ( MWTIMAE * DPI ) )
+
+       IF( AIETET_IDX .GT. 0 ) THEN
+          INV_MWIETET = REAL( 1.0/ aerospc_mw( AIETET_IDX ), 8 )
+       ELSE
+          INV_MWIETET = 0.0D0
+       END IF
+
+       IF( AIEOS_IDX .GT. 0 ) THEN
+          INV_MWIEOS  = REAL( 1.0/ aerospc_mw( AIEOS_IDX  ), 8 )
+       ELSE 
+          INV_MWIEOS = 0.0D0
+       END IF
+
+       NO3_IDX = INDEX1( 'NO3', NUMB_MECH_SPC, CHEMISTRY_SPC )
+       IF( NO3_IDX .GT. 0 )THEN
+           MWTNO3  = REAL( SPECIES_MOLWT( NO3_IDX ), 8 )
+       ELSE
+           MWTNO3  = 62.01D0
+       END IF
+       CFACTOR_NO3 = DSQRT( 8.0D3 * REAL( RGASUNIV, 8 ) / ( MWTNO3 * DPI ) )
+
+       GLY_IDX = INDEX1( 'GLY', NUMB_MECH_SPC, CHEMISTRY_SPC )
+       IF( GLY_IDX .GT. 0 )THEN
+           MWTGLY  = REAL( SPECIES_MOLWT( GLY_IDX ), 8 )
+       ELSE
+           MWTGLY  = 58.04D0
+       END IF
+       CFACTOR_GLY = DSQRT( 8.0D3 * REAL( RGASUNIV, 8 ) / ( MWTGLY * DPI ) )
+
+       MGLY_IDX = INDEX1( 'MGLY', NUMB_MECH_SPC, CHEMISTRY_SPC )
+       IF( MGLY_IDX .GT. 0 )THEN
+           MWTMGLY  = REAL( SPECIES_MOLWT( MGLY_IDX ), 8 )
+       ELSE
+           MWTMGLY  = 72.07D0
+       END IF
+       CFACTOR_MGLY = DSQRT( 8.0D3 * REAL( RGASUNIV, 8 ) / ( MWTMGLY * DPI ) )
+
+C ***  Map to acids/nucleophiles for epoxide uptake
+       INDX =  INDEX1( NAMES_AERO_RATES( IA_IEPOX ), NHETERO, HETERO )   
+       IF ( INDX .GT. 0 ) THEN ! Find indices for acid catalyzed species in IEPOX reaction
+          If ( INDEX( MECHNAME, 'SAPRC07TIC_AE6I' ) .GT. 0 ) then
+             NUMVOC         = 2
+             N_NUCPAIRS     = N_NUCPAIRS_AE6I
+             ALLOCATE ( ACID_NUC_PAIRS( N_NUCPAIRS ) )
+             ACID_NUC_PAIRS = ACID_NUC_PAIRS_AE6I
+          Else ! AERO6
+             NUMVOC         = 1
+             N_NUCPAIRS     = N_NUCPAIRS_AE6
+             ALLOCATE ( ACID_NUC_PAIRS( N_NUCPAIRS ) )
+             ACID_NUC_PAIRS = ACID_NUC_PAIRS_AE6
+          END IF
+          ALLOCATE ( ACID_PRODMAP_IDX( N_NUCPAIRS ) )
+          ALLOCATE (  ACID_NUCMAP_IDX( N_NUCPAIRS ) )
+          ACID_PRODMAP_IDX = 0
+          ACID_NUCMAP_IDX  = 0
+          DO N = 1, N_NUCPAIRS
+            ACID_PRODMAP_IDX(N) = FINDAERO( ACID_NUC_PAIRS(N)%PROD, .TRUE. )
+            ACID_NUCMAP_IDX(N)  = FINDAERO( ACID_NUC_PAIRS(N)%NUC,  .TRUE. )
+#ifdef verbose_aerosol_chemistry        
+            Write( logdev,'( 5x, a, i4 )' ) acid_nuc_pairs(n)%prod, acid_prodmap_idx(n)
+            Write( logdev,'( 5x, a, i4 )' ) acid_nuc_pairs(n)%nuc,  acid_nucmap_idx(n)
+#endif
+          END DO
+       END IF
+
+       AERO_CHEM_SET = .TRUE.
+
+      END IF   ! first time condition
+
+      KHETERO = 0.0D0
+      
+      IF ( PMDIAG .OR. APMDIAG ) THEN
+         GAMMA_N2O5IJ = 0.0
+         GAMMA_N2O5K  = 0.0
+         YCLNO2IJ     = 0.0
+         YCLNO2K      = 0.0
+         GAMMA_IEPOX  = 0.0
+         GAMMA_IMAE   = 0.0
+         KPARTIEPOX   = 0.0
+      END IF
+     
+C *** Calculate rate constants at each grid cell location
+      LOOP_LAY: DO L = 1, NLAYS
+         LOOP_ROW: DO R = 1, MY_NROWS
+            LOOP_COL: DO C = 1, MY_NCOLS
+     
+#ifdef verbose_aerosol_chemistry        
+               IF ( L .EQ. 1 .AND. R .EQ. INT(MY_NROWS/2)+1 .AND.
+     &              C .EQ. INT(MY_NCOLS/2)+1 ) THEN
+                  DUMP_CELL = .TRUE.
+               ELSE
+                  DUMP_CELL = .FALSE.
+               END IF
+#endif         
+      
+C *** extract grid cell concentrations of aero species from CGRID
+C     into aerospc_conc in aero_data module
+C     also converts dry surface area to wet second moment
+               CALL EXTRACT_AERO ( CGRID( C,R,L,: ), .TRUE. )
+
+C *** extract soa concentrations from CGRID
+               CALL EXTRACT_SOA ( CGRID( C,R,L,: ) )
+
+C *** extract in inorganic aerosol processors
+
+               CALL EXTRACT_PRECURSOR( CGRID( C,R,L,: ) ) 
+               
+               AIRTEMP = REAL( TEMP( C,R,L ), 8 )
+
+C *** to compute RH & molecular kinetic factors
+
+               H2OVP = REAL( PRESS( C,R,L ) * WVAPOR( C,R,L )
+     &               / ( EPSWATER  + WVAPOR( C,R,L ) ), 8 )    
+     
+               AIRRH = MAX( 0.005D0, MIN( 0.99D0, H2OVP * INV_ESATL( AIRTEMP ) ) )
+
+               CBAR_COEFF  = REAL( SQRT( CFACTOR * TEMP( C,R,L ) ), 8) 
+               
+               ADJUST_DIFF = REAL( ( TEMP( C,R,L ) * INV_STDTEMP ) ** 1.75 * ( STDATMPA / PRESS( C,R,L ) ), 8 )
+
+               IF ( PRESENT( DENS ) ) THEN
+                  PPM_FACTOR  = 1.0D-3 * REAL( MWAIR / DENS( C,R,L ), 8 )
+               ELSE
+                  PPM_FACTOR  = UGM3_CONV_FAC * REAL( TEMP( C,R,L ) / PRESS( C,R,L ), 8 )
+               END IF
+              
+               RFACTOR = 60.0D0 * COEF1 * REAL( PRESS( C,R,L ) / TEMP( C,R,L ), 8 )
+
+C *** Update geometric mean diameters, geometric
+C     standard deviations, modal mass totals, and modal particle
+C     densities, based on the concentrations of M2, M0, and speciated
+C     masses.
+               CALL getpar( FIXED_sg )
+    
+C *** set up variables needed for calculating KN2O5 and YIELD_CLNO2
+
+               DO N = 1, N_MODE
+C *** estimate the "wet third moments" from moment3_conc
+C     Note: this is the H2O concentration from previous time step
+                  WET_M3( N ) = REAL( MOMENT3_CONC( N ), 8 )
+C *** calculate "wet second moment" assuming that H2O does not
+C     affect the geometric standard deviation
+                  WET_M2( N ) = REAL( MOMENT2_CONC( N ), 8 ) 
+C *** The "wet" geometric mean (same as median) diameter was updated in
+C     getpar. It is stored in aeromode_diam
+C *** calculate effective diameter (this is actually the mean) using Eq 3 of Pleim et al (1995)
+                  DE_WET( N ) = REAL( AEROMODE_DIAM( N ) * EXP( 1.5 * AEROMODE_LNSG( N ) ** 2 ), 8)
+               END DO
+
+C *** Retrieve and Save the Dry 3rd and 2nd Moments
+               CALL calcmoments( .False. )
+               CHEM_M2DRY_INIT( C,R,L,: ) = REAL( MOMENT2_CONC( : ), 8 )
+               CHEM_M3DRY_INIT( C,R,L,: ) = REAL( MOMENT3_CONC( : ), 8 )
+
+C *** calculate molecular speeds (m/s) using Eq 4 of Pleim et al (1995)
+
+               CBAR = CBAR_COEFF * INV_SQRT_MWN2O5 
+               CBARNO3 = CFACTOR_NO3 * DSQRT( AIRTEMP )
+               CBARGLY = CFACTOR_GLY  * DSQRT( AIRTEMP )
+               CBARMGLY = CFACTOR_MGLY * DSQRT( AIRTEMP )
+
+C *** correct N2O5 molecular diffusivity for ambient conditions
+
+               INV_DIFFUSIVITY = 1.0D0 / ( STD_DIFF_N2O5 * ADJUST_DIFF )
+
+C *** correct BRONO2 molecular diffusivity for ambient conditions - assumed similar to that of N2O5
+
+               INV_DIFF_BRONO2 = 1.0D0 / ( STD_DIFF_BRONO2 * ADJUST_DIFF )
+
+C *** get KN2O5 rate constants YIELD_CLNO2 for each mode
+               YIELD_CLNO2 = 0.0D0
+               YIELDIJ     = 0.0D0
+
+               DO N = 1, N_MODE          
+
+                  IF ( N .LE. 2 ) THEN
+                     GAMMA = N2O5_GAMMA( AIRTEMP, AIRRH, 0 )
+                     IF ( PMDIAG .OR. APMDIAG ) GAMMA_N2O5IJ( C,R,L ) = REAL( GAMMA, 4 )
+                  ELSE IF ( N .EQ. 3 ) THEN
+                     GAMMA = N2O5_GAMMA( AIRTEMP, AIRRH, 5 )
+                     IF ( PMDIAG .OR. APMDIAG ) GAMMA_N2O5K( C,R,L ) = REAL( GAMMA, 4 )
+                  ELSE
+                     GAMMA = 0.0D0
+                  END IF
+                                     
+                  XXF( N ) = WET_M2( N )
+     &                    / ( 4.0D0 + 0.5D0 * DE_WET( N ) * GAMMA * CBAR * INV_DIFFUSIVITY )
+     
+                  KN2O5( N ) = GAMMA * XXF( N )
+
+                  IF ( GAMMA_NO3 .GT. 0.0D0 ) THEN
+                     KNO3( N ) = GAMMA_NO3 * WET_M2( N ) 
+     &                         / ( 4.0D0 + 0.5D0 * DE_WET( N ) * GAMMA_NO3 
+     &                         * CBARNO3 * INV_DIFFUSIVITY ) * CBARNO3 * DPI
+                  ELSE
+                     KNO3( N ) = 0.0d0
+                  END IF
+
+                  IF( GAMMA_GLY .GT. 0.0D0) THEN
+                     KGLY( N ) = GAMMA_GLY * WET_M2( N ) 
+     &                         / ( 4.0D0 + 0.5D0 * DE_WET( N ) * GAMMA_GLY 
+     &                         * CBARGLY * INV_DIFFUSIVITY ) * CBARGLY * DPI
+                     ! scale MGLY uptake by relative H-law (Marais et
+                     ! al. ACPD approach) implemented 1/2016 H. Pye
+                     KMGLY( N ) = 0.09 * GAMMA_GLY * WET_M2( N ) 
+     &                          / ( 4.0D0 + 0.5D0 * DE_WET( N ) * 0.09 * GAMMA_GLY 
+     &                          * CBARMGLY * INV_DIFFUSIVITY ) * CBARMGLY * DPI
+                  ELSE
+                     KGLY( N ) = 0.0D0
+                     KMGLY( N ) = 0.0D0
+                  END IF
+
+
+c *** get fine aerosol H2O and chlorine concentrations in
+                  AH2O = aerospc_conc( AH2O_IDX,N )
+                  ACL  = aerospc_conc( ACL_IDX, N )
+
+                  CL_PPM( N ) = PPM_FACTOR * ( ACL * INV_MWCL )
+
+C *** If only a small amount of water is present on aerosol, keep YIELD_CLNO2 zero
+                 IF ( AH2O .GT. 5.0E-01 .AND. ACL .GT. 1.0E-04 ) THEN
+                     IF ( MWH2OCL * ACL .GT. 1.0E-4 * AH2O ) THEN 
+                        YIELD_CLNO2( N ) = 1.0D0
+     &                                   / ( 1.0D0 + ( 1.0D0 / 483.0D0 ) * ( AH2O / ACL ) * MWCLH2O )
+                     END IF
+                  END IF
+ 
+               END DO ! End each mode 
+
+c *** compute yield from lumped Aitken and Accumulations concentrations
+               AH2O = aerospc_conc( AH2O_IDX,1 ) + aerospc_conc( AH2O_IDX,2 )
+               ACL  = aerospc_conc( ACL_IDX,1 )  + aerospc_conc( ACL_IDX,2 )
+               IF ( AH2O .GT. 5.0E-01 .AND. ACL .GT. 1.0E-04 ) THEN
+                  IF ( MWH2OCL * ACL .GT. 1.0E-4 * AH2O ) THEN 
+                     YIELDIJ = 1.0D0 / ( 1.0D0 + ( 1.0D0 / 483.0D0 )
+     &                       * REAL( ( AH2O / ACL ) * MWCLH2O, 8 ) )
+                  END IF
+               END IF  
+              
+               KN2O5 = CBAR * DPI * KN2O5
+C *** calculate aerosol surface area
+               TOTSURFA = ( WET_M2( 1 ) + WET_M2( 2 ) ) * DPI
+
+C *** set up variables needed for calculating K_BRONO2
+               CBAR_BRONO2 = CBAR_COEFF * INV_SQRT_MWBRONO2
+               BRONO2_RXN_TIME = 4.0D0 * INV_GAMMA_BRONO2 / CBAR_BRONO2
+
+C *** Calculate IEPOX and MAE uptake information for accumulation mode
+               RADIUS    = 0.5D0 * DE_WET( 2 ) ! particle size
+               CBARIEPOX = CFACTOR_IEPOX * DSQRT( AIRTEMP )
+               CBARIMAE  = CFACTOR_IMAE  * DSQRT( AIRTEMP )
+
+               ! Rate constants and concentrations
+               CALL CALCISOPGAMMAS( RADIUS, AIRTEMP, GAMMAIEPOX,
+     &                              GAMMAIMAE, KPIEPOX, FH2O, FOS, FDIM1, FDIM2)
+
+               IF( GAMMAIEPOX .GT. 1.0D-72 ) THEN
+                  KIEPOX = WET_M2( 2 ) * DPI
+     &                   / ( RADIUS * INV_DIFFUSIVITY +  4.0D0 / ( CBARIEPOX * GAMMAIEPOX) )
+                  If ( AIETET_IDX .GT. 0 ) Then
+                     TETROL_PPM  = PPM_FACTOR
+     &                       * REAL( aerospc_conc( AIETET_IDX,2 ), 8 ) * INV_MWIETET
+                  Else
+                     TETROL_PPM = 0.0D0
+                  End If 
+                  If ( AIEOS_IDX .GT. 0 ) Then
+                     IEPOXOS_PPM = PPM_FACTOR
+     &                     * REAL( aerospc_conc( AIEOS_IDX,2 ), 8 ) * INV_MWIEOS
+                  Else
+                     IEPOXOS_PPM = 0.0D0
+                  End If
+               ELSE
+                  KIEPOX = 0.0D0
+                  TETROL_PPM = 0.0D0
+                  IEPOXOS_PPM = 0.0D0
+               END IF
+
+               IF( GAMMAIMAE .GT. 1.0D-72 ) THEN
+                  KIMAE = WET_M2( 2 ) * DPI
+     &                  / ( RADIUS * INV_DIFFUSIVITY + 4.0D0 / ( CBARIMAE * GAMMAIMAE ) )
+               ELSE
+                  KIMAE = 0.0d0
+               END IF
+
+               ! Diagnostic information
+               IF ( PMDIAG .OR. APMDIAG ) GAMMA_IEPOX( C,R,L ) = REAL( GAMMAIEPOX,4 )
+               IF ( PMDIAG .OR. APMDIAG ) GAMMA_IMAE(  C,R,L ) = REAL( GAMMAIMAE, 4 )
+               IF ( PMDIAG .OR. APMDIAG ) KPARTIEPOX(  C,R,L ) = REAL( KPIEPOX,   4 )
+
+               LOOP_RATES: DO IRATE = 1, SELECTED_AERO_RATES
+ 
+               SELECT CASE( WHICH_AERO_RATE( IRATE ) )
+                  CASE( IA_N2O5IJ )  
+                     KHETERO( IRATE, C,R,L ) = 60.0D0 * ( KN2O5( 1 ) + KN2O5( 2 ) )! convert to min-1
+                          
+                  CASE( IA_N2O5K )  
+                     KHETERO( IRATE, C,R,L ) = 60.0D0 * KN2O5 (3) ! convert to min-1
+                     
+                  CASE( IA_N2O5J )  
+                     KHETERO( IRATE, C,R,L ) = 60.0D0 * KN2O5 (2) ! convert to min-1
+                     
+                  CASE( IA_N2O5I )  
+                     KHETERO( IRATE, C,R,L ) = 60.0D0 * KN2O5 (1) ! convert to min-1
+                     
+                  CASE( IA_N2O5IJY )  
+                     KHETERO( IRATE, C,R,L ) = 60.0D0 * YIELDIJ * ( KN2O5( 1 ) + KN2O5( 2 ) ) ! convert to min-1
+                     IF ( PMDIAG .OR. APMDIAG ) YCLNO2IJ( C,R,L ) = REAL( YIELDIJ, 4 )
+
+                  CASE( IA_N2O5KY )  
+                     KHETERO( IRATE, C,R,L ) = 60.0D0 * YIELD_CLNO2( 3 ) * KN2O5( 3 ) 
+                     IF ( PMDIAG .OR. APMDIAG ) YCLNO2K( C,R,L ) = REAL( YIELD_CLNO2( 3 ), 4 )
+
+                  CASE( IA_H2NO3PAIJ )  
+                     KHETERO( IRATE, C,R,L ) = 60.0D0 * AQUEOUS_FREQUENCY
+     &                                       *  MAX( ( 1.0D0 - YIELDIJ ), 0.0D0 ) 
+                     IF ( PMDIAG .OR. APMDIAG ) YCLNO2IJ( C,R,L ) = REAL( YIELDIJ, 4 )
+                     
+                  CASE( IA_H2NO3PBIJ )  
+                     IF ( YIELDIJ .GT. 0.0D0 ) THEN
+                        KHETERO( IRATE, C,R,L ) = 60.0D0 * AQUEOUS_FREQUENCY * YIELDIJ 
+     &                                          / ( CL_PPM( 1 ) + CL_PPM( 2 ) )   ! 1/(min*ppm)
+                     ELSE
+                        KHETERO( IRATE, C,R,L ) = 0.0D0
+                     END IF
+                     
+                  CASE( IA_H2NO3PAI )
+                     KHETERO( IRATE, C,R,L ) = 60.0D0 * AQUEOUS_FREQUENCY
+     &                                       * MAX( ( 1.0D0 - YIELD_CLNO2( 1 ) ), 0.0D0 ) 
+
+                  CASE( IA_H2NO3PBI )
+                     IF ( YIELD_CLNO2( 1 ) .GT. 0.0D0 ) THEN
+                        KHETERO( IRATE, C,R,L ) = 60.0D0 * AQUEOUS_FREQUENCY
+     &                                          * YIELD_CLNO2( 1 ) / CL_PPM( 1 ) ! (min*ppm)-1
+                        IF ( PMDIAG .OR. APMDIAG ) THEN
+                           FACTOR = CL_PPM( 1 ) / ( CL_PPM( 1 )+ CL_PPM( 2 ) )
+                           YCLNO2IJ( C,R,L ) = REAL( FACTOR * YIELD_CLNO2( 1 ), 4 ) 
+     &                                       + YCLNO2IJ( C,R,L )
+                        END IF
+                     ELSE
+                        KHETERO( IRATE, C,R,L ) = 0.0D0
+                     END IF 
+                              
+                  CASE( IA_H2NO3PAJ )
+                     KHETERO( IRATE, C,R,L ) = 60.0D0 * AQUEOUS_FREQUENCY
+     &                                       * MAX( ( 1.0D0 - YIELD_CLNO2( 2 ) ), 0.0D0 ) 
+                               
+                  CASE( IA_H2NO3PBJ )
+                     IF (  YIELD_CLNO2( 2 ) .GT. 0.0D0 ) THEN
+                        KHETERO( IRATE, C,R,L ) =  60.0D0 * AQUEOUS_FREQUENCY
+     &                                          *  YIELD_CLNO2( 2 ) / CL_PPM( 2 ) ! (min*ppm)-1
+                        IF ( PMDIAG .OR. APMDIAG ) THEN
+                           FACTOR = CL_PPM( 2 ) / ( CL_PPM( 1 )+ CL_PPM( 2 ) )
+                           YCLNO2IJ( C,R,L ) = YCLNO2IJ( C,R,L ) + REAL( FACTOR * YIELD_CLNO2( 2 ), 4 ) 
+                        END IF                               
+                     ELSE
+                          KHETERO( IRATE, C,R,L ) = 0.0D0
+                     END IF 
+                                
+                  CASE( IA_PNCOMLI )
+                     POC   = aerospc_conc( APOC_IDX,1 )
+                     PNCOM = aerospc_conc( APNCOM_IDX,1 )
+                     KHETERO( IRATE, C,R,L ) = RFACTOR * PNCOM_LOSS( POC, PNCOM )
+                      
+                  CASE( IA_PNCOMLJ )
+                     POC   = aerospc_conc( APOC_IDX,2 )
+                     PNCOM = aerospc_conc( APNCOM_IDX,2 )
+                     KHETERO( IRATE, C,R,L ) = RFACTOR * PNCOM_LOSS( POC, PNCOM )
+
+                  CASE( IA_H2NO3PAK )
+                     KHETERO( IRATE, C,R,L ) = 60.0D0 * AQUEOUS_FREQUENCY
+     &                                       *  MAX( ( 1.0D0 - YIELD_CLNO2( 3 ) ), 0.0D0 ) ! * KN2O5( 3 )
+                               
+                  CASE( IA_H2NO3PBK )
+                     IF ( YIELD_CLNO2( 3 ) .GT. 0.0D0 ) THEN
+                        KHETERO( IRATE, C,R,L ) = 60.0D0 * AQUEOUS_FREQUENCY
+     &                                          * YIELD_CLNO2( 3 ) / CL_PPM( 3 ) ! (min*ppm)-1
+                        IF ( PMDIAG .OR. APMDIAG ) YCLNO2K( C,R,L ) = REAL( YIELD_CLNO2( 3 ), 4 ) 
+                     ELSE
+                        KHETERO( IRATE, C,R,L ) = 0.0D0
+                     END IF 
+                               
+                  CASE( IA_NO2 )
+C *** calculate pseudo-first order rate constant for NO2 loss using Eq 1 of Vogel
+C     et al. (2003). Units of KNO2 is in 1/min in the paper; divide it
+C     by 60 to convert it into 1/sec
+                     KNO2 = MAX ( 0.0D0, 1.0D-04 * TOTSURFA )
+                     KHETERO( IRATE, C,R,L )  = 60.0D0 * KNO2 ! convert to min-1
+
+C ***            Isoprene epoxide uptake
+                 CASE( IA_IEPOX )
+                     KHETERO( IRATE, C,R,L ) = 60.0D0 * KIEPOX ! min-1
+
+                 CASE( IA_TETROL )
+                     KHETERO( IRATE, C,R,L ) = 60.0D0 * AQUEOUS_FREQUENCY * FH2O( 1 )
+
+                 CASE( IA_IEPOXOS )
+                     KHETERO( IRATE, C,R,L ) = 60.0D0 * AQUEOUS_FREQUENCY * FOS( 1 )
+
+                 CASE( IA_TETROLDIM )
+                     IF ( TETROL_PPM .GT. 0.0D0 ) THEN
+                        KHETERO( IRATE, C,R,L ) = 60.0D0 * AQUEOUS_FREQUENCY
+     &                                          * FDIM1( 1 ) / TETROL_PPM ! min*ppm-1  
+                     ELSE
+                        KHETERO( IRATE, C,R,L ) = 0.0D0
+                     END IF
+
+                 CASE( IA_IEPOXOSDI )
+                     IF ( IEPOXOS_PPM .GT. 0.0D0 ) THEN
+                        KHETERO( IRATE, C,R,L ) = 60.0D0 * AQUEOUS_FREQUENCY
+     &                                          * FDIM2( 1 ) / IEPOXOS_PPM ! min*ppm-1
+                     ELSE
+                        KHETERO( IRATE, C,R,L ) = 0.0D0
+                     END IF
+
+                 CASE( IA_IMAE )
+                     KHETERO( IRATE, C,R,L ) = 60.0D0 * KIMAE ! min-1
+
+                 CASE( IA_2MG )
+                     KHETERO( IRATE, C,R,L ) = 60.0D0 * AQUEOUS_FREQUENCY * FH2O(2)
+
+                 CASE( IA_IMAEOS )
+                     KHETERO( IRATE, C,R,L ) = 60.0D0 * AQUEOUS_FREQUENCY * FOS(2)
+
+                 CASE( IA_NO3 )
+                     KHETERO( IRATE, C,R,L ) = 60.0D0 * ( KNO3( 1 ) + KNO3( 2 ) ) ! min-1
+
+                 CASE( IA_GLY )
+                     KHETERO( IRATE, C,R,L ) = 60.0D0 * (  KGLY( 2 ) ) ! min-1
+
+                 CASE( IA_MGLY )
+                     KHETERO( IRATE, C,R,L ) = 60.0D0 * (  KMGLY( 2 ) ) ! min-1
+
+                 CASE( IA_NTR2 )
+C *** calculate gas-particle partitioning of NTR2
+                    CON_TOA = 0.0
+                    IF ( INDEX( MECHNAME, 'NVPOA' ) .NE. 0 ) THEN
+                      CON_TOA = aerospc_conc(   apoc_idx,1 ) + aerospc_conc(   apoc_idx,2 )
+     &                        + aerospc_conc( apncom_idx,1 ) + aerospc_conc( apncom_idx,2 )
+                    END IF
+
+                    DO I = 1, n_aerospc
+                       IF ( aerospc( I )%nonVol_soa ) THEN
+                          IF ( aerospc( I )%tracer ) CYCLE
+                          CON_TOA = CON_TOA + aerospc_conc( I,2 )
+                       END IF
+                    END DO
+                    DO I = 1, n_vapor
+                      N = soa_aeroMap( I )
+                      IF ( aerospc( N )%tracer ) CYCLE
+                      CON_TOA = CON_TOA + aerospc_conc( N,2 )
+                    END DO
+
+                    F_PART_NTR2 = 0.0
+                    IF ( CON_TOA .GE. MIN_TOA ) THEN
+                       F_PART_NTR2 = ON_ALPHA1 / ( 1.0 + ON_CSTAR1 / CON_TOA )
+     &                             + ON_ALPHA2 / ( 1.0 + ON_CSTAR2 / CON_TOA )
+                    END IF
+
+C *** calculate pseudo-first order rate constant for heterogeneous NTR2
+C hydrolysis
+                     IF ( AIRRH .LE. 0.2D0 .OR. F_PART_NTR2 .LE. 0.0 ) THEN
+                        KHETERO( IRATE, C, R, L ) = 0.0D0
+                     ELSE IF ( AIRRH .GE. 0.4D0 ) THEN
+                        KHETERO( IRATE, C, R, L ) = REAL( F_PART_NTR2 * KHON, 8 ) ! [1/min]
+                     ELSE
+                        KHETERO( IRATE, C, R, L ) = REAL( F_PART_NTR2 * KHON, 8 ) ! [1/min]
+     &                                            * ( 5.0D0 * AIRRH - 1.0D0 )
+                     END IF
+
+                 CASE( IA_BRONO2IJ )
+C *** calculate total KBRONO2 from fine modes
+                     KBRONO2 = WET_M2( 1 ) * DPI
+     &                       / ( 0.5D0 * DE_WET( 1 ) * INV_DIFF_BRONO2 + BRONO2_RXN_TIME )
+     &                       + WET_M2( 2 ) * DPI
+     &                       / ( 0.5D0 * DE_WET( 2 ) * INV_DIFF_BRONO2 + BRONO2_RXN_TIME )
+                     KHETERO( IRATE, C,R,L ) = 60.0D0 * KBRONO2
+
+                 CASE( IA_BRONO2K )
+C *** calculate KBRONO2 from coarse mode
+                     KBRONO2 = WET_M2( 3 ) * DPI
+     &                       / ( 0.5D0 * DE_WET( 3 ) * INV_DIFF_BRONO2 + BRONO2_RXN_TIME )
+                     KHETERO( IRATE, C,R,L ) = 60.0D0 * KBRONO2
+
+               END SELECT
+
+            END DO LOOP_RATES
+
+#ifdef verbose_aerosol_chemistry
+            IF ( DUMP_CELL ) THEN
+
+               WRITE( LOGDEV,* ) 'In GAS HETCHEM for MYPE = ', MYPE
+               WRITE( LOGDEV,9499 ) C,R,L
+               WRITE( LOGDEV,9500 ) 'TEMP        = ', AIRTEMP
+               WRITE( LOGDEV,9500 ) 'AIRRH       = ', AIRRH
+               WRITE( LOGDEV,9500 ) 'DIFFUSIVITY = ', 1.0 / INV_DIFFUSIVITY
+               WRITE( LOGDEV,9500 ) 'INV_SQRT_MWN2O5 = ', INV_SQRT_MWN2O5
+               WRITE( LOGDEV,9500 ) 'CBAR_COEFF      = ', CBAR_COEFF
+               WRITE( LOGDEV,9500 ) 'CBAR        = ', CBAR
+               WRITE( LOGDEV,9500 ) 'PPM_FACTORA = ',
+     &                UGM3_CONV_FAC * REAL( TEMP( C,R,L ) / PRESS( C,R,L ), 8 )
+               WRITE( LOGDEV,9500 ) 'PPM_FACTOR = ', PPM_FACTOR
+               WRITE( LOGDEV,9500 ) 'PPM_FACTOR*INV_MWCL = ', PPM_FACTOR * INV_MWCL
+               WRITE( LOGDEV,9500 ) 'PPM_FACTORA*INV_MWCL = ',
+     &                UGM3_CONV_FAC * REAL( TEMP( C,R,L ) / PRESS( C,R,L ), 8 ) * INV_MWCL
+               WRITE( LOGDEV,9500 ) 'ACLI_PPM  = ', CL_PPM( 1 )
+               WRITE( LOGDEV,9500 ) 'ACLJ_PPM  = ', CL_PPM( 2 )
+               WRITE( LOGDEV,9500 ) 'ACLK_PPM  = ', CL_PPM( 3 )
+               WRITE( LOGDEV,9500 ) 'ANH4I = ', aerospc_conc( ANH4_IDX,1 ) 
+               WRITE( LOGDEV,9500 ) 'ANO3I = ', aerospc_conc( ANO3_IDX,1 ) 
+               WRITE( LOGDEV,9500 ) 'ASO4I = ', aerospc_conc( ASO4_IDX,1 ) 
+               WRITE( LOGDEV,9500 ) 'ACLI  = ', aerospc_conc( ACL_IDX,1 ) 
+               WRITE( LOGDEV,9500 ) 'AH2OI = ', aerospc_conc( AH2O_IDX,1 ) 
+               WRITE( LOGDEV,9500 ) 'ANH4J = ', aerospc_conc( ANH4_IDX,2 ) 
+               WRITE( LOGDEV,9500 ) 'ANO3J = ', aerospc_conc( ANO3_IDX,2 ) 
+               WRITE( LOGDEV,9500 ) 'ASO4J = ', aerospc_conc( ASO4_IDX,2 ) 
+               WRITE( LOGDEV,9500 ) 'ACLJ  = ', aerospc_conc( ACL_IDX,2) 
+               WRITE( LOGDEV,9500 ) 'AH2OJ = ', aerospc_conc( AH2O_IDX,2 ) 
+               WRITE( LOGDEV,9500 ) 'ANH4IJ = ',
+     &                aerospc_conc( ANH4_IDX,1 ) + aerospc_conc( ANH4_IDX,2 ) 
+               WRITE( LOGDEV,9500 ) 'ANO3IJ = ',
+     &                aerospc_conc( ANO3_IDX,1 ) + aerospc_conc( ANO3_IDX,2 ) 
+               WRITE( LOGDEV,9500 ) 'ASO4IJ = ',
+     &                aerospc_conc( ASO4_IDX,1 ) + aerospc_conc( ASO4_IDX,2 ) 
+               WRITE( LOGDEV,9500 ) 'ACLIJ  = ',
+     &                aerospc_conc( ACL_IDX,1 ) + aerospc_conc( ACL_IDX,2 ) 
+               WRITE( LOGDEV,9500 ) 'AH2OIJ = ',
+     &                aerospc_conc( AH2O_IDX,1 ) + aerospc_conc( AH2O_IDX,2 ) 
+               WRITE( LOGDEV,9500 ) 'GAMMA = ', N2O5_GAMMA( AIRTEMP, AIRRH, 0 )
+               WRITE( LOGDEV,9500 ) 'ANH4K = ', aerospc_conc( ANH4_IDX,3 ) 
+               WRITE( LOGDEV,9500 ) 'ANO3K = ', aerospc_conc( ANO3_IDX,3 ) 
+               WRITE( LOGDEV,9500 ) 'ASO4K = ', aerospc_conc( ASO4_IDX,3 ) 
+               WRITE( LOGDEV,9500 ) 'ACLK  = ', aerospc_conc( ACL_IDX, 3 ) 
+               WRITE( LOGDEV,9500 ) 'AH2OK = ', aerospc_conc( AH2O_IDX,3 ) 
+               WRITE( LOGDEV,9500 ) 'GAMMAK     = ', N2O5_GAMMA( AIRTEMP, AIRRH, 5 )
+               WRITE( LOGDEV,9500 ) 'XXF_AT     = ', XXF( 1 )
+               WRITE( LOGDEV,9500 ) 'XXF_AC     = ', XXF( 2 )
+               WRITE( LOGDEV,9500 ) 'XXF_COR    = ', XXF( 3 )
+               WRITE( LOGDEV,'( A )' ) 'Product/Nucleophile mapping for epox uptake:'
+               DO N = 1, N_NUCPAIRS
+                  WRITE( LOGDEV,'( 5X,A,I4 )' ) ACID_NUC_PAIRS( N )%PROD, ACID_PRODMAP_IDX( N )
+                  WRITE( LOGDEV,'( 5X,A,I4 )' ) ACID_NUC_PAIRS( N )%NUC, ACID_NUCMAP_IDX( N )
+               END DO
+               WRITE( LOGDEV,9500 ) 'GAMMAIEPOX  = ', GAMMAIEPOX
+               WRITE( LOGDEV,9500 ) 'GAMMAIMAE   = ', GAMMAIMAE
+               WRITE( LOGDEV,9500 ) 'k_particle_iepox =       ', KPIEPOX
+               WRITE( LOGDEV,9500 ) 'Fraction tetrol =        ', FH2O( 1 )
+               WRITE( LOGDEV,9500 ) 'Fraction iepoxos =       ', FOS(  1 )
+               WRITE( LOGDEV,9500 ) 'Fraction tetrol dimer =  ', FDIM1( 1 )
+               WRITE( LOGDEV,9500 ) 'Fraction iepoxos dimer = ', FDIM2( 1 )
+               WRITE( LOGDEV,9500 ) 'Fraction 2-MG =          ', FH2O( 2 )
+               WRITE( LOGDEV,9500 ) 'Fraction mae-os =        ', FOS( 2 )
+               WRITE( LOGDEV,9500 ) 'Fraction mae dimers = 0  ', FDIM1( 2 ) + FDIM2( 2 )
+               WRITE( LOGDEV,9500 ) 'TETROL_PPM =             ', TETROL_PPM
+               WRITE( LOGDEV,9500 ) 'IEPOXOS_PPM =            ', IEPOXOS_PPM
+               WRITE( LOGDEV,9501 ) 'KN2O5IJ = ', 60.0D0 * ( KN2O5( 1 ) + KN2O5( 2 ) ),' 1/min'
+               WRITE( LOGDEV,9501 ) 'KN2O5K =  ', 60.0D0 * KN2O5(3), ' 1/min'
+               WRITE( LOGDEV,9501 ) 'KNO2  =   ', 60.0D0 * KNO2, ' 1/min'
+               WRITE( LOGDEV,9501 ) 'YIELDI =  ', YIELD_CLNO2( 1 ), ' '
+               WRITE( LOGDEV,9501 ) 'YIELDJ =  ', YIELD_CLNO2( 2 ), ' '
+               WRITE( LOGDEV,9501 ) 'YIELDIJ = ', YIELDIJ, ' '
+               WRITE( LOGDEV,9501 ) 'YIELDK =  ', YIELD_CLNO2( 3 ), ' '
+               WRITE( LOGDEV,9501 ) 'F_PART_NTR2 =  ', F_PART_NTR2, ' '
+               WRITE( LOGDEV,9501 ) 'GAMMA_NO3= ', GAMMA_NO3, ' '
+               WRITE( LOGDEV,9501 ) 'GAMMA_GLY= ', GAMMA_GLY, ' '
+               WRITE( LOGDEV,9501 ) 'KNO3(1)= ', KNO3( 1 ), ' '
+               WRITE( LOGDEV,9501 ) 'KNO3(2)= ', KNO3( 2 ), ' '
+               WRITE( LOGDEV,9501 ) 'KNO3(3)= ', KNO3( 3 ), ' '
+               WRITE( LOGDEV,9501 ) 'KGLY(2)= ', KGLY( 2 ), ' '
+               WRITE( LOGDEV,9501 ) 'KMGLY(2)= ', KMGLY( 2 ), ' '
+               DO N = 1, NHETERO
+                  WRITE( LOGDEV,9501 ) HETERO( N ) // ' = ', KHETERO( N, C,R,L ),' '
+               END DO
+            END IF          
+9499        FORMAT( 'At COL = ',I3,' ROW = ',I3,' LAY = ',I3 )
+9500        FORMAT( A, ES12.4 )
+9501        FORMAT( A, ES12.4, A )          
+#endif
+        
+            END DO LOOP_COL
+         END DO  LOOP_ROW
+      END DO LOOP_LAY
+
+      RETURN
+
+      END SUBROUTINE HETCHEM_RATES
+ 
+C:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+      SUBROUTINE HETCHEM_UPDATE_AERO ( CGRID )  
+
+c  Calculates the change in aerosol surface area due to heterogeneous
+C  reactions and updates the CGRID array with this information.
+C  
+C  History
+C  May 2016: BM Created
+
+C  Key Subroutines Called: none
+C
+C  Called by: Gas-Phase Chemistry Driver
+      USE AERO_DATA        
+      USE AEROMET_DATA, ONLY: pi
+      USE GRID_CONF, ONLY: NLAYS, MY_NROWS, MY_NCOLS
+
+      IMPLICIT NONE
+      
+      REAL, POINTER   :: CGRID ( :,:,:,: )  ! pointer to model concentrations
+      REAL, PARAMETER :: TWOTHIRDS = 2.0 / 3.0
+      REAL            :: M2DRY_FINAL( N_MODE ) ! Dry 2nd Aerosol Moment
+      REAL            :: M3DRY_FINAL( N_MODE ) ! Dry 3rd Aerosol Moment
+      INTEGER L, R, C, M 
+      LOOP_LAY: DO L = 1, NLAYS
+         LOOP_ROW: DO R = 1, MY_NROWS
+            LOOP_COL: DO C = 1, MY_NCOLS
+     
+               ! Extract grid cell concentrations of aero species from CGRID
+               ! into aerospc_conc in aero_data module
+               ! also converts dry surface area to wet second moment
+               CALL extract_aero ( CGRID( C,R,L,: ), .True. )
+
+               ! Recalculate Dry 3rd Moment After Chemistry Processes
+               ! 2nd moment hasn't been update yet.
+               CALL calcmoments( .False. )
+               M2DRY_FINAL( : ) = MOMENT2_CONC( : )
+               M3DRY_FINAL( : ) = MOMENT3_CONC( : )
+
+               ! Calculate new Second Moment Manually
+               ! Assume standard deviation is fixed.
+               M2DRY_FINAL( : ) = REAL( CHEM_M2DRY_INIT( C,R,L,: ) ) 
+     &                          * ( M3DRY_FINAL( : ) / REAL( CHEM_M3DRY_INIT( C,R,L,: ) ) ) ** TWOTHIRDS
+
+               ! Update the Aerosol Surface Area making sure to multiply
+               ! the 2nd moment by Pi to convert properly
+               DO M = 1, N_MODE
+                 CGRID( C,R,L, aerosrf_map( M ) ) = PI * M2DRY_FINAL( M )
+               END DO
+
+            END DO LOOP_COL
+         END DO LOOP_ROW
+      END DO LOOP_LAY
+
+      END SUBROUTINE HETCHEM_UPDATE_AERO
+
+C ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+      REAL( 8 ) FUNCTION PNCOM_LOSS( POC, PNCOM )
+! Calculates rate constant in cm3 molec-1 sec-1 for PNCOM loss by reacting 
+! with OH, derived from the reactions in the below POA aging scheme 
+! in CMAQ v5.0-v5.02:
+! start with the definition of POCRm 
+!      - POCRm = reduced primary organic carbon (molar concentration)
+!  changes POCRm correspond to changes in PNCOM via a rate constant
+!  koheff*[OH] that comes from Weitkamp et al (2008) and George et al (2007)
+!
+! POCRm = POC/12 - Omoles
+!  where Omoles represent fraction that is already PNCOM oxidized
+! Omoles = NCOM/(16 + PHOrat) if 14/12 < (POC + NCOM)/POC <  44/12 
+!      - see Simon et al (2011) for derivation
+! Omoles = NCOM/16            if (POC + NCOM)/POC >= 44/12 
+!      - interpretted as POC is fully oxidized and all 
+!        NCOM is oxygen 
+! Omoles = 0                  if (POC + NCOM)/POC <= 14/12 
+!      - if OM/OC < 1.167, then POC is fully reduced and all 
+!        NCOM is hydrogen
+!      - see Simon et al. (2011) for derivation
+! note:we divide POC by 12 b/c we want moles of carbon atoms not moles 
+!      of POC (since each carbon atom w\in the molecule is allowed 
+!      to react)
+! note: we calculate Omoles based on the equations above derived from 
+!      Heald et al (2010) and documented in Simon et al (2011).
+!
+! The following rate equation comes from the reaction above:
+!      dPOCRm/dt = POCRm*koheff*[OH] 
+!        -assume that [OH] does not change as a result of this reaction
+!      solve for POCRm at time, t
+!        moles: POCRm(t) = POCRm(0)*EXP(-koheff*[OH]*t) = POCRm(0)*expdt
+!
+!      One mole of "NCOMm" is formed for every mole of POCRm that reacts:
+!             -dPOCRm/dt = dNCOMm/det
+!        moles of NCOMm: NCOMm = NCOMm(0) + POCRm(0)*[1-EXP(-koheff*[OH]*t)] = 
+!                        NCOMm(0) + POCRm(0)*(1-expdt)
+!        NCOMg = NCOMm*15.0 
+!          - every mole of newly formed NCOM results in an average gain of 1 oxygen atom 
+!            and an average loss of 1 hydrogen atoms (on average, two oxidation steps 
+!            convert a CH3 functional group into a COOH functional group) 
+!               -(based on Heald et al. (2010)) 
+!      Rewrite NCOM formation equation using grams: 
+!        NCOMg/15.0 = NCOMg(0)/15.0 + POCRm*(1-expdt) 
+!                         V 
+!        NCOMg == NCOM(0) + 15.0*POCRm*(1-expdt)
+!                          or
+!        dNCOMg/dt = (15.0/12.0)*POC*koheff*[OH]-15.0*Omoles*PNCOM*koheff*[OH]
+!            ----> 15.0*Omoles*koheff is rate constant of PNCOM loss
+! 
+! Key Subroutines Called: none
+!
+! Key Functions Called: none
+!
+! Revision History:
+!    June 2014:  Bill Hutzell-initial version based on the poaaging subroutine
+!                in CMAQ v5.0 thru v5.0.2.
+! 
+!  REFERENCES:
+!   1. George, I.J., Vlasenko, A., Slowik, J.G., Broekhuizen, K., 
+!      Abbatt, J.P.D. (2007), Heterogeneous oxidation of saturated
+!      organic aerosols by hydroxyl radicals: uptake kinetics, 
+!      condesned-phase products, and particle size change, 
+!      Atmospheric Chemistry and Physics, 7, 4187-4201 
+!     
+!   2. Heald, C.L., Kroll, J.H., Jimenez, J.L., Docherty, K.S., 
+!      DeCarlo, P.F., Aiken, A.C., Chen, Q., Martin, S.T., Farmer, S.T.,
+!      Artaxo, P. (2010), A simplified description of the evolution of 
+!      organic aerosol composition in the atmosphere, GRL, 37, L08803. 
+!
+!   3. Simon, H. and Bhave, P.V. (2011), Simulating the degree of oxidation 
+!      in atmospheric organic particles  
+!      In Review at ES&T.
+!
+!   4. Weitkamp, E.A., Lambe, A.T., Donahue, N.M., Robinson, A.L. (2008),
+!      Laboratory measurements of the heterogeneous oxidation of condensed-
+!      phase organic molecular markers for motor vehicl exhaust, 42, 
+!      7950-7956.
+!-----------------------------------------------------------------------
+      
+      IMPLICIT NONE
+      
+! Arguments: Note specific units do not material as long as consistent
+!           between arguments, i.e., the same
+       REAL, INTENT( IN ) :: POC    ! concentration of primary organic carbon
+       REAL, INTENT( IN ) :: PNCOM  ! concentration of primart noncarbon organic matter
+! Parameter:
+       REAL( 8 ), PARAMETER :: KOHEFF      =  2.5D-12  ! POC + OH rate constant, cm3 molec-1 sec-1
+       REAL,      PARAMETER :: LOWER_LIMIT =  7.0/6.0
+       REAL,      PARAMETER :: UPPER_LIMIT = 11.0/3.0
+       REAL( 8 ), PARAMETER :: MAX_RATE    = 15.0D0/16.0D0 * KOHEFF ! max rate constant for PNCOM loss
+! Local    
+       REAL( 8 )            :: RATIO   ! the hydrogen to oxygen ratio in organic matter
+       
+        PNCOM_LOSS = 0.0D0
+
+        IF (  POC .LE. 1.0D-30 ) RETURN
+              
+        RATIO = REAL( ( POC + PNCOM ) / POC, 8 )
+
+        IF ( RATIO .GT. LOWER_LIMIT .AND. RATIO .LT. UPPER_LIMIT ) THEN
+           PNCOM_LOSS = 15.0D0 * KOHEFF
+     &                / ( 16.0D0 + (UPPER_LIMIT - RATIO) / (RATIO - LOWER_LIMIT) )
+        ELSE IF ( RATIO .GE. UPPER_LIMIT ) THEN 
+           PNCOM_LOSS = MAX_RATE
+        END IF
+        
+        RETURN   
+      END FUNCTION PNCOM_LOSS
+
+C:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+      REAL( 8 ) FUNCTION N2O5_GAMMA( TEMP, RH, GPARAM )
+
+C  Calculates the N2O5 heterogeneous reaction probability, which is the
+C  fraction of collisions between a gaseous N2O5 molecule and a particle
+C  surface that leads to nitrate production.  In the literature, this
+C  probability is commonly referred to with the Greek letter, GAMMA.  To
+C  avoid conflicts with the intrinsic GAMMA function on some compilers,
+C  we refer to the reaction probability as N2O5_GAMMA in this function.
+
+C  A variety of parameterizations of N2O5_GAMMA are available in this
+C  function.  Users may select among the different parameterizations
+C  by changing the input argument, GPARAM.  This argument may take on
+C  the following values (see code for further details):
+C     1. Constant value of 0.1 based on Dentener & Crutzen (1993)
+C     2. Function of particle SO4 and NO3, based on Riemer et al. (2003)
+C     3. Function of RH, Temp, and particle composition, based on a
+C        combination of parameterizations by Evans & Jacob (2005) and
+C        Riemer et al. (2003)
+C  If GPARAM matches none of the above values, the default calculation
+C  of N2O5_GAMMA is a function of RH, T, particle composition, and phase
+C  state, based on the parameterization by Davis et al. (2008).
+
+C  Key Subroutines Called: none
+
+C  Key Functions Called: CRYSTALIZED, FREEZES
+
+C  Revision History:
+C    First version was coded in November 2007 by Dr. Prakash Bhave
+C    using excerpts of the HETCHEM subroutine, which contained only
+C    one option for computing N2O5_GAMMA (i.e., GPARAM = 3).
+C
+C  PVB 11/03/07 Removed code that sets N2O5_GAMMA to zero when RH < 1%.
+C
+C  PVB 11/05/07 Corrected GPARAM = 3 option to fix the typographical
+C               error in the paper by Evans & Jacob (2005), which was
+C               found by Dr. Jerry Davis.
+C
+C  PVB 04/11/08 Updated formulas for LAM1 & LAM2 based on revised paper
+C               by Davis et al. (2008).  Added APNDX flag so users may
+C               switch between base parameterization and the alternative
+C               discussed in Appendix A by Davis et al.  Set default
+C               parameterization to match equations in Appendix A.
+C               Reduced all regression coefficients by one decimal place
+C               for consistency with revised paper.
+C
+C  JTK 04/17/08 Moved molar mass to AERO_INFO.f
+C
+C  SH  12/08/09 Use new Fortran modules (aero_data, met_data) in lieu of
+C               CBLK array and AERO_INFO module
+C
+C  SH  03/10/11 Renamed met_data to aeromet_data
+
+C  GS  09/12/14 Added an opiton for N2O5 heterogeneous reaction probability
+C               based on Bertram and Thornton (2009) (fine and coarse mode)
+ 
+C References:
+C   1. Dentener, F.J. and P.J. Crutzen, Reaction of N2O5 on tropospheric
+C      aerosols: Impact of global distributions of NOx, O3, and OH.
+C      J. Geophys. Res., Vol 98, 7149-7163, 1993.
+C
+C   2. Riemer, N., H. Vogel, B. Vogel, B. Schell, I. Ackermann, C.
+C      Kessler, and H. Hass, Impact of the heterogeneous hydrolysis
+C      of N2O5 on chemistry of nitrate aerosol formation in the lower
+C      troposphere under photosmog conditions.  J. Geophys. Res., Vol
+C      108, No D4, 4144, doi:10.1029/2002JD002436, 2003.
+C
+C   3. Evans, M.J. and D.J. Jacob, Impact of new laboratory studies of
+C      N2O5 hydrolysis on global model budgets of tropospheric nitrogen
+C      oxides, ozone, and OH.  Geophys. Res. Lett., 32, L09813,
+C      doi:10.1029/2005GL022469, 2005.
+C
+C   4. Davis, J.M., P.V. Bhave, and K.M. Foley, Parameterization of N2O5
+C      reaction probabilities on the surface of particles containing
+C      ammonium, sulfate, and nitrate.  Atmos. Chem. Phys., 2008, in
+C      press.
+C
+C   5. Mentel, T.F., M. Sohn, and A. Wahner, Nitrate effect in the
+C      heterogeneous hydrolysis of dinitrogen pentoxide on aqueous
+C      aerosols.  Phys. Chem. Chem. Phys., 1, 5451-5457, 1999.
+C
+C   6. Bertram, T. H. and J.A. Thornton, Toward a general parameterization
+C      of N2O5 reactivity on aqueous particles: the competing effects of 
+C      particle liquid water, nitrate, and chloride, ACP, 9, 8351-8363, 2009. 
+
+C-----------------------------------------------------------------------
+
+      USE AERO_DATA
+      USE AEROMET_DATA   ! Includes CONST.EXT
+
+      IMPLICIT NONE
+
+C *** Arguments
+      REAL( 8 ),    INTENT( IN ) :: TEMP     ! Air temperature [ K ]
+      REAL( 8 ),    INTENT( IN ) :: RH       ! Fractional relative humidity
+      INTEGER,      INTENT( IN ) :: GPARAM   ! switch to select among
+                                             !  parameterizations
+
+C *** Parameters
+
+C *** switch for alternative parameterization of LAM1 & LAM2
+C     when APNDX = .TRUE. (default), Eqs A1-A2 are used for reaction
+C     probability on aqueous sulfate particles.  Alternatively, set
+C     APNDX = .FALSE. to use Eqs 4-5.
+      LOGICAL, PARAMETER :: APNDX = .TRUE.
+
+C *** Local Variables
+
+C *** chemical species concentrations [ug/m3]
+      REAL      ANH4      ! i+j mode ammonium
+      REAL      ANO3      ! i+j mode nitrate
+      REAL      ASO4      ! i+j mode sulfate
+
+C *** variables for computing N2O5_GAMMA when GPARAM = 2 or 3
+      REAL      FRACSO4   ! aerosol mass ratio of SO4/(SO4+NO3)
+      REAL      GAMMA1    ! upper limit of rxn prob
+      REAL      GAMMA2    ! lower limit of rxn prob
+      REAL      ALPHA     ! RH-dependent parameter to compute GAMMA1
+      REAL      BETA      ! TEMP-dependent parameter to compute GAMMA1
+
+C *** variables for default parameterization of N2O5_GAMMA
+!     LOGICAL, EXTERNAL ::   CRYSTALIZED      ! function to determine if RH is below CRH
+      LOGICAL   CRYSTAL   ! true if ambient RH < CRH, false otherwise
+!     LOGICAL, EXTERNAL ::   FREEZES   ! function to determine whether RH exceeds IRH
+      LOGICAL   FROZEN    ! true if ambient RH > IRH, false otherwise
+      REAL      NNO3      ! particle-phase nitrate [micromoles/m3]
+      REAL      NSO4      ! particle-phase sulfate [micromoles/m3]
+      REAL      NNH4      ! particle-phase ammonium [micromoles/m3]
+      REAL      NANI      ! particle-phase anions [micromoles/m3]
+      REAL      X1        ! mole fraction of ammonium bisulfate
+      REAL      X2        ! mole fraction of ammonium sulfate
+      REAL      X3        ! mole fraction of ammonium nitrate
+      REAL      LAM1      ! logit transformation of N2O5_GAMMA on
+      REAL      LAM2      !   aqueous NH4HSO4 [LAM1], aqueous (NH4)2SO4
+      REAL      LAM3      !   [LAM2], aqueous NH4NO3 [LAM3], and dry
+      REAL      LAMD      !   sulfate-containing particles [LAMD]
+      REAL      GAM1      ! reaction probability on aqueous NH4HSO4
+      REAL      GAM2      !    "          "      "     "    (NH4)2SO4
+      REAL      GAM3      !    "          "      "     "    NH4NO3
+      REAL      GAMD      !    "          "      " dry sulfate particles
+      REAL      T293,T291 ! temperature threshold variables
+      REAL      RH46      ! RH threshold variable
+
+C *** variables for parameterization based on Bertram and Thornton (2009)
+
+      REAL      ACLF      ! I & J mode chloride, ug/m3 
+      REAL      AH2OF     ! I & J mode water, ug/m3    
+      REAL      ANO3F     ! I & J mode nitrate, ug/m3  
+
+      REAL      ACLK      ! k mode chloride, ug/m3 
+      REAL      AH2OK     ! k mode water, ug/m3    
+      REAL      ANO3K     ! k mode nitrate, ug/m3  
+
+      REAL      ACLM      ! chloride, [moles / liter of particles] 
+      REAL      AH2OM     ! water,    [moles / liter of particles] 
+      REAL      ANO3M     ! nitrate,  [moles / liter of particles] 
+   
+      REAL DEN1           ! local varible
+      REAL DEN2           ! local varible
+      REAL DEN            ! local varible
+      REAL INV_VOL        ! local variable 
+      
+      REAL, PARAMETER :: A = 3.2E-08       ! Unit [s] - Table 2       
+      REAL, PARAMETER :: BETA_BT = 1.15E06 ! Unit [1/s] - Table 2  
+      REAL, PARAMETER :: DELTA = 1.3E-01   ! Unit [1/M] - Table 2  
+      REAL, PARAMETER :: K3OK2B = 6.0E-02  ! Unit [ ] - Table 2  
+      REAL, PARAMETER :: K4OK2B = 29.0     ! Unit [ ] - Table 2  
+      REAL K2FP                            ! varible in eqn 10
+                 
+C *** statement function for inverting the logit transformation given
+C     in Eq 7 by Davis et al (2008)
+      REAL      LOGITINV  ! statement function
+      REAL      XX        ! dummy argument for LOGITINV
+      LOGITINV( XX ) = 1.0 / ( 1.0 + EXP( -XX ) )
+
+C-----------------------------------------------------------------------
+
+C *** retrieve fine-mode particle-phase ammonium, nitrate, and sulfate [ug/m3]
+      ANH4 = aerospc_conc( ANH4_IDX,1 ) + aerospc_conc( ANH4_IDX,2 )
+      ANO3 = aerospc_conc( ANO3_IDX,1 ) + aerospc_conc( ANO3_IDX,2 )
+      ASO4 = aerospc_conc( ASO4_IDX,1 ) + aerospc_conc( ASO4_IDX,2 )
+
+c *** Retrieve fine-mode particle-phase liquid water, chloride, nitrate [ug/m3]
+      AH2OF  = aerospc_conc( AH2O_IDX,1 ) + aerospc_conc( AH2O_IDX,2 ) 
+      ACLF   = aerospc_conc( ACL_IDX,1 )  + aerospc_conc( ACL_IDX,2 ) 
+      ANO3F  = aerospc_conc( ANO3_IDX,1 ) + aerospc_conc( ANO3_IDX,2 )
+
+c *** Retrieve coarse-mode particle-phase liquid water, chloride, nitrate [ug/m3]
+      AH2OK  = aerospc_conc( AH2O_IDX,3 )
+      ACLK   = aerospc_conc(  ACL_IDX,3 )
+      ANO3K  = aerospc_conc( ANO3_IDX,3 )      
+
+      WHAT_OPTION: SELECT CASE( GPARAM )
+
+         CASE ( 1 )
+C *** User Option: GPARAM = 1
+C     Dentener and Crutzen (1993) recommended a constant value of
+C     N2O5_GAMMA = 0.1, which was used in CMAQ prior to ver4.3.  In more
+C     recent literature, this value has been recognized as an upper
+C     estimate of N2O5_GAMMA so it should not be used for routine
+C     simulations.  It is included here only to facilitate sensitivity
+C     studies by CMAQ model users.
+
+            N2O5_GAMMA = 0.1D0
+            RETURN
+            
+         CASE( 2, 3 )
+C *** User Options: GPARAM = 2 and 3
+C     These options both employ Eqs 2 and 3 by Riemer et al (2003), in
+C     which N2O5_GAMMA varies according to the particle-phase sulfate and
+C     nitrate concentrations.  In both options, the NO3 effect (i.e.,
+C     GAMMA1/GAMMA2) is assumed to be a factor of 10 based on Mentel et
+C     al (1999) and Riemer et al (2003).
+C      - When GPARAM = 2, upper limit of N2O5_GAMMA is fixed at 0.02.
+C        This was the default setting in CMAQ ver4.3 through ver4.5.1.
+C      - When GPARAM = 3, upper limit of N2O5_GAMMA is a function of
+C        ambient TEMP & RH based on the "Sulfate" equation in Table 1
+C        by Evans & Jacob (2005).  This was the default setting in CMAQ
+C        ver4.6.  After that release, a typographical error was found
+C        in the published equation of Evans & Jacob (2005) so this code
+C        has been corrected accordingly.
+
+            IF ( GPARAM .EQ. 2 ) THEN
+            
+                GAMMA1 = 0.02
+
+            ELSE 
+C        In this function, RH is in fractional units whereas the
+C        published equation by Evans&Jacob refers to RH as a percentage.
+
+               ALPHA = 2.79E-04
+     &               + REAL( RH * ( 1.3D-02 + RH * ( -3.43D-02 + 7.52D-02 * RH ) ), 4 )
+
+C        To fix the typographical error by Evans & Jacob (2005), the
+C        sign of BETA has been switched in this code.
+
+               IF ( TEMP .LT. 282.0D0 ) THEN
+                  GAMMA1 = 3.0199517 * ALPHA   ! (10.0 ** 0.48) * ALPHA
+               ELSE
+                  BETA  = 0.04 * ( 294.0 - REAL( TEMP,4 ) )
+                  GAMMA1 = ALPHA * ( 10.0 ** BETA )
+               END IF
+            END IF
+
+            IF ( ANO3 .GT. 0.0 ) THEN
+               FRACSO4 = ASO4 / ( ASO4 + ANO3 )
+            ELSE
+               FRACSO4 = 1.0
+            END IF
+
+            GAMMA2 = 0.1 * GAMMA1
+            N2O5_GAMMA = REAL( ( GAMMA2 + FRACSO4 * ( GAMMA1 - GAMMA2 ) ), 8 )
+   
+            RETURN
+
+         CASE ( 4 )
+
+C *** User Option: GPARAM = 4  (fine-mode particles)
+C *** It calculates N2O5_GAMMA based on Bertran and Thornton, 2009
+  
+            INV_VOL = 1.0E-9 * f6pi / REAL( ( WET_M3( 1 ) + WET_M3( 2 ) ), 4 )
+        
+            AH2OM = AH2OF * INV_VOL / aerospc_mw( AH2O_IDX )
+            ACLM  = ACLF  * INV_VOL / aerospc_mw( ACL_IDX )
+            ANO3M = ANO3F * INV_VOL / aerospc_mw( ANO3_IDX )
+            
+            K2FP =  BETA_BT - BETA_BT * EXP( -DELTA * AH2OM )
+          
+            DEN1 = K3OK2B * ( AH2OM / ANO3M )
+
+            DEN2 = K4OK2B * ( ACLM  / ANO3M  )
+
+            DEN  = DEN1 + 1.0 + DEN2
+         
+            N2O5_GAMMA = REAL( A * K2FP * (1.0 - 1.0 / DEN), 8 )
+                   
+            RETURN
+
+         CASE ( 5 )
+   
+C *** User Option: GPARAM = 5 (coarse-mode particles)
+C     It calculates N2O5_GAMMA based on Bertran and Thornton, 2009
+
+            INV_VOL = 1.0E-9 * f6pi / REAL( WET_M3( 3 ), 4 )
+        
+            AH2OM = AH2OK * INV_VOL / aerospc_mw( AH2O_IDX )
+            ACLM  = ACLK  * INV_VOL / aerospc_mw( ACL_IDX )
+            ANO3M = ANO3K * INV_VOL / aerospc_mw( ANO3_IDX )
+            
+            K2FP =  BETA_BT - BETA_BT * EXP( -DELTA * AH2OM )
+          
+            DEN1 = K3OK2B * ( AH2OM / ANO3M )
+
+            DEN2 = K4OK2B * ( ACLM  / ANO3M )
+
+            DEN  = DEN1 + 1.0 + DEN2      
+
+            N2O5_GAMMA = REAL( A * K2FP * (1.0 - 1.0 / DEN), 8)
+                                                         
+            RETURN
+    
+!           IF ( DUMP_CELL ) THEN
+!              WRITE(*,*)'AH2OM = ',AH2OM
+!              WRITE(*,*)'ACLM  = ',ACLM
+!              WRITE(*,*)'ANO3M = ',ANO3M
+!              WRITE(*,*)'DEN   = ',DEN
+!              WRITE(*,*)'DEN1  = ',DEN1
+!              WRITE(*,*)'DEN2  = ',DEN2
+!              WRITE(*,*)'K2FP  = ',K2FP
+!              WRITE(*,*)'GAMMAK = ',A * K2FP * (1.0 - 1.0 / DEN)
+!           END IF
+                                
+!           RETURN
+             
+         CASE DEFAULT
+      
+C *** Default setting in current version of CMAQ:
+C     This code implements the paramaterization given in Eq 15 by Davis
+C     et al (2008), in which N2O5_GAMMA is a function of RH, TEMP,
+C     particle composition, and phase state.  Note: In this function, RH
+C     is in fractional units whereas the published equations refer to RH
+C     as a percentage.
+
+C *** Check whether the ambient RH is below the crystallization RH for
+C     the given inorganic particle composition.
+            CRYSTAL = CRYSTALIZED( RH, .TRUE. )
+
+C *** Check whether the ambient RH exceeds the RH of ice formation.
+            FROZEN = FREEZES( TEMP, RH )
+      
+            IF ( FROZEN ) THEN
+C *** Set N2O5_GAMMA to constant value if particles contain ice, based on
+C     Eq 14 by Davis et al (2008).
+
+               N2O5_GAMMA = 0.02D0                               ! Eq 14
+
+            ELSE
+C *** Compute mole-fractional-composition of particles based on Eq 11 by
+C     Davis et al (2008).
+               NNO3 = ANO3 / aerospc_mw( ANO3_IDX )
+               NSO4 = ASO4 / aerospc_mw( ASO4_IDX )
+               NNH4 = ANH4 / aerospc_mw( ANH4_IDX )
+               NANI = NNO3 + NSO4
+         
+               X3 = NNO3 / NANI
+               X2 = MAX( 0.0, MIN( 1.0 - X3, NNH4/NANI - 1.0 ) )
+               X1 = 1.0 - ( X2 + X3 )
+
+C *** Compute N2O5_GAMMA on pure NH4NO3 particles using Eqs 6 and 8 by
+C     Davis et al (2008).
+               LAM3 = -8.10774 + 4.902 * REAL( RH, 4 )            ! Eq 6
+               GAM3 = MIN( LOGITINV( LAM3 ), 0.0154 )             ! Eq 8
+
+C *** Compute N2O5_GAMMA on dry particles using Eqs 9, 10, and 13 by
+C     Davis et al (2008).
+               IF ( CRYSTAL ) THEN
+                  T293     = MAX( 0.0, REAL( TEMP ) - 293.0 )
+                  LAMD     = -6.13376 + 3.592 * REAL( RH, 4 )     ! Eq 9
+     &                     - 0.19688 * T293
+                  GAMD     = MIN( LOGITINV( LAMD ), 0.0124 )      ! Eq 10
+                  N2O5_GAMMA = REAL( ( X1 + X2 ) * GAMD           ! Eq 13
+     &                       +         X3 * MIN( GAMD, GAM3 ), 8)
+
+C *** Compute N2O5_GAMMA on aqeuous particles using Eqs A1, A2, 8, and 12
+C     by Davis et al (2008).  When APNDX = .TRUE. (default), Eqs A1-A2
+C     are used for reaction probability on aqueous sulfate particles.
+C     Switch to .FALSE. if Eqs 4-5 are desired.  See Appendix A by
+C     Davis et al. (2008) for a discussion of these options.
+               ELSE
+                  T291 = MAX( 0.0, REAL( TEMP ) - 291.0 )
+                  IF ( APNDX ) THEN
+                     RH46  = MIN( 0.0, REAL( RH )- 0.46 )
+                     LAM2  = -3.64849 + 9.553 * RH46          ! Eq A2
+                     LAM1  = LAM2 + 0.97579                   ! Eqs A1 & A2
+     &                     - 0.20427 * T291
+                  ELSE
+                     LAM1  = -4.10612 + 2.386 * REAL( RH )    ! Eq 4
+     &                     - 0.23771 * T291
+                     LAM2  = LAM1 - 0.80570                   ! Eqs 4 & 5
+     &                     + 0.10225 * T291
+                  END IF
+
+                  GAM1     = MIN( LOGITINV( LAM1 ), 0.08585 ) ! Eq 8
+                  GAM2     = MIN( LOGITINV( LAM2 ), 0.053 )   ! Eq 9
+                  N2O5_GAMMA = REAL( ( X1 * GAM1 )            ! Eq 12
+     &                       +       ( X2 * GAM2 )
+     &                       +       ( X3 * GAM3 ), 8 )
+
+               END IF
+            END IF
+
+      END SELECT WHAT_OPTION
+
+
+      RETURN
+
+      END FUNCTION N2O5_GAMMA
+
+C:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+      LOGICAL FUNCTION CRYSTALIZED( RH, COMPLETE )
+
+C  Determines whether the ambient RH is below the crystallization relative
+C  humidity (CRH).  The output of this logical function is .TRUE. when the
+C  ambient RH is below the CRH and .FALSE. otherwise.  The empirical
+C  equations developed by Martin et al (2003) are applied to determine the
+C  CRH for a given mixture of sulfate, nitrate, and ammonium.  Though those
+C  equations are validated only at 293K, they are applied at all ambient
+C  temperatures because insufficient data exist to estimate the temperature
+C  dependence of the CRH of mixed sulfate-nitrate-ammonium particles.
+C  Users can opt to compute either the RH of initial crystal formation
+C (i.e., COMPLETE .EQ. .FALSE.) or the RH of compete crystallization (i.e.,
+C  COMPLETE .EQ. .TRUE.).
+
+C  References:
+C   1. Martin, S.T., J.C. Schlenker, A. Malinowski, H.-M. Hung, and
+C      Y. Rudich, Crystallization of atmospheric sulfate-nitrate-
+C      ammonium particles.  Geophys. Res. Lett., 30(21), 2102,
+C      doi:10.1029/2003GL017930, 2003.
+
+C  Revision History:
+C    PVB 11/05/07 Coded the first version.
+C    JTK 04/17/08 Moved molar mass to AERO_INFO.f
+C    SH  12/08/09 Use aero_data module in lieu of CBLK array
+
+C-----------------------------------------------------------------------
+
+      USE AERO_DATA
+
+      IMPLICIT NONE
+
+C *** Arguments
+      REAL( 8 ), INTENT( IN )    :: RH        ! fractional relative humidity
+      LOGICAL,   INTENT( IN )    :: COMPLETE  ! flag deciding which CRH
+                                              !  equation to use
+
+C *** Local Variables
+
+C *** chemical species concentrations [micromoles/m3]
+      REAL      NSO4     ! i+j mode sulfate
+      REAL      NNO3     ! i+j mode nitrate
+      REAL      NNH4     ! i+j mode ammonium
+      REAL      NCAT     ! i+j mode cations
+      REAL      NANI     ! i+j mode anions
+
+C *** cation and anion mole fractions used in CRH equations
+      REAL X         ! ammonium/cation mole fraction: NH4/(NH4+H)
+      REAL Y         ! sulfate/anion mole fraction:  SO4/(SO4+NO3)
+
+C *** intermediate variables used in CRH equations
+      REAL X2, XY, Y2, X2Y, XY2, RDEN
+
+      REAL CRH       ! crystallization RH (fractional units)
+
+C-----------------------------------------------------------------------
+
+C *** Experimental measurements of CRH are lacking below 1% relative
+C     humidity.  Under those very dry conditions, we assume that
+C     particles will crystallize.  Equations by Martin et al (2003) for
+C     internally-mixed sulfate-nitrate-ammonium particles yield maximum
+C     CRH values of 35.03% and 34.50% for initial crystal formation and
+C     complete crystallization, respectively.  Therefore, the full CRH
+C     calculation can be avoided when RH > 35.1%.
+      IF ( RH .LE. 0.01D0 ) THEN
+         CRYSTALIZED = .TRUE.    ! ambient particles are dry
+         RETURN
+      ELSE IF ( RH .GT. 0.351D0 ) THEN
+         CRYSTALIZED = .FALSE.   ! ambient RH exceeds CRH
+         RETURN
+      END IF
+
+C *** calculate total particle-phase composition [micromoles/m3]
+      NNO3 = ( aerospc_conc( ANO3_IDX,1 ) + aerospc_conc( ANO3_IDX,2 ) )
+     &     / aerospc_mw( ANO3_IDX )
+      NSO4 = ( aerospc_conc( ASO4_IDX,1 ) + aerospc_conc( ASO4_IDX,2 ) )
+     &     / aerospc_mw( ASO4_IDX )
+      NNH4 = ( aerospc_conc( ANH4_IDX,1 ) + aerospc_conc( ANH4_IDX,2 ) )
+     &     / aerospc_mw( ANH4_IDX )
+
+C *** calculate total anion and cation concentrations
+      NCAT = MAX( NNH4, 2.0 * NSO4 + NNO3 )
+      NANI = NNO3 + NSO4
+
+C *** calculate ammonium and sulfate mole fractions
+      X = NNH4 / NCAT
+      Y = NSO4 / NANI
+
+C *** Experimental data of Martin et al. (2003) show no crystal
+C     formation when X < 0.50 or Y < 0.22.  For these particle
+C     compositions, the full CRH calculation can be avoided.
+C
+C     Note: Martin`s equation for initial crystal formation returns
+C     very large CRH values when X and Y approach zero.  However,
+C     those values were verified to be erroneous by personal
+C     communication with Dr. Scot Martin on Aug. 30, 2007.
+      IF ( ( X .LT. 0.50 ) .OR. ( Y .LT. 0.22 ) ) THEN
+         CRYSTALIZED = .FALSE.   ! ambient RH exceeds CRH
+         RETURN
+      END IF
+
+C *** store some terms needed to evaluate the CRH equations
+      X2   = X * X
+      XY   = X * Y
+      X2Y  = X2 * Y
+      Y2   = Y * Y
+      XY2  = X * Y2
+      RDEN = 1.0 / ( 25.0 + ( X - 0.7 ) * ( Y - 0.5 ) )
+
+C *** calculate CRH using empirical equations of Martin et al (2003)
+      IF ( COMPLETE ) THEN
+
+         CRH = 3143.44 + (63.07 * X) + (0.114 * X2) + (87.97 * Y)
+     &       - (125.73 * XY) + (0.586 * X2Y) + (0.95 * Y2)
+     &       - (1.384 * XY2) - (79692.5 * RDEN)
+
+      ELSE
+
+         CRH = -697.908 - (15.351 * X) + (0.43 * X2) - (22.11 * Y)
+     &       + (33.882 * XY) - (1.818 * X2Y) + (0.772 * Y2)
+     &       - (1.636 * XY2) + (17707.6 * RDEN)
+
+      END IF
+
+C *** set value of the output variable, CRYSTALIZED
+      IF ( RH .LE. REAL( CRH, 8 ) ) THEN
+         CRYSTALIZED = .TRUE.    ! ambient particles are dry
+      ELSE
+         CRYSTALIZED = .FALSE.   ! ambient RH exceeds CRH
+      END IF
+
+      RETURN
+
+      END FUNCTION CRYSTALIZED
+
+C:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+      LOGICAL FUNCTION FREEZES( TEMP, RH )
+
+C  Determines whether the ambient RH has exceeded the RH of ice formation,
+C  based on the Goff-Gratch equations as given by List (1984).
+
+C  References:
+C   1. Goff, J.A. and S. Gratch, Low-pressure properties of water from
+C      -160 to 212 F, in Transactions of the American Society of Heating
+C      and Ventilating Engineers, pp 95-122, New York, 1946.
+C   2. List, R.J. (editor), Smithsonian Meteorological Tables, 5th ed.
+C      pp. 350, 1984.
+
+C  Revision History:
+C   PVB 11/06/07 Coded the first version.
+C-----------------------------------------------------------------------
+
+      IMPLICIT NONE
+
+C *** Arguments
+      REAL( 8 ), INTENT( IN ) :: TEMP        ! Air temperature [ K ]
+      REAL( 8 ), INTENT( IN ) :: RH          ! Fractional relative humidity
+
+C *** Parameters
+
+C *** The following values are taken from List (1984).  Note that
+C     these differ slightly from the original equations published by
+C     Goff & Gratch (1946).  We also note that T0 and PST differ
+C     slightly from STDTEMP and STDATMPA in the AERO_INFO module.
+C     Here, we use 273.16 K and 1013.246 hPa to be consistent with
+C     the Goff-Gratch equations as given by List (1984).
+      REAL( 8 ), PARAMETER :: TST = 373.16D0    ! steam-point temperature, K
+      REAL( 8 ), PARAMETER :: T0  = 273.16D0    ! ice-point temperature, K
+      REAL( 8 ), PARAMETER :: PST = 1013.246D0  ! sat vapor pres at TST, hPa
+      REAL( 8 ), PARAMETER :: P0  = 6.1071D0    ! sat vapor pres at T0, hPa
+
+      REAL( 8 ), PARAMETER :: LOGPST = 3.0057149D0     ! LOG10(PST)
+      REAL( 8 ), PARAMETER :: LOGP0  = 0.78583503D0    ! LOG10(P0)
+
+C *** Local Variables
+
+C *** estimates of IRH using a polynomial approximation
+      REAL( 8 )      EIRH   ! IRH approximated using 2nd order polynomial
+      REAL( 8 )      LIRH   ! lower-bound of IRH
+      REAL( 8 )      UIRH   ! upper-bound of IRH
+
+C *** variables used to compute RH of ice formation
+      REAL( 8 )      TSDT, TDTS, T0DT, TDT0  ! intermediate variables
+      REAL( 8 )      LOGPW  ! log10 of saturation vapor pressure over H2O
+      REAL( 8 )      LOGPI  ! log10 of saturation vapor pressure over ice
+
+      REAL( 8 )      IRH    ! fractional RH at which ice forms
+
+C-----------------------------------------------------------------------
+
+      IF ( TEMP .LT. T0 ) THEN
+
+C *** To mitigate the computational expense associated with Goff-Gratch
+C     equations, use a 2nd order polynomial function to approximate IRH.
+C     This approximation, EIRH, matches IRH from the full Goff-Gratch
+C     equations within 0.004 over the entire low-temperature range of
+C     interest (200 to 275K) and is used for screening purposes.
+         EIRH = 1.61299D0 + TEMP * ( 4.4117437D-5 * TEMP - 1.4293888D-2 )
+         LIRH = EIRH - 0.005D0
+         UIRH = EIRH + 0.005D0
+
+         IF ( RH .GT. UIRH ) THEN
+            FREEZES = .TRUE.
+         ELSE IF ( RH .LT. LIRH ) THEN
+            FREEZES = .FALSE.
+         ELSE
+
+C *** Compute IRH using Goff-Gratch equations as given by List (1984)
+            TSDT  = TST / TEMP
+            TDTS  = TEMP / TST
+            T0DT  = T0 / TEMP
+            TDT0  = TEMP / T0
+            LOGPW = -7.90298D0 * ( TSDT - 1.0D0 )
+     &            + 5.02808D0 * LOG10( TSDT )
+     &            - 1.3816D-7 * ( 10.0D0 ** ( 11.344D0 *  (1.0D0 - TDTS) ) - 1.0D0 )
+     &            + 8.1328D-3 * ( 10.0D0 ** ( -3.49149D0 * (TSDT - 1.0D0) ) - 1.0D0 )
+     &            + LOGPST
+            LOGPI = -9.09718D0 * (T0DT - 1.0D0)
+     &            - 3.56654D0 * LOG10( T0DT )
+     &            + .876793D0 * (1.0D0 - TDT0)
+     &            + LOGP0
+            IRH   = 10.0D0 ** ( LOGPI - LOGPW )
+
+            IF ( RH .GT. IRH ) THEN
+               FREEZES = .TRUE.
+            ELSE
+               FREEZES = .FALSE.
+            END IF
+
+         END IF
+      ELSE
+         FREEZES = .FALSE.
+      END IF
+
+      RETURN
+
+      END FUNCTION FREEZES
+
+C:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+      SUBROUTINE CALCISOPGAMMAS( RADIUS, TEMPERATURE,
+     &                           GAMMAIEPOX, GAMMAIMAE,
+     &                           KPIEPOX, fTET, fOS, fdim1, fdim2 )
+
+C  Calculates the uptake coefficients (gammas) for IEPOX, IMAE, and IHMML
+C  based on particle phase H+ (EQLBH) and other particle constituents.
+C  Also returns calculated particle phase reaction rate, fraction of uptake
+C  producing tetrols, organosulfates, and dimers.
+
+C  Note that indices 1 and 2 are used for both acids (1=H+, 2=bisulfate) and
+C  the organics (1=IEPOX, 2=IMAE).
+
+C  Key Subroutines Called: none
+
+C  Key Functions Called: none
+
+C  Revision History: 
+C  HOTP 1/18/13 First coding
+C  HOTP 9/26/14 Reduced form considering only IEPOX uptake with no
+C               speciation developed for CB05
+C  HOTP 5/10/16 Merged with AERO6I code. Now handles SAPRC07tic and MAE uptake.
+
+C  References
+C  1. Chan, M. N., et al. "Characterization and quantification of isoprene-
+C     derived expoxydiols in ambient aerosol in the Southeastern United States,"
+C     Environ. Sci. Technol., 2010, 44, 4590-4596.
+C  2. Eddingsaas, N. C., VanderVelde, D. G., Wennberg, P. O. "Kinetics 
+C     and products of the acid-catalyzed ring-opening of atmospherically
+C     relevant butyl epoxy alcohols," J. Phys. Chem A., 2010, 114, 8106-8113.
+C  3. Gharagheizi, F., et al. "Representation and prediction of molecular diffusivity
+C     of nonelectrolyte organic compounds in water at infinite dilution using the
+C     artificial neural network-group contribution method," J. Chemical & Engineering
+C     Data, 2011, 46, 1741-1750.
+C  4. Hanson, D. R., Ravishankara, A. R., Solomon, S. "Heterogeneous reactions in
+C     sulfuric acid aerosols: A framework for model calculations," J. Geophys. Res.,
+C     1994, 99, 3615-3629.
+C  5. McNeill, V. F., et al. "Aqueous-phase secondary organic aerosol and organosulfate 
+C     formation in atmospheric aerosols: A modeling study," Environ Sci Technol., 2012,
+C     46, 8075-8081.
+C  6. Pye et al., Epoxide pathways improve model predictions of isoprene
+C     markers and reveal key role of acidity in aerosol formation,
+C     Envion. Sci. Technol, 2013, doi: 10.1021/es402106h. 
+C-----------------------------------------------------------------------
+
+      Use aero_data
+      Use precursor_data
+      Use aeromet_data   ! Includes CONST.EXT (pi) and airtemp
+      Use utilio_defn    ! error message and abort
+
+      Implicit None
+
+C *** Arguments
+      Real( 8 ), Intent( IN )  :: RADIUS       ! Particle radius [m]
+      Real( 8 ), Intent( IN )  :: TEMPERATURE  ! air temperature [deg K]
+      Real( 8 ), Intent( OUT ) :: GAMMAIEPOX ! Uptake coeff for IEPOX []
+      Real( 8 ), Intent( OUT ) :: GAMMAIMAE  ! Uptake coeff for MAE []
+      Real( 8 ), Intent( OUT ) :: KPIEPOX ! Particle phase reaction rate for IEPOX [1/s]
+      Real( 8 ), Intent( OUT ) :: fTET(2), fOS(2), fdim1(2), fdim2(2)
+                                  ! fraction of tetrol, organosulfate, tetroldimer, osdimer []
+                                  ! first value for IEPOX-derived, second for IMAE-derived
+C *** Parameters
+C     For gamma calculation
+      Real( 8 ), Parameter :: inv_alpha    = 1.0d0/0.02d0 ! reciproaccomodation coefficient from McNeill et al. 2012 []
+      Real( 8 ), Parameter :: diffusivity  = 1.0d-9    ! liquid phase diffusivity, based on C4-C5 epoxides 
+                                                       ! and diols at infinite dilution in water (Gharagheizi et al. 2011) [m2/s]
+      Real( 8 ), Parameter :: RgasLatmmolK = 0.08206d0 ! Universal gas constant [L atm/mol K]
+      Real( 8 ), Parameter :: small        = 1.0d-8   ! small number to prevent calculations that may have precision issues
+      Real( 8 ), Parameter :: smaller      = 1.0d-20  ! smaller number to prevent division by zero
+
+C     Acid related
+      Integer, Parameter   :: n_acids      = 2 ! number of acids: H+ and HSO4-
+      Integer, Parameter   :: hacid_idx    = 1 ! H+ acid index
+      Integer, Parameter   :: hso4acid_idx = 2 ! HSO4 acid index
+
+C     Henry's law coeff for IEPOX (1) and IMAE (2) (HenryWin v 3.2)
+      Real( 8 ) :: Heff(2)
+
+C     Diagnostic
+      Character (16 ), Parameter :: pname = 'CALCISOPGAMMAS'
+
+C *** Local Variables
+      Integer   :: i                   ! counter and temporary indices
+      Real( 8 ) :: eqlbh               ! Particle Phase H+ from isoropia [mol/m**3]
+      Real( 8 ) :: q, denom            ! quantities in Hanson et al. 1994 equation for gamma []
+      Real( 8 ) :: nu                  ! molecular speed [m/s], note this is the same as CBAR but we want to avoid excessive passing
+      Real( 8 ) :: acidmolconc( n_acids ) ! concentration of acid in mol/m3
+      Real( 8 ) :: acid                ! temporary concentration of acid in mol/m3
+      Real( 8 ) :: nuc                 ! nucleophile concentration in mol/m3
+      Real( 8 ) :: charge              ! temporary for charge balance calculation [umol/m3]
+      Real( 8 ) :: inv_volume          ! reciprocal of particle volume [m3 air/Liters particles]
+      Real( 8 ) :: kchem, kparticle(2) 
+      Real( 8 ) :: kchemtet(2),kchemos(2), kchemdim1(2), kchemdim2(2) ! particle phase rxn rates [1/s] 
+      Real( 8 ) :: gammaisop(2)        ! temporary value for IEPOX (1) and IMAE (2) gammas
+      Real( 8 ) :: cfactor_isop(2)     ! cfactor for IEPOX(1) and MAE(2)
+      Real( 4 ) :: temp                ! air temperature [deg K]
+      Character ( 80 ) :: xmsg         ! error message
+
+C *** External functions
+      Interface
+         Real Function hlconst ( cname, temp, effective, hplus )
+           Use utilio_defn
+           Implicit None
+           Character*(*), Intent ( In ) :: cname
+           Real,          Intent ( In ) :: temp
+           Logical,       Intent ( In ) :: effective
+           Real,          Intent ( In ) :: hplus
+        End Function hlconst
+      End Interface
+
+C-----------------------------------------------------------------------
+
+C *** Determine H+ acid concentration of j mode [mol/m3]
+      eqlbh = aerospc_conc( ah3op_idx, 2 ) / aerospc_mw( ah3op_idx ) * 1.0d-6
+      acidmolconc( hacid_idx ) = Max( eqlbh, 0.0d0 ) 
+
+C *** Calculate HSO4 by charge balance
+C     Note: if isorropia has returned a negative H+ concentration
+C     we effectively treat all H+ like HSO4 (slightly less effective
+C     in catalyzing the ring-opening)
+      charge = 0.0d0  ! umol/m3
+      Do i = 1, n_aerospc
+         If ( aerospc( i )%tracer ) Cycle
+         If ( aero_missing( i,2 ) ) Cycle
+         charge = charge - aerospc( i )%charge * aerospc_conc( i,2 )
+     &          / aerospc_mw( i )
+      End Do
+      acidmolconc( hso4acid_idx ) = Max( ( charge*1.0d-6 - acidmolconc( hacid_idx ) ), 0.0d0 ) 
+
+C *** J-mode particle volume [L/m**3 air]
+      inv_volume = 0.0d0
+      Do i = 1, n_aerospc 
+         If ( aerospc( i )%tracer ) Cycle
+         If ( aero_missing( i,2 ) ) Cycle
+!        If ( aerospc( i )%no_M2Wet ) Cycle
+         inv_volume = inv_volume + Real( aerospc_conc( i, 2 ) / aerospc(i)%density, 8 ) !  * 1.0d-6
+      End Do
+      inv_volume = 1.0d6 / inv_volume
+
+C *** Loop over nucleophile/acid pairs defined in acid_nuc_pairs in AERO_DATA
+C     and calculate rate of particle phase reaction
+      kchem     = 0.0d0   ! intermediate value
+      kparticle = 0.0d0   ! accumulating IEPOX and IMAE value
+      kchemos   = 0.0d0   ! accumulating organosulfate for IEPOX and IMAE
+      kchemtet  = 0.0d0   ! accumulating tetrols or equivalent for IEPOX and IMAE
+      kchemdim1 = 0.0d0   ! accumulating tetrol-dimer or equivalent for IEPOX and IMAE
+      kchemdim2 = 0.0d0   ! accumulating os-dimer or equivalent for IEPOX and IMAE
+
+      Do i = 1, n_nucpairs
+
+C        Find J-mode nucleophile concentration in ug/m3 and convert to mol/m3
+         nuc = aerospc_conc( acid_nucmap_idx( i ), 2 ) 
+     &       /  aerospc_mw( acid_nucmap_idx( i ) ) * 1.0d-6
+
+         acid = acidmolconc( acid_nuc_pairs( i )%idx_acid ) ! mol/m3
+
+C        Correct sulfate for presence of bisulfate
+         If ( acid_nuc_pairs( i )%idx_remove .Ge. 1 ) Then
+            nuc = Max( nuc - acidmolconc( acid_nuc_pairs( i )%idx_remove ), 0.0d0 )
+         End If
+
+C        Determine rate of particle phase rxn for a given pair (Eddingsaas et al.)
+         kchem = acid_nuc_pairs( i )%kchem* nuc * acid * ( inv_volume*inv_volume )
+         
+C        Update sum
+C        Store information with speciation for IEPOX
+         if ( acid_nuc_pairs( i )%parent .eq. 'IEPOX' ) then
+            kparticle( 1 )  = kparticle(1) + kchem
+            if ( acid_nuc_pairs( i )%prod .eq. 'AIEOSJ' ) then !ae6i
+              kchemos( 1 )  = kchemos(1)   + kchem
+            else if ( (acid_nuc_pairs( i )%prod .eq. 'ADIMJ')
+     &             .and. (acid_nuc_pairs( i )%nuc .eq. 'AIETETJ') ) then !ae6i
+              kchemdim1( 1 ) = kchemdim1(1)  + kchem
+            else if ( (acid_nuc_pairs( i )%prod .eq. 'ADIMJ')
+     &             .and. (acid_nuc_pairs( i )%nuc .eq. 'AIEOSJ') ) then !ae6i
+              kchemdim2( 1 ) = kchemdim2(1)  + kchem
+            else if ( acid_nuc_pairs( i )%prod .eq. 'AIETETJ' ) then !ae6i
+              kchemtet( 1 ) = kchemtet(1)  + kchem
+            else if ( acid_nuc_pairs( i )%prod .eq. 'AISO3J' ) then
+              ! do nothing for aero6 since speciation isn't tracked
+            else
+               xmsg = 'For IEPOX parent, reaction product not recognized '
+               CALL M3EXIT( PNAME, 0, 0, XMSG, XSTAT2 )
+            end if
+         end if
+
+C        Store information with speciation for IMAE
+         if ( acid_nuc_pairs( i )%parent .eq. 'IMAE' ) then
+            kparticle( 2 )  = kparticle( 2 ) + kchem
+            if( acid_nuc_pairs( i )%prod .eq. 'AIMOSJ' ) then
+              kchemos( 2 )  = kchemos( 2 )   + kchem
+            else if( acid_nuc_pairs( i )%prod .eq. 'AIMGAJ' ) then
+              kchemtet( 2 ) = kchemtet( 2 )  + kchem
+            else
+               xmsg = 'For IMAE parent, reaction product not recognized '
+               CALL M3EXIT( PNAME, 0, 0, XMSG, XSTAT2 )
+            end if
+         end if
+      End Do      
+
+C *** Calculate gamma following Pye et al. 2013 ES&T
+C     (see also Hanson et al. 1994 JGR Eqn (2) for details)
+C *** Calculate gammas for IEPOX and IMAE
+
+C *** Henry's Law coefficients
+      temp = real( TEMPERATURE, 4)
+      Heff( 1 ) = REAL(HLCONST( 'IEPOX', temp, .False., 0.0 ), 8)
+      Heff( 2 ) = REAL(HLCONST( 'IMAE',  temp, .False., 0.0 ), 8)
+
+C *** Cfactor
+      cfactor_isop( 1 ) = cfactor_iepox
+      cfactor_isop( 2 ) = cfactor_imae
+
+C     Loop over precursor species and calculate gamma
+C     (see Hanson et al. 1994 JGR Eqn (2) for details)
+      Do  i = 1, numvoc
+
+C     Note that if the rate of particle phase reaction is very slow, there may not
+C     be enough digits of precision to properly calculate q which can result in
+C     erroneously high gamma values. Only calculate gamma if particle phase reaction
+C     is faster than 1e-8 1/s
+
+      ! Diffuso reactive parameter [ m * sqrt ( 1/s s/m2 ) = dim'less ]
+      q = radius * dsqrt ( kparticle(i)/ diffusivity )
+
+      If ( q / Tanh( q ) .Gt. 1.0d0 ) Then
+
+         ! Molecular speed [ sqrt ( J/mol K * K / g * mol * g/ kg ) = sqrt (J/kg) = m/s ]
+         nu = cfactor_isop( i ) * dsqrt( temperature )
+
+         ! Gamma [ denom:  m/s / ( mol/L/atm * L atm /mol/ K * K * sqrt ( m2/s * 1/s )) = dim'less ]
+
+          denom = ( inv_alpha + nu * radius
+     &          / ( 4.0d0 * Heff( i )* RgasLatmmolK * temperature * diffusivity
+     &            * ( q / Tanh( q ) -1.0d0 ) ) ) 
+
+          gammaisop( i ) = 1.0d0 / denom
+
+          ftet( i ) = kchemtet( i ) / kparticle( i )
+          fos( i )  = kchemos( i ) / kparticle( i )
+          fdim1( i ) = kchemdim1( i ) / kparticle( i )
+          fdim2( i ) = kchemdim2( i ) / kparticle( i )
+
+C     No/slow reaction
+      Else
+
+         gammaisop( i ) = 0.0d0
+         ftet( i )  = 0d0
+         fos( i )   = 0d0
+         fdim1( i ) = 0d0
+         fdim2( i ) = 0d0
+
+      End If
+
+      End Do
+
+C *** Calculate final values to return
+      gammaiepox = gammaisop( 1 )
+      gammaimae  = gammaisop( 2 )
+      kpiepox    = kparticle( 1 )
+
+      RETURN
+ 
+      END SUBROUTINE CALCISOPGAMMAS
+
+      END MODULE AEROSOL_CHEMISTRY

--- a/DOCS/Known_Issues/CMAQv5.2-i5/AERO_DATA.F
+++ b/DOCS/Known_Issues/CMAQv5.2-i5/AERO_DATA.F
@@ -1,0 +1,1644 @@
+
+!------------------------------------------------------------------------!
+!  The Community Multiscale Air Quality (CMAQ) system software is in     !
+!  continuous development by various groups and is based on information  !
+!  from these groups: Federal Government employees, contractors working  !
+!  within a United States Government contract, and non-Federal sources   !
+!  including research institutions.  These groups give the Government    !
+!  permission to use, prepare derivative works of, and distribute copies !
+!  of their work in the CMAQ system to the public and to permit others   !
+!  to do so.  The United States Environmental Protection Agency          !
+!  therefore grants similar permission to use the CMAQ system software,  !
+!  but users are requested to provide copies of derivative works or      !
+!  products designed to operate in the CMAQ system to the United States  !
+!  Government without restrictions as to use by others.  Software        !
+!  that is used with the CMAQ system but distributed under the GNU       !
+!  General Public License or the GNU Lesser General Public License is    !
+!  subject to their copyright restrictions.                              !
+!------------------------------------------------------------------------!
+
+C RCS file, release, date & time of last delta, author, state, [and locker]
+C $Header: /project/yoj/arc/CCTM/src/aero/aero6/AERO_DATA.F,v 1.10 2012/01/19 13:18:37 yoj Exp $
+
+C:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+      Module aero_data
+
+C  Defines aerosol species arrays and the parameters required in aerosol
+C  processing.
+
+C  Contains:
+C     Subroutine map_aero
+C     Subroutine map_pmemis
+C     Subroutine extract_aero
+C     Subroutine update_aero
+C     Function findAero
+
+C  Revision History:
+C     First version was coded in April 2010 by Steve Howard with
+C     Prakash Bhave, Jeff Young, and Sergey Napelenok.
+
+C HS = Heather Simon; GS = Golam Sarwar; SH = Steve Howard; SR = Shawn Roselle;
+C JY = Jeff Young; HOTP = Havala Pye; KF = Kathleen Fahey, CGN = Chris Nolte;
+C PL = Peng Liu;
+
+C HS  01/24/11 Updated to initial AERO6; PMOTHR -> 9 species
+C GS  03/02/11 Revised parameters for Mg, K, and Ca
+C SH  03/10/11 Inserted functionality of PMEM_DEFN
+C    -new subroutine map_pmemis
+C HS  03/10/11 Made PNCOM a required species
+C SR  03/25/11 Replaced I/O API include files with UTILIO_DEFN
+C SH  04/04/11 Added sea-salt speciation factors
+C GS  04/09/11 Updated sea-salt speciation; replaced ANAK with ASEACAT;
+C              made MG, K, CA, SEACAT required species;
+C JY  04/21/11 Added optional log messages (verbose_aero)
+C JY  05/02/11 Added Reshape to aerospc_ssf initialization for pgf90 compiler
+C BH  08/31/11 Adapted for mercury and HAP mechanisms
+C JY  06/08/12 remove full character blank padding put in for GNU Fortran (GCC) 4.1.2
+C HOTP 01/16/13 Removed isoprene acid enhanced aerosol and added new isoprene aerosol
+C HOTP 01/18/13 Added information for particle phase reaction of isoprene products
+C               based on Eddingsaas et al. 2010
+C KF  09/17/14 Changed emitted modal PM mass fractions and geometric mean diameter and
+C              geometric standard deviation of emitted particles according to
+C              Elleman and Covert (2010)
+C HOTP 09/27/14 Added alkane and PAH SOA species. PAH SOA densities follow Chan et al.
+C JY  08/24/15 Changed visual index factors
+C HOTP 2/17/2016 Updated SOA densities. BTX follows Ng et al. 2007.
+C                1.4 g/cm3 used by default.
+C JY  02/17/16 Created named constants for speciation and other factors for AERO_EMIS,
+C              DUST_EMIS, aero_subs:VOLINORG, and aqchem
+C CGN 04/14/16 Changed AMGJ speciation factor from 0.0 to 0.019 following Upadhyay et al.
+C HOTP,BM  5/20/16 Updated to work with all ae6 mechs (6, 6i, 6mp)
+C PL 05/15/16 Update visual_idx, and add visual_idx_large in spcs_type, due to ammonium sulfate, nitrate and OM
+C             are splitted into small and large modes.
+C             visual_idx for ammominm is zero, because it will be treated together with sulfate and nitrate
+C             see Pitchford et al., Journal of the Air & Waste Management Association (57)(2007), pp 1326
+C PL 05/15/16 Add "om" in spcs_type, to flag organic aerosols, which
+C             will be used to calculate total mass of organic aerosls for estimating
+C             aerosol extinction efficiency
+
+C References:
+C 1. Eddingsaas, N. C., Vandervelde, D. G., Wennberg, P. O., "Kinetics and
+C    products of the acid-catalyzed ring-opening of atmospherically relevant
+C    butyl epoxy alcohols," J. Phys. Chem. A., 2010, 114, 8106-8113.
+C 2. Chan, et al., "Secondary organic aerosol formation from photooxidation
+C    of naphthalene and alkylnaphthalenes: implications for oxidation of
+C    intermediate volatility organic compounds (IVOCs)", Atmos. Chem. Phys.,
+C    2009, 9, 3049-3060.
+C 3. Ng, N. L., Kroll, J. H., Chan, A. W. H., Chhabra, P. S., Flagan, R.
+C    C., and Seinfeld, J. H.: Secondary organic aerosol formation from
+C    m-xylene, toluene, and benzene, Atmos. Chem. Phys., 7, 3909-3922,
+C    doi:10.5194/acp-7-3909-2007, 2007.
+C 4. Elleman and Covert, "Aerosol size distribution modeling with the Community Multiscale
+C    Air Quality modeling system in the Pacific Northwest: 3. Size distribution of
+C    particles emitted into a mesoscale model", JGR, 115, D03204, 2010
+C 5. Simon, et al., "The development and uses of EPA's SPECIATE database",
+C    Atmos. Poll. Res., 1, 196-206, 2010
+C 6. Upadhyay, et al., "Size-Differentiated Chemical Composition of Re-Suspended Soil
+C    Dust from the Desert Southwest United States," Aero. and AQ Res., 2015, 387-398
+
+C JY: From Christian Hogrefe...
+C Based on Malm and Hand (Atmos. Env. 41, 3407-3427, 2007), the revised
+C IMPROVE extinction calculation includes coarse particles, sea salt, and
+C a relative humidity correction for sea salt. Also, the factor for "LAC"
+C (light absorbing carbon, i.e. AECI and AECJ) should be 10, not 0 since
+C both scattering and absorption contribute to total extinction.
+C ASEACAT includes all sea-salt cations in coarse mode (Na, Ca, K, and Mg)
+C Also note...
+C In the Fortran user-derived spcs_type, below, visual_idx is an optimal dry mass
+C extinction efficiency [m^2/g], see White, Atmos.Env., 294(10)(1990), pp 2673-1672
+C and Malm, et al., JGR, 99(D1)(1994), pp 1347-1370
+C----------------------------------------------------------------------
+
+      Implicit None
+
+C Number of aerosol species and modes
+
+      Integer, Parameter :: n_aerolist = 89     ! number of aero species
+      Integer, Parameter :: n_mode = 3          ! number of modes:
+                                                ! 1 = Aitken
+                                                ! 2 = accumulation
+                                                ! 3 = coarse
+
+      Integer, Save :: n_aerospc ! number of aero species
+
+C Default minimum concentration
+      Real,    Parameter :: conmin  = 1.0E-30    ! [ ug/m^3 ]
+      Real(8), Parameter :: conminD = 1.0D-30    ! [ ug/m^3 ]
+      Real,    Parameter :: evapmin = 1.0E-20    ! [ ug/m^3 ]
+      Real(8), Parameter :: evapminD= 1.0D-20    ! [ ug/m^3 ]
+      Real,    Parameter :: cm_set( n_mode ) = (/conmin, conmin, conmin/)
+      Real,    Parameter :: cm_so4( n_mode ) = (/1.0E-12,1.0E-6, conmin/)
+      Real,    Parameter :: cm_cor( n_mode ) = (/conmin, conmin, 1.889544E-05/)
+
+C Emissions splits
+      Real,    Parameter :: es_fin( n_mode ) = (/ 0.100, 0.900, 0.000 /)
+      Real,    Parameter :: es_acc( n_mode ) = (/ 0.000, 1.000, 0.000 /)
+      Real,    Parameter :: es_cor( n_mode ) = (/ 0.000, 0.000, 1.000 /)
+      Real,    Parameter :: es_0  ( n_mode ) = (/ 0.000, 0.000, 0.000 /)
+
+C Geometric mean diameter by volume (or mass) of emitted particles in
+C each mode [ m ].  See paragraph #14 of Binkowski & Roselle (2003)
+C 09/17/14 change by Kathleen Fahey - see Revision History, above
+      Real,    Parameter :: dgvem( n_mode ) = (/ 0.06E-6, 0.28E-6, 6.0E-6 /)
+      Real,    Parameter :: def_diam( n_mode )   = (/ 15.0E-9, 80.0E-9,  600.0E-9 /)  ! default background mean diameter for each mode
+      Real,    Parameter :: min_diam_g( n_mode ) = (/ 1.0E-9,  30.0E-9,  120.0E-9 /)
+      Real,    Parameter :: max_diam_g( n_mode ) = (/ 30.0E-9, 120.0E-9, 100.0E-6 /)
+
+C Geometric standard deviation of emitted particles in each mode, as
+C described in paragraph #14 of Binkowski & Roselle (2003)
+C 09/17/14 change by Kathleen Fahey - see Revision History, above
+      Real,    Parameter :: sgem( n_mode )        = (/ 1.7, 1.7, 2.2 /)
+      Real,    Parameter :: def_sigma_g( n_mode ) = (/ 1.70, 2.0, 2.2 /)       ! default background sigma-g for each mode
+      Real,    Parameter :: min_sigma_g = 1.05
+      Real,    Parameter :: max_sigma_g = 2.5001
+      Real,    Save      :: def_l2sg( n_mode ), max_l2sg, min_l2sg   
+
+C If FIXED_sg = T, atkn & accum std. dev. are not changed by GETPAR
+C If FIXED_sg = F, the second moment will be adjusted if the standard
+C                  deviation (sigma_g) is outside of the bounds specified 
+C                  by min_sigma_g and max_sigma_g.
+      LOGICAL, PARAMETER :: FIXED_sg = .FALSE.
+
+C Flag to obtain coagulation coefficients
+C by analytical approximation (True) or by Gauss-Hermite quadrature (False)
+      Logical, Parameter :: fastcoag_flag = .True.
+
+C Define Logical values as T and F for the aerospc table
+      Logical, Parameter, Private :: T = .true.
+      Logical, Parameter, Private :: F = .false.
+
+      Integer, Private, Save :: logdev
+      Integer, Private, External :: setup_logdev
+
+C-------------------------------------------------------------------------------------------------------
+
+      Type spcs_type
+         Character( 16 ) :: name( n_mode )       ! names of aerosol species for each mode
+         Real            :: min_conc( n_mode )   ! minimum concentration values for each mode
+         Real            :: density              ! density [ kg/m^3 ]
+         Logical         :: no_M2Wet             ! flag to exclude from 2nd moment during transport
+         Logical         :: nonVol_soa           ! non-volatile SOA flag
+         Logical         :: tracer               ! tracer flag; does have not mass
+         Integer         :: charge               ! electroneutrality charge
+         Real            :: visual_idx           ! visual index factor [ m^2/g ]
+         Real            :: visual_idx_large     ! visual index factor [m^2/g ] for large mode, if not applicable, same value as visual_idx
+         Logical         :: om                   ! flag for organic aerosols
+         Character( 16 ) :: optic_surr           ! optical surrogate name
+         Character( 16 ) :: emis                 ! file emissions names
+         Real            :: emis_split( n_mode ) ! minimum concentration values for each mode
+      End Type spcs_type
+
+      ! Create Array of Aerosol Species to Be Filled with User Preferences
+      Type( spcs_type ), Allocatable, Save :: aerospc ( : )
+
+      ! Master List of Aerosol Species and Properties
+      Type( spcs_type ), Parameter :: aerolist( n_aerolist ) = (/
+C                                                                       nonVolSOA       Visidx_Large
+C                                                                   no_M2Wet|Tracer         |
+C                  -------------Name--------------                        | | | Charge      | OM                  Emissions
+C                   Aitken      Accum       Coarse      Min_Concs Density | | |   | Visidx  |  |  OptSurr       Emis       Splits
+C                  ---------   ---------   ---------    --------- ------- + + +   + ------ --- +  -------- --------------- ------
+     & spcs_type((/'ASO4I    ','ASO4J    ','ASO4K    '/), cm_so4, 1800.0, F,F,F, -2,  2.2, 4.8,F, 'SOLUTE','PSO4         ',es_fin),
+     & spcs_type((/'ANO3I    ','ANO3J    ','ANO3K    '/), cm_set, 1800.0, F,F,F, -1,  2.4, 5.1,F, 'SOLUTE','PNO3         ',es_fin),
+     & spcs_type((/'ACLI     ','ACLJ     ','ACLK     '/), cm_set, 2200.0, F,F,F, -1,  1.7, 1.7,F, 'SOLUTE','PCL          ',es_fin),
+     & spcs_type((/'ANH4I    ','ANH4J    ','ANH4K    '/), cm_set, 1800.0, F,F,F,  1,  0.0, 0.0,F, 'SOLUTE','PNH4         ',es_fin),
+     & spcs_type((/'ANAI     ','ANAJ     ','         '/), cm_set, 2200.0, F,F,F,  1,  1.7, 1.7,F, 'SOLUTE','PNA          ',es_fin),
+     & spcs_type((/'         ','AMGJ     ','         '/), cm_set, 2200.0, F,F,F,  2,  1.0, 1.0,F, 'DUST  ','PMG          ',es_acc),
+     & spcs_type((/'         ','AKJ      ','         '/), cm_set, 2200.0, F,F,F,  1,  1.0, 1.0,F, 'DUST  ','PK           ',es_acc),
+     & spcs_type((/'         ','ACAJ     ','         '/), cm_set, 2200.0, F,F,F,  2,  1.0, 1.0,F, 'DUST  ','PCA          ',es_acc),
+     & spcs_type((/'APOCI    ','APOCJ    ','         '/), cm_set, 1400.0, F,F,F,  0,  2.8, 6.1,T, 'DUST  ','POC          ',es_fin),
+     & spcs_type((/'APNCOMI  ','APNCOMJ  ','         '/), cm_set, 1400.0, F,F,F,  0,  2.8, 6.1,T, 'DUST  ','PNCOM        ',es_fin),
+     & spcs_type((/'AECI     ','AECJ     ','         '/), cm_set, 2200.0, F,F,F,  0, 10.0,10.0,F, 'SOOT  ','PEC          ',es_fin),
+     & spcs_type((/'         ','AFEJ     ','         '/), cm_set, 2200.0, F,F,F,  0,  1.0, 1.0,F, 'DUST  ','PFE          ',es_acc),
+     & spcs_type((/'         ','AALJ     ','         '/), cm_set, 2200.0, F,F,F,  0,  1.0, 1.0,F, 'DUST  ','PAL          ',es_acc),
+     & spcs_type((/'         ','ASIJ     ','         '/), cm_set, 2200.0, F,F,F,  0,  1.0, 1.0,F, 'DUST  ','PSI          ',es_acc),
+     & spcs_type((/'         ','ATIJ     ','         '/), cm_set, 2200.0, F,F,F,  0,  1.0, 1.0,F, 'DUST  ','PTI          ',es_acc),
+     & spcs_type((/'         ','AMNJ     ','         '/), cm_set, 2200.0, F,F,F,  0,  1.0, 1.0,F, 'DUST  ','PMN          ',es_acc),
+     & spcs_type((/'AH2OI    ','AH2OJ    ','AH2OK    '/), cm_set, 1000.0, T,F,F,  0,  0.0, 0.0,F, 'WATER ','PH2O         ',es_fin),
+     & spcs_type((/'AH3OPI   ','AH3OPJ   ','AH3OPK   '/), cm_set, 1000.0, T,F,T,  0,  0.0, 0.0,F, 'WATER ','             ',es_0),
+     & spcs_type((/'AOTHRI   ','AOTHRJ   ','         '/), cm_set, 2200.0, F,F,F,  0,  1.0, 1.0,F, 'DUST  ','PMOTHR       ',es_fin),
+     & spcs_type((/'         ','AALK1J   ','         '/), cm_set, 1400.0, T,F,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','AALK2J   ','         '/), cm_set, 1400.0, T,F,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','AXYL1J   ','         '/), cm_set, 1480.0, T,F,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','AXYL2J   ','         '/), cm_set, 1480.0, T,F,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','AXYL3J   ','         '/), cm_set, 1330.0, F,T,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','ATOL1J   ','         '/), cm_set, 1240.0, T,F,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','ATOL2J   ','         '/), cm_set, 1240.0, T,F,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','ATOL3J   ','         '/), cm_set, 1450.0, F,T,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','ABNZ1J   ','         '/), cm_set, 1400.0, T,F,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','ABNZ2J   ','         '/), cm_set, 1400.0, T,F,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','ABNZ3J   ','         '/), cm_set, 1400.0, F,T,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','ATRP1J   ','         '/), cm_set, 1400.0, T,F,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','ATRP2J   ','         '/), cm_set, 1400.0, T,F,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','AISO1J   ','         '/), cm_set, 1400.0, T,F,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','AISO2J   ','         '/), cm_set, 1400.0, T,F,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','AISO3J   ','         '/), cm_set, 1400.0, F,T,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','ASQTJ    ','         '/), cm_set, 1400.0, T,F,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','APAH1J   ','         '/), cm_set, 1480.0, T,F,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','APAH2J   ','         '/), cm_set, 1480.0, T,F,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','APAH3J   ','         '/), cm_set, 1550.0, F,T,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','AOLGAJ   ','         '/), cm_set, 1400.0, F,T,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','AOLGBJ   ','         '/), cm_set, 1400.0, F,T,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','AORGCJ   ','         '/), cm_set, 1400.0, F,T,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','         ','ASOIL    '/), cm_set, 2600.0, F,F,F,  0,  0.6, 0.6,F, 'DUST  ','             ',es_cor),
+     & spcs_type((/'         ','         ','ACORS    '/), cm_cor, 2200.0, F,F,F,  0,  0.6, 0.6,F, 'DUST  ','PMC          ',es_cor),
+     & spcs_type((/'         ','         ','ASEACAT  '/), cm_cor, 2200.0, F,F,F,  1,  1.7, 1.7,F, 'SOLUTE','             ',es_cor),
+
+       ! Associated with ae6i
+     & spcs_type((/'         ','AMTNO3J  ','         '/), cm_set, 1400.0, T,F,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','AISOPNNJ ','         '/), cm_set, 1400.0, T,F,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','AMTHYDJ  ','         '/), cm_set, 1400.0, F,T,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','AIETETJ  ','         '/), cm_set, 1400.0, F,F,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','AIEOSJ   ','         '/), cm_set, 1400.0, F,F,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','ADIMJ    ','         '/), cm_set, 1400.0, F,F,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','AIMGAJ   ','         '/), cm_set, 1400.0, F,F,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','AIMOSJ   ','         '/), cm_set, 1400.0, F,F,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+
+       ! ae6i and cb6
+     & spcs_type((/'         ','AGLYJ    ','         '/), cm_set, 1400.0, F,F,F,  0,  2.8, 6.1,T, 'DUST  ','             ',es_0),
+ 
+       ! Semivolatile POA
+     & spcs_type((/'ALVPO1I  ','ALVPO1J  ','         '/), cm_set, 1400.0, T,F,F,  0,  4.0, 6.1,T, 'DUST  ','POC          ',es_fin),
+     & spcs_type((/'ASVPO1I  ','ASVPO1J  ','         '/), cm_set, 1400.0, T,F,F,  0,  4.0, 6.1,T, 'DUST  ','POC          ',es_fin),
+     & spcs_type((/'ASVPO2I  ','ASVPO2J  ','         '/), cm_set, 1400.0, T,F,F,  0,  4.0, 6.1,T, 'DUST  ','POC          ',es_fin),
+     & spcs_type((/'         ','ASVPO3J  ','         '/), cm_set, 1400.0, T,F,F,  0,  4.0, 6.1,T, 'DUST  ','POC          ',es_acc),
+     & spcs_type((/'         ','AIVPO1J  ','         '/), cm_set, 1400.0, T,F,F,  0,  4.0, 6.1,T, 'DUST  ','POC          ',es_acc),
+     & spcs_type((/'ALVOO1I  ','ALVOO1J  ','         '/), cm_set, 1400.0, T,F,F,  0,  4.0, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'ALVOO2I  ','ALVOO2J  ','         '/), cm_set, 1400.0, T,F,F,  0,  4.0, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'ASVOO1I  ','ASVOO1J  ','         '/), cm_set, 1400.0, T,F,F,  0,  4.0, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'ASVOO2I  ','ASVOO2J  ','         '/), cm_set, 1400.0, T,F,F,  0,  4.0, 6.1,T, 'DUST  ','             ',es_0),
+     & spcs_type((/'         ','ASVOO3J  ','         '/), cm_set, 1400.0, T,F,F,  0,  4.0, 6.1,T, 'DUST  ','             ',es_0), ! pcSOA
+     & spcs_type((/'         ','APCSOJ   ','         '/), cm_set, 1400.0, T,F,F,  0,  4.0, 6.1,T, 'DUST  ','             ',es_0),
+
+       ! The following species are associated with the Multi-Pollutant code
+     & spcs_type((/'ANII     ','ANIJ     ','         '/), cm_set, 2200.0, F,F,T,  0,  0.0, 0.0,F, 'DUST  ','NICKEL_F     ',es_fin),
+     & spcs_type((/'         ','         ','ANIK     '/), cm_set, 2200.0, F,F,T,  0,  0.0, 0.0,F, 'DUST  ','NICKEL_C     ',es_cor),
+     & spcs_type((/'ACR_VII  ','ACR_VIJ  ','         '/), cm_set, 2200.0, F,F,T,  0,  0.0, 0.0,F, 'DUST  ','CHROMHEX_F   ',es_fin),
+     & spcs_type((/'         ','         ','ACR_VIK  '/), cm_set, 2200.0, F,F,T,  0,  0.0, 0.0,F, 'DUST  ','CHROMHEX_C   ',es_cor),
+     & spcs_type((/'ACR_IIII ','ACR_IIIJ ','         '/), cm_set, 2200.0, F,F,T,  0,  0.0, 0.0,F, 'DUST  ','CHROMTRI_F   ',es_fin),
+     & spcs_type((/'         ','         ','ACR_IIIK '/), cm_set, 2200.0, F,F,T,  0,  0.0, 0.0,F, 'DUST  ','CHROMTRI_C   ',es_cor),
+     & spcs_type((/'ABEI     ','ABEJ     ','         '/), cm_set, 2200.0, F,F,T,  0,  0.0, 0.0,F, 'DUST  ','BERYLLIUM_F  ',es_fin),
+     & spcs_type((/'         ','         ','ABEK     '/), cm_set, 2200.0, F,F,T,  0,  0.0, 0.0,F, 'DUST  ','BERYLLIUM_C  ',es_cor),
+     & spcs_type((/'APBI     ','APBJ     ','         '/), cm_set, 2200.0, F,F,T,  0,  0.0, 0.0,F, 'DUST  ','LEAD_F       ',es_fin),
+     & spcs_type((/'         ','         ','APBK     '/), cm_set, 2200.0, F,F,T,  0,  0.0, 0.0,F, 'DUST  ','LEAD_C       ',es_cor),
+     & spcs_type((/'ADE_OTHRI','ADE_OTHRJ','         '/), cm_set, 2200.0, F,F,T,  0,  0.0, 0.0,F, 'DUST  ','DIESEL_PMFINE',es_fin),
+     & spcs_type((/'ADE_ECI  ','ADE_ECJ  ','         '/), cm_set, 2200.0, F,F,T,  0,  0.0, 0.0,F, 'DUST  ','DIESEL_PMEC  ',es_fin),
+     & spcs_type((/'ADE_OCI  ','ADE_OCJ  ','         '/), cm_set, 2000.0, F,F,T,  0,  0.0, 0.0,F, 'DUST  ','DIESEL_PMOC  ',es_fin),
+     & spcs_type((/'         ','ADE_NO3J ','         '/), cm_set, 1800.0, F,F,T,  0,  0.0, 0.0,F, 'DUST  ','DIESEL_PMNO3 ',es_acc),
+     & spcs_type((/'         ','ADE_SO4J ','         '/), cm_set, 1800.0, F,F,T,  0,  0.0, 0.0,F, 'DUST  ','DIESEL_PMSO4 ',es_acc),
+     & spcs_type((/'         ','         ','ADE_K    '/), cm_set, 2200.0, F,F,T,  0,  0.0, 0.0,F, 'DUST  ','DIESEL_PMC   ',es_cor),
+     & spcs_type((/'ACDI     ','ACDJ     ','         '/), cm_set, 2200.0, F,F,T,  0,  0.0, 0.0,F, 'DUST  ','CADMIUM_F    ',es_fin),
+     & spcs_type((/'         ','         ','ACDK     '/), cm_set, 2200.0, F,F,T,  0,  0.0, 0.0,F, 'DUST  ','CADMIUM_C    ',es_cor),
+     & spcs_type((/'AMN_HAPSI','AMN_HAPSJ','         '/), cm_set, 2200.0, F,F,T,  0,  0.0, 0.0,F, 'DUST  ','MANGANESE_F  ',es_fin),
+     & spcs_type((/'         ','         ','AMN_HAPSK'/), cm_set, 2200.0, F,F,T,  0,  0.0, 0.0,F, 'DUST  ','MANGANESE_C  ',es_cor),
+     & spcs_type((/'APHGI    ','APHGJ    ','         '/), cm_set, 2200.0, F,F,T,  0,  0.0, 0.0,F, 'DUST  ','PHGI         ',es_fin),
+     & spcs_type((/'         ','         ','APHGK    '/), cm_set, 2200.0, F,F,T,  0,  0.0, 0.0,F, 'DUST  ','             ',es_cor),
+     & spcs_type((/'AASI     ','AASJ     ','         '/), cm_set, 2200.0, F,F,T,  0,  0.0, 0.0,F, 'DUST  ','ARSENIC_F    ',es_fin),
+     & spcs_type((/'         ','         ','AASK     '/), cm_set, 2200.0, F,F,T,  0,  0.0, 0.0,F, 'DUST  ','ARSENIC_C    ',es_cor)
+     & /)
+ 
+C Primary Organic Aerosol Volatility Distributions
+      Integer, Parameter :: n_vbs_bin = 5
+      Character( 10 ) :: poa_name( n_vbs_bin ) = (/ 'LVPO1', 'SVPO1', 'SVPO2', 'SVPO3', 'IVPO1' /)
+      Real, Parameter :: poa_op_vf( n_vbs_bin ) = (/ 0.09,  0.09,  0.14,  0.18,  0.5 /)  ! Aggregated
+
+! The Following Volatility Distributions are alternative options
+! but at this point can only be implemented indivdually for the
+! entire POA suite of compounds.
+!     Real, Parameter :: poa_gv_vf(n_vbs_bin) = (/0.27,  0.15,   0.26,   0.15,   0.17/) ! Gasoline
+!     Real, Parameter :: poa_dv_vf(n_vbs_bin) = (/0.03,  0.25,   0.37,   0.24,   0.11/) ! Diesel
+!     Real, Parameter :: poa_bb_vf(n_vbs_bin) = (/0.2,   0.1,    0.1,    0.2,    0.4/)  ! Biomass Burning
+!     Real, Parameter :: poa_nv_vf(n_vbs_bin) = (/1.0,   0.0,    0.0,    0.0,    0.0/)  ! Nonvolatile
+!     Real, Parameter :: poa_mc_vf(n_vbs_bin) = (/0.35,  0.35,   0.1,    0.1,    0.1/)  ! Meat Cooking
+
+! POA_AMF is the fraction of total emissions in the particle phase.
+! This parameter is for distributing the total emissions between
+! gas and particle BEFORE the aerosol size distribution is applied.
+! This helps prevent numerical issues with shrinking the particles
+! instantaneously.
+      Real, Parameter :: poa_amf( n_vbs_bin ) = (/ 1.0, 0.5, 0.0, 0.0, 0.0 /)
+ 
+C number of lognormal modes in windblown dust aerosol = n_mode
+C - but only accumulation and coarse modes used
+      Type emis_table
+         Character( 16 ) :: description
+         Character( 16 ) :: name  ( n_mode )
+         Real            :: spcfac( n_mode )
+      End type emis_table
+
+C For the wind-blown dust speciation factors, we used the median of the Desert Soil
+C profiles 3398, 3403, 3408, and 3413 for the J mode from the SPECIATE database and
+C profiles 3399, 3404, 3409, and 3414 for coarse PM. (G. Pouliot - private communication)
+C See Ref. (4), above and https://cfpub.epa.gov/si/speciate/
+! For toxic metal species, more recent sources were consulted because the above profiles give large uncertainties in their 
+! speciation factors
+! For the air toxics version of manganese, nickel, chromium(III), arsenic, and lead:
+!    Table 2 in Y. Su, and R. Yang., Background concentrations of elements in surface soils and 
+!    their changes as affected by agriculture use in the desert-oasis ecotone in the middle of Heihe
+!    River Basin, North-west China, Journal of Geochemical Exploration, 98, 2008, 57–64 was used.
+!    The table represents natural desert soils prior to cultivation. Note that all chromium is 
+!    to be trivalent based on assuming low pH or anoxics conditions. 
+! For cadmium:
+!    The background mixing ratio was used from Table 3 in Su, C., Jiang, L.,and Zhang, W., 
+!    A review on heavy metal contamination in the soil worldwide: Situation, impact and 
+!    remediation techniques, Environmental Skeptics and Critics, 2014, 3(2): 24-38. 
+!    The table reviews worldwide cultivation soils.
+! For mercury:
+!    Table 2 in D. Obrist et al., A synthesis of terrestrial mercury in the western United States: 
+!    Spatial distribution defined by land cover and plant productivity, Science of the Total Environment, 
+!    568, 2016, 522–535.
+!    Factors were based on mixing ratios for barren and cultivated land cover type
+! Speciation factors between j and k modes were assumed constant because no data was found.
+
+C maximum number of chemical species in windblown dust aerosol
+      Integer, Parameter :: ndust_list = 26
+      Integer            :: ndust_spc
+
+       
+      Type( emis_table ) :: dust_spc_list( ndust_list ) = (/
+C                    --description--           -------- name --------             -------- spcfac --------
+C                                           Aitken     accum       coarse          Aitken  accum   coarse
+     &   emis_table( 'Sulfate       ', (/'         ','ASO4J    ','ASO4K    '/), (/ 0.0, 0.02250, 0.02655/) ),   ! Sulfate
+     &   emis_table( 'Nitrate       ', (/'         ','ANO3J    ','ANO3K    '/), (/ 0.0, 0.00020, 0.00160/) ),   ! Nitrate
+     &   emis_table( 'Chlorine      ', (/'         ','ACLJ     ','ACLK     '/), (/ 0.0, 0.00945, 0.01190/) ),   ! Chlorine
+     &   emis_table( 'Ammonium      ', (/'         ','ANH4J    ','         '/), (/ 0.0, 0.00005, 0.0    /) ),   ! Ammonium
+     &   emis_table( 'Sodium        ', (/'         ','ANAJ     ','         '/), (/ 0.0, 0.03935, 0.0    /) ),   ! Sodium
+     &   emis_table( 'Calcium       ', (/'         ','ACAJ     ','         '/), (/ 0.0, 0.07940, 0.0    /) ),   ! Calcium
+     &   emis_table( 'Magnesium     ', (/'         ','AMGJ     ','         '/), (/ 0.0, 0.01900, 0.0    /) ),   ! Magnesium
+     &   emis_table( 'Potassium     ', (/'         ','AKJ      ','         '/), (/ 0.0, 0.03770, 0.0    /) ),   ! Potassium
+     &   emis_table( 'Org. Carbon   ', (/'         ','APOCJ    ','         '/), (/ 0.0, 0.01075, 0.0    /) ),   ! Organic Carbon
+     &   emis_table( 'NonCarbon Org.', (/'         ','APNCOMJ  ','         '/), (/ 0.0, 0.00430, 0.0    /) ),   ! Non-Carbon Organic Matter
+     &   emis_table( 'Black Carbon  ', (/'         ','AECJ     ','         '/), (/ 0.0, 0.0,     0.0    /) ),   ! Black or Elemental Carbon
+     &   emis_table( 'Iron          ', (/'         ','AFEJ     ','         '/), (/ 0.0, 0.03355, 0.0    /) ),   ! Iron
+     &   emis_table( 'Aluminum      ', (/'         ','AALJ     ','         '/), (/ 0.0, 0.05695, 0.0    /) ),   ! Aluminum
+     &   emis_table( 'Silcon        ', (/'         ','ASIJ     ','         '/), (/ 0.0, 0.19425, 0.0    /) ),   ! Silicon
+     &   emis_table( 'Titanum       ', (/'         ','ATIJ     ','         '/), (/ 0.0, 0.00280, 0.0    /) ),   ! Titanium
+     &   emis_table( 'Manganese     ', (/'         ','AMNJ     ','         '/), (/ 0.0, 0.00115, 0.0    /) ),   ! Manganese
+     &   emis_table( 'Water         ', (/'         ','AH2OJ    ','AH2OK    '/), (/ 0.0, 0.00541, 0.00637/) ),   ! Water
+     &   emis_table( 'Undefined Mass', (/'         ','AOTHRJ   ','         '/), (/ 0.0, 0.48319, 0.0    /) ),   ! Other
+     &   emis_table( 'Non-Anion Dust', (/'         ','         ','ASOIL    '/), (/ 0.0, 0.0,     0.95358/) ),   ! Non-Anion Dust
+     &   emis_table( 'Air Toxics Mn ', (/'         ','AMN_HAPSJ','AMN_HAPSK'/), (/ 0.0, 0.00041, 0.00041/) ),   ! Air toxics Manganese J and K mode
+     &   emis_table( 'Nickel        ', (/'         ','ANIJ     ','ANIK     '/), (/ 0.0, 2.0E-05, 2.0E-05/) ),   ! Nickel J and K mode
+     &   emis_table( 'Chromium III  ', (/'         ','ACR_IIIJ ','ACR_IIIK '/), (/ 0.0, 5.6E-05, 5.6E-05/) ),   ! Trivalent Chromium J and K mode
+     &   emis_table( 'Arsenic       ', (/'         ','AASJ     ','AASK     '/), (/ 0.0, 5.5E-06, 5.5E-06/) ),   ! Arsenic J and K mode
+     &   emis_table( 'Lead          ', (/'         ','APBJ     ','APBK     '/), (/ 0.0, 1.6E-05, 1.6E-05/) ),   ! Lead J and K mode
+     &   emis_table( 'Cadmium       ', (/'         ','ACDJ     ','ACDK     '/), (/ 0.0, 9.7E-08, 9.7E-08/) ),   ! Cadmium J and K mode
+     &   emis_table( 'Mercury       ', (/'         ','APHGJ    ','APHGK    '/), (/ 0.0, 1.4E-08, 1.4E-08/) ) /) ! Mercury J and K mode
+
+      Type( emis_table ), Allocatable :: dust_spc( : )
+
+C Sea-Salt Speciation factors based on seawater composition:
+! For toxic metal species, Use Table 1 in K.W. Bruland and M.C. Lohan, 6.02 - Controls of Trace Metals in Seawater, 
+! In Treatise on Geochemistry, edited by Heinrich D. Holland and Karl K. Turekian, Pergamon, Oxford, 2003, Pages 23-47,
+! ISBN 9780080437514, http://dx.doi.org/10.1016/B0-08-043751-6/06105-3.
+
+C number of chemical species in seawater aerosol composition
+      integer, parameter :: nsea_spc = 15
+
+      Type( emis_table ), Parameter :: sea_spc( nsea_spc ) = (/
+C                     -description--            -------- name --------                -------- spcfac --------
+C                                           Aitken    accum     coarse             Aitken  accum   coarse
+     &   emis_table( 'Sulfate       ', (/'         ','ASO4J    ','ASO4K    '/), (/ 0.0, 0.07760, 0.07760/) ),   ! Sulfate
+     &   emis_table( 'Chlorine      ', (/'         ','ACLJ     ','ACLK     '/), (/ 0.0, 0.55380, 0.55380/) ),   ! Chlorine
+     &   emis_table( 'Sodium        ', (/'         ','ANAJ     ','         '/), (/ 0.0, 0.30860, 0.0    /) ),   ! Sodium
+     &   emis_table( 'Calcium       ', (/'         ','ACAJ     ','         '/), (/ 0.0, 0.01180, 0.0    /) ),   ! Calcium
+     &   emis_table( 'Magnesium     ', (/'         ','AMGJ     ','         '/), (/ 0.0, 0.03680, 0.0    /) ),   ! Magnesium
+     &   emis_table( 'Potassium     ', (/'         ','AKJ      ','         '/), (/ 0.0, 0.01140, 0.0    /) ),   ! Potassium
+     &   emis_table( 'SeaSalt_Cation', (/'         ','         ','ASEACAT  '/), (/ 0.0, 0.0    , 0.36860/) ),   ! Sea-Salt Cations
+     &   emis_table( 'Chromium IV   ', (/'         ','ACR_VIJ  ','ACR_VIK  '/), (/ 0.0, 5.95E-9, 5.95E-9/) ),   ! accumaltion and coarse mode Hexavalent Chromium
+     &   emis_table( 'Nickel        ', (/'         ','ANIJ     ','ANIK     '/), (/ 0.0, 1.34E-8, 1.34E-8/) ),   ! accumaltion and coarse mode Nickle
+     &   emis_table( 'Arsenic       ', (/'         ','AASJ     ','AASK     '/), (/ 0.0, 4.93E-8, 4.93E-8/) ),   ! accumaltion and coarse mode Arsenic
+     &   emis_table( 'Beryllium     ', (/'         ','ABEJ     ','ABEK     '/), (/ 0.0, 5.2E-11, 5.2E-11/) ),   ! accumaltion and coarse mode Beryllium
+     &   emis_table( 'Mercury       ', (/'         ','APHGJ    ','APHGK    '/), (/ 0.0, 5.8E-11, 5.8E-11/) ),   ! accumaltion and coarse mode Mercury
+     &   emis_table( 'Lead          ', (/'         ','APBJ     ','APBK     '/), (/ 0.0, 6.0E-11, 6.0E-11/) ),   ! accumaltion and coarse mode Lead
+     &   emis_table( 'Cadmium       ', (/'         ','ACDJ     ','ACDK     '/), (/ 0.0, 1.93E-9, 1.93E-9/) ),   ! accumaltion and coarse mode cadmium
+     &   emis_table( 'Air Toxics Mn ', (/'         ','AMN_HAPSJ','AMN_HAPSK'/), (/ 0.0, 4.7E-11, 4.7E-11/) ) /) ! accumaltion and coarse mode Air toxics Manganese
+ 
+      Real, Allocatable, Save :: aerospc_ssf( :,: )
+
+C Constants used in other routines:
+
+      Real( 8 ), Parameter :: asoil_renorm = 1.0D0 - 0.04642D0  ! = 0.95358, same as ASOIL speciation factor in the dust_spc table above
+
+      Real( 8 ), Parameter :: ascat_na_fac = 0.8373D0    ! coarse sea-salt NA cation
+      Real( 8 ), Parameter :: asoil_na_fac = 0.0626D0    ! for NA in windblown dust
+      Real( 8 ), Parameter :: acors_na_fac = 0.0023D0    ! for NA in anthropogenic coarse
+
+      Real( 8 ), Parameter :: ascat_mg_fac = 0.0997D0    ! coarse sea-salt MG cation
+      Real( 8 ), Parameter :: asoil_mg_fac = 0.0170D0    ! for MG in windblown dust
+      Real( 8 ), Parameter :: acors_mg_fac = 0.0032D0    ! for MG in anthropogenic coarse
+
+      Real( 8 ), Parameter :: ascat_k_fac =  0.0310D0    ! coarse sea-salt K cation
+      Real( 8 ), Parameter :: asoil_k_fac =  0.0242D0    ! for K in windblown dust
+      Real( 8 ), Parameter :: acors_k_fac =  0.0176D0    ! for K in anthropogenic coarse
+
+      Real( 8 ), Parameter :: ascat_ca_fac = 0.0320D0    ! coarse sea-salt CA cation
+      Real( 8 ), Parameter :: asoil_ca_fac = 0.0838D0    ! for CA in windblown dust
+      Real( 8 ), Parameter :: acors_ca_fac = 0.0562D0    ! for CA in anthropogenic coarse
+
+
+      Real( 8 ), Parameter :: asoil_fe_fac = 0.02695D0   ! for FE in dust*
+      Real( 8 ), Parameter :: acors_fe_fac = 0.0467D0    ! for FE in anthropogenic coarse
+
+      Real( 8 ), Parameter :: asoil_mn_fac = 0.00075D0   ! for MN in dust*
+      Real( 8 ), Parameter :: acors_mn_fac = 0.0011D0    ! for MN in anthropogenic coarse
+
+C Coarse mode PMC speciation based on anthopogenic inventory composite from various
+C sources (G. Pouliot - private communication):
+
+      Real( 8 ), Parameter :: acorsem_aso4_fac = 0.00100D0
+      Real( 8 ), Parameter :: acorsem_ano3_fac = 0.00048D0
+      Real( 8 ), Parameter :: acorsem_acl_fac  = 0.00145D0
+      Real( 8 ), Parameter :: acorsem_ah2o_fac = 0.00032D0
+      Real( 8 ), Parameter :: acors_renorm = 1.0D0
+     &                                     - acorsem_aso4_fac
+     &                                     - acorsem_ano3_fac
+     &                                     - acorsem_acl_fac
+     &                                     - acorsem_ah2o_fac
+
+C Required species
+      Character( 16 ), Private, Parameter :: req_so4    = 'ASO4'
+      Character( 16 ), Private, Parameter :: req_no3    = 'ANO3'
+      Character( 16 ), Private, Parameter :: req_cl     = 'ACL'
+      Character( 16 ), Private, Parameter :: req_nh4    = 'ANH4'
+      Character( 16 ), Private, Parameter :: req_na     = 'ANA'
+      Character( 16 ), Private, Parameter :: req_mg     = 'AMG'
+      Character( 16 ), Private, Parameter :: req_k      = 'AK'
+      Character( 16 ), Private, Parameter :: req_ca     = 'ACA'
+      Character( 16 ), Private, Parameter :: req_fe     = 'AFE'
+      Character( 16 ), Private, Parameter :: req_mn     = 'AMN'
+      Character( 16 ), Private, Parameter :: req_poc    = 'APOC'
+      Character( 16 ), Private, Parameter :: req_ncom   = 'APNCOM'
+      Character( 16 ), Private, Parameter :: req_h2o    = 'AH2O'
+      Character( 16 ), Private, Parameter :: req_h3op   = 'AH3OP'
+      Character( 16 ), Private, Parameter :: req_soil   = 'ASOIL'
+      Character( 16 ), Private, Parameter :: req_cors   = 'ACORS'
+      Character( 16 ), Private, Parameter :: req_seacat = 'ASEACAT'
+
+C Indices of required species
+      Integer :: aso4_idx
+      Integer :: ano3_idx
+      Integer :: acl_idx
+      Integer :: anh4_idx
+      Integer :: ana_idx
+      Integer :: amg_idx
+      Integer :: ak_idx
+      Integer :: aca_idx
+      Integer :: afe_idx
+      Integer :: amn_idx
+      Integer :: apoc_idx
+      Integer :: apncom_idx
+      Integer :: ah2o_idx
+      Integer :: ah3op_idx
+      Integer :: asoil_idx
+      Integer :: acors_idx
+      Integer :: aseacat_idx
+
+C Flag if optional species present
+      Logical :: ae6isoa = .False.
+      Logical :: ae6hg   = .False.
+
+C Optional Species
+      Character( 16 ), Private, Parameter :: req_ietet  = 'AIETET'
+      Character( 16 ), Private, Parameter :: req_ieos   = 'AIEOS'
+      Character( 16 ), Private, Parameter :: req_dim    = 'ADIM'
+      Character( 16 ), Private, Parameter :: req_imga   = 'AIMGA'
+      Character( 16 ), Private, Parameter :: req_imos   = 'AIMOS'
+      Character( 16 ), Private, Parameter :: req_phgj   = 'APHGJ'
+
+C Indices of Optional species
+      Integer :: aietet_idx = 0
+      Integer :: aieos_idx  = 0
+      Integer :: adim_idx   = 0
+      Integer :: aimga_idx  = 0
+      Integer :: aimos_idx  = 0
+      Integer :: aphgj_idx  = 0
+
+      Real, Allocatable :: aerospc_mw( : )     ! aero species M.W. (from AE_SPC Namelist) [ g/mol ]
+      Real, Allocatable :: aerospc_conc( :,: ) ! aero species concentration [ ug/m^3 ]
+
+C Common factors
+      Real( 8 ) :: h2ofac                      ! converts mass concentrations [ug/m3] to 3rd moment concentrations [m3/m3]
+
+C-------------------------------------------------------------------------------------------------------
+
+      Type mode_type
+         Character( 16 ) :: num_name     ! name of aerosol number variable
+         Character( 16 ) :: srf_name     ! name of aerosol surface area variable
+         Real            :: min_numconc  ! minimum number concentration
+         Real            :: min_m2conc   ! minimum 2nd moment concentration
+         Real            :: min_m3conc   ! minimum 3rd moment concentration
+      End Type mode_type
+
+      Type ( mode_type ), Parameter  :: aeromode( n_mode ) = (/
+C                   number     surface   minimum minimum minimum
+C                    name       name     numconc  m2conc  m3conc
+C                  ----------  -------  -------- -------  ------
+     &   mode_type('NUMATKN', 'SRFATKN', conmin,  conmin, conmin),
+     &   mode_type('NUMACC ', 'SRFACC ', conmin,  conmin, conmin),
+     &   mode_type('NUMCOR ', 'SRFCOR ', conmin,  conmin, conmin)/)
+
+
+      Real          :: moment0_conc( n_mode )     ! 0th moment concentration
+      Real          :: moment2_conc( n_mode )     ! 2nd moment concentration
+      Real          :: moment3_conc( n_mode )     ! 3rd moment concentration
+      Logical, save :: wet_moments_flag           ! T if M2 and M3 are wet, F otherwise
+
+C Mass concentration (calculated by GETPAR)
+      Real :: aeromode_mass( n_mode )   ! [ ug/m^3 ]
+
+C Particle density (calculated by GETPAR)
+      Real :: aeromode_dens( n_mode )   ! [ kg/m^3 ]
+
+C Geometric mean diameter (calculated by GETPAR)
+      Real :: aeromode_diam( n_mode )   ! [ m ]
+
+C Log of geometric standard deviation (calculated by GETPAR )
+      Real :: aeromode_lnsg( n_mode )
+
+C Minimum number (calculated in map_aero routine)
+      Real :: aeromode_minNum( n_mode )
+
+C Minimum 2nd moment (calculated in map_aero routine)
+      Real :: aeromode_minM2( n_mode )
+
+C Mapping for loading from and unloading to CGRID array
+      Integer, Allocatable :: aerospc_map( :,: )  ! indices of aero species to CGRID
+      Integer, Allocatable :: aeronum_map( : )      ! indices of aero number variable to CGRID
+      Integer, Allocatable :: aerosrf_map( : )      ! indices of aero surf area variable to CGRID
+
+C Missing aerosol species map
+      Logical, Allocatable :: aero_missing( :,: )  ! indices of aero species to CGRID
+
+C Emissions mapping
+      Integer         :: n_emis_pm              ! number of aerospc with emissions
+      Integer, Allocatable :: pmem_map( : )     ! mapping to aerospc array for PM emissions
+      Character( 16 ), Allocatable :: pmem_map_name( : )! mapping to aerospc array for PM emissions
+      Character( 16 ) :: pmem_units             ! units for PM emissions for all species
+
+      Logical, Save :: V51_SOA_mechanism   = .False. !
+      Logical, Save :: AE_eflag            = .False. ! error flag for AERO_DATA
+C IC/BC Correction Mapping
+      !The following vectors store masks of the aerosol species
+      !identities. For example, LBCNUM stores 1's for every species that
+      !represents an aerosol number concentration and 0's otherwise.
+      !   LBCNUM - Number Concentration
+      !   LBCSURF - Surface Area Concentration
+      !   LBCMASS - Mass Concentration
+      !   LBCMODE - Mask for each aerosol mode
+      LOGICAL, ALLOCATABLE, SAVE :: LBCNUM(:), LBCSRF(:), LBCMASS(:),
+     &                        LBCMODE(:,:)
+      REAL, ALLOCATABLE, SAVE :: AEROCGRID_RHOINV( : ) !
+      
+C Private variables for loading from and unloading to CGRID array
+      Logical, Private, Save :: mapped    = .False.
+      Character( 16 ), Private, Save :: pname = 'Aero_Data'
+
+      Contains
+
+C-----------------------------------------------------------------------
+      Subroutine map_aero()
+
+C  Defines aerosol mapping from CGRID for species concentration and moments.
+ 
+C  Revision History:
+C     First version was coded in April 2010 by Steve Howard with
+C     Prakash Bhave, Jeff Young, and Sergey Napelenok.
+
+C HS  01/24/11 Renamed AORGPA as POC for AERO6
+C GS  03/02/11 Find new req`d species for AERO6 (Mg, K, Ca)
+C HS  03/10/11 Get index for new required species, PNCOM
+C JY  03/22/16 Get index for new required species: Fe, Mn (aqchem)
+C HOTP 05/11/16 Add IEPOX derived species
+C-----------------------------------------------------------------------
+
+      Use rxns_data             ! chemical mechanism data
+      Use cgrid_spcs            ! CGRID mechanism species
+      Use aeromet_data
+      Use utilio_defn
+      Implicit None
+
+C Local Variables:
+      Character( 256 ) :: xmsg
+      Character( 256 ) :: xmsg2
+      Real    :: mole_weight( n_aerolist )
+      Integer :: aerolist_map  ( n_aerolist,n_mode )
+      Integer :: aerospc_tolist( n_aerolist )
+
+      Integer, Allocatable :: aerospc_in_dustlist( : )
+
+      Integer l, m, n, spc, isea, idust
+      Real    so4fac
+      Real    anthfac
+
+      Real    dust_POC  ! dust scale factor for Primary Organic Carbon
+      Real    dust_PNC  ! dust scale factor for Primary Non-Carbon aerosol
+      Real    dust_POA  ! scale factor for Semivolatile POA in dust emissions
+      Real    dust_OOA  ! scale factor for Semivolatile OOA in dust emissions
+      Real    dust_OMOC ! ratio of Organic Matter to Organic Carbon in dust emissions
+      Real    dust_OC   ! ratio of Elmental Oxygen to Carbon in dust emissions
+      Real    POA_OC    ! ratio of Elemental Oxygen to Carbon in POA
+      Real    OOA_OC    ! ratio of Elemental Oxygen to Carbon in Oxygenated OA
+
+      Integer dust_org1, dust_org2
+      Logical ae6isoa
+      Logical ae6hg
+      Logical dust_match
+
+      If ( mapped ) Return
+
+      logdev      = setup_logdev()
+      mole_weight = 0.0
+
+      n_aerospc      = 0   ! Number of Used Aerosol Chemical Species
+      aerolist_map   = 0   ! Pointer from aerolist to CGRID
+      aerospc_tolist = 0   ! Pointer from aerospc to aerolist
+      AE_eflag       = .False.
+      max_l2sg       = ( LOG( max_sigma_g ) ) ** 2
+      min_l2sg       = ( LOG( min_sigma_g ) ) ** 2
+      def_l2sg( : )  = ( LOG( def_sigma_g( : ) ) ) ** 2
+      
+
+      allocate( aerocgrid_rhoinv( n_ae_trns ), lbcnum( n_ae_trns ),
+     &          lbcsrf( n_ae_trns ), lbcmass( n_ae_trns ),
+     &          lbcmode( n_mode,n_ae_trns ) )
+      aerocgrid_rhoinv = 0.
+      lbcnum = .False.
+      lbcsrf = .False.
+      lbcmass= .False.
+      lbcmode= .False.
+
+C Build mapping to CGRID for each species in the master AeroList
+      Do spc = 1, n_aerolist
+         Do m = 1, n_mode   ! Loop through modes
+
+            If ( aerolist( spc )%name( m )(1:1) .Ne. ' ' ) Then
+               ! This place on the AeroList has a potential species in
+               ! it. Check to see if it is in the namelist
+               n = index1( aerolist( spc )%name( m ) , n_ae_spc, ae_spc )
+
+               If ( n .Ne. 0 ) Then
+                  ! Species is in the Master List and on the NameList
+                  If ( .Not. ( Any( aerolist_map( spc,: ) .NE. 0 ) ) ) Then
+                     ! Add this species to the map if it does not exist already
+                     n_aerospc = n_aerospc + 1
+                     aerospc_tolist( n_aerospc ) = spc
+                     ! Set the Molecular Weight
+                     mole_weight( spc ) = ae_molwt( n )
+                  Else If ( mole_weight( spc ) .Ne. ae_molwt( n ) ) Then
+                     ! If the species already exists and the
+                     ! molecular weight from this mode on the
+                     ! namelist is not matching the standing
+                     ! molecular weight, throw an error
+                     xmsg = 'molecular weight of ' // Trim( aerolist(spc )%name( m ) )
+     &                      // ' is different from that of the same species'
+     &                      // ' in the same or another mode.'
+                     Call m3warn( pname, 0, 0, xmsg )
+                     Write( xmsg,* ) 'New Value(', n, ') = ', ae_molwt( n ),
+     &                               'Expected value(', spc, ')= ', mole_weight( spc )
+                     Call m3warn( pname, 0, 0, xmsg )
+                     AE_eflag  = .True.
+                  End If
+                  ! Add the map from CGRID to AeroList
+                  aerolist_map( spc,m ) = ae_strt - 1 + n
+                  lbcmode( m,n ) = .True.
+                  If ( .Not. aerolist( spc)%tracer ) lbcmass( n ) = .True.
+                  !Map the CGRID Aerosol Species to their Densities
+                  aerocgrid_rhoinv( n ) = 1.0 / aerolist( spc )%density
+
+               End If
+            End If
+         End Do
+      End Do
+
+      ! Migrate all of the user-requested aerosols from AeroList to
+      ! AeroSpc. Begin by allocating all of the new arrays now that we
+      ! know the value of n_aerospc
+      Allocate ( aerospc     ( n_aerospc ) )
+      Allocate ( aerospc_mw  ( n_aerospc ) )
+      Allocate ( aerospc_map ( n_aerospc, n_mode ) )
+      Allocate ( aerospc_conc( n_aerospc, n_mode ) )
+      Allocate ( aerospc_ssf ( n_mode, n_aerospc ) )
+      Allocate ( aero_missing( n_aerospc, n_mode ) )
+      Allocate ( aeronum_map ( n_aerospc ) )
+      Allocate ( aerosrf_map ( n_aerospc ) )
+
+      aerospc_ssf = 0.0
+
+      Do spc = 1, n_aerospc ! Loop through user-requested chemical species
+         l = aerospc_tolist( spc )
+         aerospc( spc ) = aerolist( l )   ! Map AeroList to AeroSpc
+         aerospc_mw( spc ) = mole_weight( l )
+
+#ifdef verbose_aero
+         If( spc .eq. 1 )Write(logdev,99948)
+#endif
+         Do n = 1,n_mode
+            ! Map the Modal-Dependent CGRID Pointers from AeroSpc to AeroList
+            aerospc_map( spc, n ) = aerolist_map( l, n )
+
+            ! Map The Sea-Salt Species to the aerospc_ssf Array
+            Do isea = 1, nsea_spc
+               Do m = 1, n_mode
+                  If ( sea_spc( isea )%name( m ) .Eq. aerospc( spc )%name( n ) ) Then
+                     aerospc_ssf( n, spc ) = sea_spc( isea )%spcfac( m )
+#ifdef verbose_aero
+                      If ( sea_spc( isea )%spcfac( m ) .Lt. conmin )Cycle
+                      Write(logdev,99950)spc,sea_spc( isea )%name( m ),sea_spc( isea )%spcfac( m )
+#endif
+                  End If
+               End Do
+            End Do
+
+
+            ! If a user invokes a chemical species, they should have the
+            ! same modes present as is indicated in the table above.
+            ! Check that this is true.
+            If ( aerospc( spc )%name( n )(1:) .Ne. ' ' .And.
+     &           aerolist_map( aerospc_tolist( spc ),n ) .Eq. 0 ) Then
+               AE_eflag  = .True.
+               Write( xmsg,* ) 'FATAL ERROR: Linked set of tracers, ',
+     &                    Trim( xmsg2 ),', is missing species, ',
+     &                    Trim( aerolist( spc )%name( n ) )
+               Call m3warn( pname, 0, 0, xmsg )
+            End If
+
+            ! Set the Aero_Missing Flag
+            If ( aerospc( spc )%name( n ) .Ne. ' ' ) Then
+                aero_missing( spc,n ) = .False.
+            Else
+                aero_missing( spc,n ) = .True.
+            End If
+
+         End Do
+
+      End Do
+
+C Build mapping to CGRID for aero # and surf area variables
+      aeronum_map = 0
+      aerosrf_map = 0
+
+      Do m = 1, n_mode
+         n = index1( aeromode( m )%num_name , n_ae_spc, ae_spc )
+         If ( n .Eq. 0 ) Then
+            xmsg = 'Species ' // Trim( aeromode( m )%num_name )
+     &           //' is not in AE namelist'
+            AE_eflag  = .True.
+            Call m3warn( pname, 0, 0, xmsg )
+!            Call m3exit( pname, 0, 0, xmsg, xstat3 )
+         Else
+            aeronum_map( m ) = ae_strt - 1 + n
+            aerocgrid_rhoinv( n ) = 1.0
+            lbcnum( n ) = .True.
+            lbcmode( m,n ) = .True.
+         End If
+
+         n = index1( aeromode( m )%srf_name , n_ae_spc, ae_spc )
+         If ( n .Eq. 0 ) Then
+            xmsg = 'species ' // Trim( aeromode( m )%srf_name )
+     &           // ' is not in AE namelist'
+            AE_eflag  = .True.
+            Call m3warn( pname, 0, 0, xmsg )
+!            Call m3exit( pname, 0, 0, xmsg, xstat3 )
+         Else
+            aerosrf_map( m ) = ae_strt - 1 + n
+            aerocgrid_rhoinv( n ) = 1.0
+            lbcsrf( n ) = .True.
+            lbcmode( m,n ) = .True.
+         End If
+      End Do
+
+C Find indices of required species
+      aso4_idx    = findAero( req_so4,    .True. )
+      ano3_idx    = findAero( req_no3,    .True. )
+      acl_idx     = findAero( req_cl,     .True. )
+      anh4_idx    = findAero( req_nh4,    .True. )
+      ana_idx     = findAero( req_na,     .True. )
+      amg_idx     = findAero( req_mg,     .True. )
+      ak_idx      = findAero( req_k,      .True. )
+      aca_idx     = findAero( req_ca,     .True. )
+      afe_idx     = findAero( req_fe,     .True. )
+      amn_idx     = findAero( req_mn,     .True. )
+      ah2o_idx    = findAero( req_h2o,    .True. )
+      ah3op_idx   = findAero( req_h3op,   .True. )
+      asoil_idx   = findAero( req_soil,   .True. )
+      acors_idx   = findAero( req_cors,   .True. )
+      aseacat_idx = findAero( req_seacat, .True. )
+
+      If ( Index( mechname, 'NVPOA' ) .Eq. 0 ) Then
+         apoc_idx    = findAero( 'ALVPO1          ', .True. )
+         apncom_idx  = 0
+      Else
+         apoc_idx    = findAero( req_poc,  .True. )
+         apncom_idx  = findAero( req_ncom, .True. )
+      End If
+
+      If ( Index( mechname, 'SAPRC07TIC_AE6I' ) .Gt. 0 ) Then
+         ae6isoa     = .True.
+         aietet_idx  = findAero( req_ietet, ae6isoa )
+         aieos_idx   = findAero( req_ieos,  ae6isoa )
+         adim_idx    = findAero( req_dim,   ae6isoa )
+         aimga_idx   = findAero( req_imga,  ae6isoa )
+         aimos_idx   = findAero( req_imos,  ae6isoa )
+      Else
+         aietet_idx  = 0
+         aieos_idx   = 0
+         adim_idx    = 0
+         aimga_idx   = 0
+         aimos_idx   = 0
+         ae6isoa     = .False.
+      End If
+
+      aphgj_idx = findAero( req_phgj,  .False. )
+      If ( aphgj_idx .Gt. 0 ) Then
+         ae6hg     = .True.
+      Else
+         aphgj_idx = 0 
+         ae6hg     = .False.
+      End If
+
+C Adjust Dust Emissions list for Organic Species, if running with semivolatile POA
+      If ( Index( mechname, 'NVPOA' ) .Eq. 0 ) Then
+         ! Find Indices for Nonvolatile Organics
+         Do idust = 1, ndust_list
+            If ( Index( dust_spc_list( idust )%name( 2 ), 'APOCJ' ) .Gt. 0 ) dust_org1 = idust
+            If ( Index( dust_spc_list( idust )%name( 2 ), 'APNCOMJ') .Gt. 0 ) dust_org2 = idust
+         End Do
+
+         ! Compute Total Organic Dust Scale Factor and O:C Ratio
+         ! The dust OM:OC should equal 1.4 if it consistent with Simon and Bhave (2011).
+         dust_POC = dust_spc_list( dust_org1 )%spcfac( 2 )
+         dust_PNC = dust_spc_list( dust_org2 )%spcfac( 2 )
+         dust_OMOC = ( dust_POC + dust_PNC ) / dust_POC
+         dust_OC = 12.0 / 15.0 * dust_OMOC - 14.0 / 15.0
+
+         ! Distribute Dust Organic Speciation between Volatility-Based Surrogates.
+         ! These hard-coded values can be generalized once O:C information is
+         ! incoporated directly into the internal OA species table.
+         POA_OC = 0.1853  ! O:C Ratio of LVPOA1
+         OOA_OC = 0.7106  ! O:C Ratio of LVOOA2
+         dust_OC = Max( dust_OC, POA_OC )
+         dust_POA = 1.0 / ( 1.0 + ( dust_OC - POA_OC ) / ( OOA_OC - dust_OC ) )
+         dust_OOA = 1.0 / ( 1.0 + ( dust_OC - OOA_OC ) / ( POA_OC - dust_OC ) )
+
+         ! Assign new names and speciation to dust table
+         dust_spc_list( dust_org1 )%name( 2 ) = 'ALVPO1J'
+         dust_spc_list( dust_org2 )%name( 2 ) = 'ALVOO2J'
+         dust_spc_list( dust_org1 )%spcfac( 2 ) = dust_POA * ( dust_POC + dust_PNC )
+         dust_spc_list( dust_org2 )%spcfac( 2 ) = dust_OOA * ( dust_POC + dust_PNC )
+      End If
+
+! Determine map between aero_spc dust emissions and the dust emission listndust_spc
+      Allocate( aerospc_in_dustlist( n_aerolist ) )
+      aerospc_in_dustlist   = 0   ! Pointer identifies to use dust emission table
+
+      ndust_spc = 0
+      Do spc = 1, n_aerospc ! Loop through user-requested chemical species
+         Do idust = 1, ndust_list ! loop through dust list
+#ifdef verbose_aero
+            xmsg = ' '
+#endif
+            dust_match = .False.
+            Do m = 1, n_mode
+               If( aero_missing(spc,m) )Cycle
+               If ( dust_spc_list( idust )%name( m ) .Eq. aerospc( spc )%name( m ) ) Then
+#ifdef verbose_aero
+                   Select Case( m )
+                     Case( 1 )
+                        xmsg = 'Aitken'
+                     Case( 2 )
+                        xmsg = Trim( xmsg ) // ' Accum.'
+                     Case( 3 ) 
+                       xmsg = Trim( xmsg ) // ' Coarse'
+                   End Select
+#endif
+                   dust_match = .True.
+               End If
+            End Do
+            If( dust_match )Then
+                ndust_spc = ndust_spc + 1
+                aerospc_in_dustlist( ndust_spc ) = idust
+#ifdef verbose_aero
+                Write( logdev,'(a,1x,a)')'Dust Emissions Added to ',
+     &          Trim( dust_spc_list( ndust_spc )%description )  // ' '
+     &          // Trim( xmsg ) // ' mode(s)'
+#endif
+            End If
+         End Do
+      End Do
+
+      If( ndust_spc .Gt. 0 )Then
+! build dust_spc type from selected list elements
+         Allocate( dust_spc( ndust_spc ) )
+         n = 0
+#ifdef verbose_aero
+         Write(logdev,99949)
+#endif
+         Do spc = 1, ndust_spc
+            idust = aerospc_in_dustlist( spc )
+            dust_spc( spc ) = dust_spc_list( idust )
+            Do m = 1, n_mode
+               If( len_trim( dust_spc( spc )%name( m ) ) .lt. 1 )cycle
+               n = n + 1
+#ifdef verbose_aero
+               Write(logdev,99950)n,dust_spc( spc )%name( m ),dust_spc( spc )%spcfac( m )
+#endif
+            End Do
+         End Do
+      End If
+
+#ifdef verbose_aero
+99948 Format(/ '_I_',1X,'Aero_Species____','SeaSalt_Emiss_Speciation')
+99949 Format(/ '_I_',1X,'Aero_Species____','Dust_Emiss_Speciation')
+99950 Format(i3,1X,a16,11X,es12.4)
+#endif
+
+      Deallocate( aerospc_in_dustlist )
+
+#ifdef verbose_aero
+      ! Mandatory Species
+      Write( logdev,'( /5x, a )' ) 'map_aero required species'
+      Write( logdev,'( 5x, a, i4 )' ) 'aso4_idx:   ', aso4_idx
+      Write( logdev,'( 5x, a, i4 )' ) 'ano3_idx:   ', ano3_idx
+      Write( logdev,'( 5x, a, i4 )' ) 'acl_idx:    ', acl_idx
+      Write( logdev,'( 5x, a, i4 )' ) 'anh4_idx:   ', anh4_idx
+      Write( logdev,'( 5x, a, i4 )' ) 'ana_idx:    ', ana_idx
+      Write( logdev,'( 5x, a, i4 )' ) 'amg_idx:    ', amg_idx
+      Write( logdev,'( 5x, a, i4 )' ) 'ak_idx:     ', ak_idx
+      Write( logdev,'( 5x, a, i4 )' ) 'aca_idx:    ', aca_idx
+      Write( logdev,'( 5x, a, i4 )' ) 'afe_idx:    ', afe_idx
+      Write( logdev,'( 5x, a, i4 )' ) 'amn_idx:    ', amn_idx
+      Write( logdev,'( 5x, a, i4 )' ) 'apoc_idx:   ', apoc_idx
+      Write( logdev,'( 5x, a, i4 )' ) 'ah2o_idx:   ', ah2o_idx
+      Write( logdev,'( 5x, a, i4 )' ) 'ah3op_idx:  ', ah3op_idx
+      Write( logdev,'( 5x, a, i4 )' ) 'asoil_idx:  ', asoil_idx
+      Write( logdev,'( 5x, a, i4 )' ) 'acors_idx:  ', acors_idx
+      Write( logdev,'( 5x, a, i4 )' ) 'apncom_idx: ', apncom_idx
+      Write( logdev,'( 5x, a, i4 )' ) 'aseacat_idx:', aseacat_idx
+      If( ae6isoa )Then
+          Write( logdev,'( 5x, a, i4 )' ) 'aietet_idx: ', aietet_idx
+          Write( logdev,'( 5x, a, i4 )' ) 'aieos_idx:  ', aieos_idx
+          Write( logdev,'( 5x, a, i4 )' ) 'adim_idx:   ', adim_idx
+          Write( logdev,'( 5x, a, i4 )' ) 'aimga_idx:  ', aimga_idx
+          Write( logdev,'( 5x, a, i4 )' ) 'aimos_idx:  ', aimos_idx
+      End If      
+      If ( ae6hg ) Then
+          Write( logdev,'( 5x, a, i4 )' ) 'aphgj_idx:  ', aphgj_idx
+      Else 
+          Write( logdev,'( 5x, a, i4 )' ) 'PHGJ not found so aphgj_idx: ', aphgj_idx
+      End If
+#endif
+ 
+C Compute common factors
+      h2ofac = 1.0D-9 * f6dpi / Real( aerospc( ah2o_idx )%density, 8 )
+
+C compute aeromode_minNum and aeromode_minM2
+      so4fac  = 1.0E-9 * Real( f6dpi, 4 ) / aerospc( aso4_idx )%density
+      anthfac = 1.0E-9 * Real( f6dpi, 4 ) / aerospc( acors_idx )%density
+
+      Do m = 1, n_mode
+         If ( m .Lt. n_mode ) Then
+            aeromode_minNum( m ) = so4fac * aerospc( aso4_idx )%min_conc( m ) /
+     &           ( def_diam( m )**3 * Exp( 4.5 * Log( def_sigma_g( m ) )**2 ) )
+         Else
+            aeromode_minNum( m ) = anthfac * aerospc( acors_idx )%min_conc( m ) /
+     &           ( def_diam( m )**3 * Exp( 4.5 * Log( def_sigma_g( m ) )**2 ) )
+         End If
+         aeromode_minM2( m ) = aeromode_minNum( m ) *
+     &             def_diam( m )**2 * Exp( 2.0 * Log( def_sigma_g( m ) )**2 )
+      End do
+
+      if( AE_eflag )Then
+         Write(logdev,99901) Trim( mechname )
+             xmsg = 'The FATAL errors found in namelist used. Check '
+     &         //  'the log of exiting processor if more details are needed.'
+         Call m3exit( pname, 0, 0, xmsg, xstat3 )
+      End If 
+
+      mapped = .True.
+
+      Write( logdev,'( 5x, a )' ) ' --- Aero Species Mapped ---'
+
+99901 Format( 'FATAL Error(s) found in the AE namelist used. Check that ' 
+     &     /  'this AE namelist contains the above required data as the file in '
+     &     /  'the respository version of the mechanism: ', a )
+      Return
+      End Subroutine map_aero
+
+C-----------------------------------------------------------------------
+      Subroutine map_pmemis ( )
+ 
+C  Set the emissions units from the header of EMIS_1 file
+C  Verify that all the units on the file are consistent
+
+      Use utilio_defn
+      Use rxns_data, only : mechname
+
+      Implicit None
+
+      Include SUBST_FILES_ID  ! file name parameters
+
+C Parameters:
+      Character( 10 ), Parameter :: blank10 = ' '
+
+C Local Variables:
+      Character( 16 ), Save :: pname = 'map_pmemis'
+      Character( 512 )      :: xmsg1
+      Character( 1024 )     :: xmsg2
+      Character( 16 )       :: units
+
+      Integer :: indx
+      Integer :: v
+      Logical :: found, match
+
+      Logical, Save :: pm_mapped = .False.
+
+      logdev = setup_logdev()
+
+C Create mapping only if first call
+      If ( pm_mapped ) Return
+
+C Call routine to map aerosol species array
+      If ( .Not. mapped ) Call map_aero ( )
+
+C Open the gridded emissions file, which contains gas, aerosol, and non-reactive
+C species
+
+      If ( .Not. open3( emis_1, fsread3, pname ) ) Then
+         xmsg1 = 'Could not open '// emis_1 // ' file'
+         Call m3exit( pname, 0, 0, Trim( xmsg1 ), xstat1 )
+      End If
+
+      If ( .Not. desc3( emis_1 ) ) Then
+         xmsg1 = 'Could not get '// 'EMIS_1' // ' file description'
+         Call m3exit( pname, 0, 0, Trim( xmsg1 ), xstat2 )
+      End If
+
+C Search emissions file for emission species names. Verify that their units
+C are the same and set pmem_units
+
+      Allocate( pmem_map      ( n_aerospc ) )
+      Allocate( pmem_map_name ( n_aerospc ) )
+      n_emis_pm = 0
+      pmem_units = 'null'
+      found = .True.
+      match = .True.
+      xmsg1 = 'Could not find the following species in emissions file'
+      xmsg2 = 'PM Units not uniform in EMIS_1 file.'
+
+      Do v = 1, n_aerospc
+         If ( aerospc( v )%emis( 1:1 ) .Ne. ' ' ) Then
+            indx = index1( aerospc( v )%emis, nvars3d, vname3d )
+            If ( indx .Le. 0 ) Then
+               xmsg1 = Trim( xmsg1 ) // crlf() // blank10
+     &               // Trim( aerospc( v )%emis )
+               found = .False.
+               Cycle
+            End If
+            n_emis_pm = n_emis_pm + 1
+            pmem_map( n_emis_pm ) = v
+            pmem_map_name (n_emis_pm ) = aerospc( v )%emis
+
+            ! Add Non-Carbon Primary Organic Emissions Surrogate and Map
+            ! it to the Carbon Primary Organic Emissions Surrogate
+            If ( Index( mechname,"NVPOA") .EQ. 0 .AND. aerospc( v )%emis .EQ. 'POC' ) Then
+              indx = index1( 'PNCOM', nvars3d, vname3d )
+              If ( indx .Le. 0 ) Then
+                 xmsg1 = Trim( xmsg1 ) // crlf() // blank10
+     &               // Trim( aerospc( v )%emis )
+                 found = .False.
+                 Cycle
+              End If
+              n_emis_pm = n_emis_pm + 1
+              pmem_map( n_emis_pm ) = v
+              pmem_map_name (n_emis_pm ) = 'PNCOM'
+            End If  
+
+C Change UNITS to upper case
+            units = units3d( indx )
+            Call upcase( units )
+
+C Save units on first emissions
+            If ( pmem_units .Eq. 'null' ) pmem_units = units
+
+C Check that all emissions units match
+            If ( pmem_units .Ne. units ) Then
+               xmsg2 = Trim( xmsg2 ) // crlf() // blank10
+     &               // Trim( aerospc( v )%emis )
+     &               // '  [' // Trim( units3d( indx ) ) // ']'
+               match = .False.
+            End If
+         End If
+      End Do
+
+      If ( .Not. found ) Then
+         Call m3warn( pname, 0, 0, Trim( xmsg1 ) )
+      End If
+
+      If ( .Not. match ) Then
+         Call m3exit( pname, 0, 0, Trim( xmsg2 ), xstat2 )
+      End If
+
+#ifdef verbose_aero
+      Write( logdev,'( /5x, a )' ) 'pmem_map to aerospc'
+         Do v = 1, n_emis_pm
+         Write( logdev,'( 5x, a, 2i4, 2x, a )' ) 'pmem_map:', v, pmem_map( v ), pmem_map_name( v )
+      End Do
+#endif
+
+      pm_mapped = .True.
+
+      Write( logdev,'( 5x, a )' ) ' --- PM Emis Species Mapped ---'
+
+      Return
+
+      End Subroutine map_pmemis
+
+C-----------------------------------------------------------------------
+      Subroutine extract_aero( conc, minchk )
+
+C  Extracts aerosol data into the AERO_DATA:aerospc_conc array
+C  The original idea is that the data for conc comes from CGRID
+C  Also transfers dry surface area to wet 2nd moment.
+
+C  Revision History:
+C     First version was coded in April 2010 by Steve Howard with
+C     Prakash Bhave, Jeff Young, and Sergey Napelenok.
+C     4/2016: Updated for 2nd moment by H. Pye and B. Murphy
+C-----------------------------------------------------------------------
+
+      Use aeromet_data, only : pi, f6pi  ! fundamental constants, data type definitions, etc.
+
+      Implicit None
+
+C Arguments:
+      Real,    Intent( In ) :: conc( : )
+      Logical, Intent( In ) :: minchk
+
+C Local Variables:
+      Integer m, n, spc
+
+      If ( .Not. mapped ) Then
+         Call map_aero()
+      End If
+
+C Copy grid cell concentrations of aero species to aerospc_conc
+      aerospc_conc = 0.0
+      If ( minchk ) Then
+         Do m = 1, n_mode
+            Do spc = 1, n_aerospc
+               n = aerospc_map( spc,m )
+               If ( n .Ne. 0 ) Then
+                  aerospc_conc( spc,m ) = Max( conc( n ), aerospc( spc )%min_conc( m ) ) ! [ug/m^3]
+               End If
+            End Do
+         End Do
+      Else
+         Do m = 1, n_mode
+            Do spc = 1, n_aerospc
+               n = aerospc_map( spc,m )
+               If ( n .Ne. 0 ) Then
+                  aerospc_conc( spc,m ) = conc( n )   ! [ug/m^3]
+               End If
+            End Do
+         End Do
+      End If
+
+      ! Calculate Dry Third Moment [ m3 / m3 ]
+      Do m = 1, n_mode
+         moment3_conc( m ) = sum( aerospc_conc(:,m) / aerospc(:)%density,
+!    &      MASK= (aerospc%no_M2wet==.false. .AND. aerospc%Tracer==.false.) )
+     &      MASK= ( ( .NOT. aerospc%no_M2wet ) .AND.
+     &              ( .NOT. aerospc%Tracer ) ) )
+         moment3_conc( m ) = max( moment3_conc( m ) * 1.0E-9 * f6pi,
+     &                            aeromode( m )%min_m3conc )
+      End Do
+
+C Copy grid cell concentrations of aero # and surf area
+C Convert surface area to M2 and set wet_moments_flag
+
+      moment0_conc = 0.0
+      moment2_conc = 0.0
+
+      If ( minchk ) Then
+         Do m = 1, n_mode
+            n = aeronum_map( m )
+            moment0_conc( m ) = Max( conc( n ), aeromode( m )%min_numconc )
+            n = aerosrf_map( m )
+            moment2_conc( m ) = Max( conc( n ) / pi, aeromode( m )%min_m2conc )
+         End Do
+      Else
+         Do m = 1, n_mode
+            n = aeronum_map( m )
+            moment0_conc( m ) = conc( n )
+            n = aerosrf_map( m )
+            moment2_conc( m ) = conc( n ) / pi
+         End Do
+      End If
+      wet_moments_flag = .false.
+
+C Convert dry 2,3 moment to wet 2,3 moment
+C flag will be set to .true.
+      Call calcmoments( .true. )
+
+      Return
+      End Subroutine extract_aero
+
+C-----------------------------------------------------------------------
+      Subroutine update_aero( conc, minchk )
+
+C  Updates conc from the AERO_DATA:aerospc_conc array.
+C  The original idea is that the data in conc updates CGRID
+C  Update_aero now also saves the updated surface area back to CGRID as
+C  well. Moment2 will be dried if necessary and flag reset.
+
+C  Revision History:
+C     First version was coded in April 2010 by Steve Howard with
+C     Prakash Bhave, Jeff Young, and Sergey Napelenok.
+C     4/2016: Updated for 2nd moment by H. Pye and B. Murphy
+C-----------------------------------------------------------------------
+
+      Use aeromet_data, only : pi     ! fundamental constants, data type definitions, etc.
+      Use utilio_defn
+
+      Implicit None
+
+C Arguments:
+      Real, Intent( Out ) :: conc( : )
+      Logical, Intent( In ) :: minchk
+
+C Local variables:
+      Character( 80 ) :: xmsg
+      Integer m, n, spc
+
+      If ( .Not. mapped ) Then
+         xmsg = 'CGRID Species has not been mapped'
+         Call m3exit( pname, 0, 0, xmsg, xstat3 )
+      End If
+
+C Copy aerospc_conc back to grid cell concentrations
+
+      If ( minchk ) Then
+         Do m = 1, n_mode
+            Do spc = 1, n_aerospc
+               n = aerospc_map( spc,m )
+               If ( n .Ne. 0 ) Then
+                    conc( n ) = Max( aerospc_conc( spc,m ), aerospc( spc )%min_conc( m ) )
+               End If
+            End Do
+         End Do
+      Else
+         Do m = 1, n_mode
+            Do spc = 1, n_aerospc
+               n = aerospc_map( spc,m )
+               If ( n .Ne. 0 ) Then
+                    conc( n ) = aerospc_conc( spc,m )
+               End If
+            End Do
+         End Do
+      End If
+
+C Copy aero number and surface area back to grid cell concentrations
+
+      If ( minchk ) Then
+         Do m = 1, n_mode
+            n = aeronum_map( m )
+            conc( n ) = Max( moment0_conc( m ), aeromode( m )%min_numconc )
+         End Do
+      Else
+         Do m = 1, n_mode
+            n = aeronum_map( m )
+            conc( n ) = moment0_conc( m )
+         End Do
+      End If
+
+C Save dry second moment to surface area (with pi conversion)
+      If ( wet_moments_flag ) Then
+         Call calcmoments( .False. ) ! called with the F flag, returns dry moments
+      End If
+
+      Do m = 1, n_mode
+         n = aerosrf_map( m )
+         conc( n ) = Real( pi, 4 ) * moment2_conc( m )
+      End Do
+
+      Return
+      End Subroutine update_aero
+
+C-----------------------------------------------------------------------
+      Function findAero( vname, required ) Result ( idx )
+
+C  Finds the index of 'required' aerosol species in the aerospc list
+
+C  Revision History:
+C     First version was coded in April 2010 by Steve Howard with
+C     Prakash Bhave, Jeff Young, and Sergey Napelenok.
+C-----------------------------------------------------------------------
+
+      Use utilio_defn
+
+      Implicit None
+
+C Arguments:
+      Character( 16 ) :: vname
+      Logical :: required
+      Integer :: idx
+
+C Local Variables:
+      Character( 80 ) :: xmsg
+      Integer spc, n
+
+      idx = 0
+C Find the substring vname in aerospc( spc )%name( n )
+      Do n = 1, n_mode
+         Do spc = 1, n_aerospc
+            If ( Index( aerospc( spc )%name( n ), trim(vname) ) .Gt. 0 ) Then
+               idx = spc
+               Return
+            End If
+         End Do
+      End Do
+
+      If ( .Not. required ) Then
+         xmsg = ' NOT FATAL: Optional Species '
+     &       // Trim( vname ) // ' Not found in AE namelist.'
+         write(logdev,'(/ a / )')xmsg
+         Return
+      End If
+
+      xmsg = 'FATAL: Required Species ' // Trim( vname ) // ' Not found in AE namelist'
+      AE_eflag  = .True.
+      Call m3warn( pname, 0, 0, xmsg )
+!     Call m3exit( pname, 0, 0, xmsg, xstat3 )
+
+      Return
+      End Function findAero
+
+C-----------------------------------------------------------------------
+      Subroutine calcmoments( addwet )
+
+C Subroutine calculates wet (addwet=T) or dry (addwet=F) aerosol third
+C and second moment and stores them in moment_conc arrays and
+C updates wet_moments_flag.
+C Note that third moment information will be overwritten no matter what
+C the wet_moments_flag indicates. M2 will depend on the history
+C of the moment (wet_moments_flag). This routine will not update
+C M2 in the event of added mass due to processes other than
+C wetting/drying.
+C
+C Notes:
+C wet_moments_flag is obtained from AERO_DATA ! true =  H2O and SOA included in 2,3 moment
+C                                             ! false = H2O and SOA excluded from 2,3 moment
+C wet_moments_flag reflects the current state of the moment2,3_conc arrays.
+C addwet will results in wet (T) or dry (F) moments.
+C
+C History:
+C 4/2016: HOT Pye Created routine
+C
+C-----------------------------------------------------------------------
+
+      Use aeromet_data, only: f6dpi, f6pi
+
+      Implicit None
+
+C Arguments:
+      Logical :: addwet ! T: result in wet m3 and m2, F: result in dry m3 and m2
+
+C Parameters:
+      Real( 8 ), Parameter :: two3rds = 2.0D0 / 3.0D0
+
+C Local variables:
+      Integer :: spc, n ! loop variable
+      Real( 4 ) :: m3( n_mode )       ! wet or dry M3
+      Real( 4 ) :: m2( n_mode )       ! wet or dry M2
+      Real( 8 ) :: drysumM3  ! dry M3 [ m**3 / m**3 ]
+      Real( 8 ) :: wetsumM3  ! wet M3 [ m**3 / m**3 ]
+      Real( 8 ) :: factor
+      Real( 4 ) :: initialM3 ! initial M3 from moment3_conc [ m**3 /m**3 ]
+      Real( 4 ) :: initialM2 ! initial M2 from moment2_conc [ m**2 /m**3 ]
+
+      Character( 16 )  :: pname_loc = 'CalcMoments'
+      Character( 100 ) :: xmsg
+
+C *** Calculate aerosol 3rd moment concentrations [ m**3 / m**3 ], 2nd
+C     moment [ m**2/m**3 ]
+
+      If( addwet ) then
+
+         Do n = 1, n_mode
+            initialM2 = moment2_conc( n )
+            If ( initialM2 .Eq. 0.0 ) Then
+                write( xmsg,'(A32,I1,A42)') "Warning: Second Moment for Mode ",
+     &                 n," is 0.0. This will cause numerical issues."
+                Call m3warn( pname_loc, 0, 0, xmsg )
+            End If
+
+            initialM3 = moment3_conc( n )
+            If ( initialM3 .Eq. 0.0 ) Then
+                write( xmsg,'(A31,I1,A42)') "Warning: Third Moment for Mode ",
+     &                 n," is 0.0. This will cause numerical issues."
+                call m3warn( pname_loc, 0, 0, xmsg )
+            End If
+
+            wetsumM3 = 0.0d0
+            Do spc = 1, n_aerospc
+               If ( aerospc( spc )%tracer .Or. aero_missing(spc,n) ) Cycle
+               factor = Real( 1.0E-9 * f6pi / aerospc( spc )%density, 8 )
+               wetsumM3  = wetsumM3 + factor * Real( aerospc_conc( spc,n ), 8 )
+            End Do
+            m3( n ) = Max ( Real( wetsumM3, 4 ), aeromode( n )%min_m3conc )
+            If ( wet_moments_flag ) Then
+               m2( n ) = initialM2
+            Else
+               m2( n ) = initialM2 * ( Real( wetsumM3, 4 ) / initialM3 ) ** Real( two3rds, 4 )
+            End if
+         End Do
+
+         ! Save back to aero_data variables
+         moment2_conc( : ) = m2( : )
+         moment3_conc( : ) = m3( : )
+         wet_moments_flag = .True.
+
+      Else ! produce dry moments
+
+         Do n = 1, n_mode
+            initialM2 = moment2_conc( n )
+            If ( initialM2 .Eq. 0.0 )  Then
+                write( xmsg,'(A32,I1,A42)') "Warning: Second Moment for Mode ",
+     &                 n," is 0.0. This will cause numerical issues."
+                Call m3warn( pname_loc, 0, 0, xmsg )
+            End If
+
+            initialM3 = moment3_conc( n )
+            If ( initialM3 .Eq. 0.0 )  Then
+                write( xmsg,'(A31,I1,A42)') "Warning: Third Moment for Mode ",
+     &                 n," is 0.0. This will cause numerical issues."
+                Call m3warn( pname_loc, 0, 0, xmsg )
+            End If
+
+            drysumM3 = 0.0d0
+            Do spc = 1, n_aerospc
+               If ( aerospc( spc )%tracer .Or. aero_missing(spc,n) .Or.
+     &              aerospc( spc )%no_M2Wet  ) Cycle
+               factor = Real( 1.0E-9 * f6pi /  aerospc( spc )%density, 8 )
+               drysumM3  = drysumM3 + factor * Real( aerospc_conc( spc,n ), 8 )
+            End Do
+            m3( n ) = Max ( Real( drysumM3, 4 ), aeromode( n )%min_m3conc )
+            If ( wet_moments_flag) Then
+               m2( n ) = initialM2 * ( Real( drysumM3, 4 ) / initialM3 ) ** Real( two3rds, 4 )
+            Else ! already dry
+               m2( n ) = initialM2
+            End If
+         End Do
+
+         ! Save back to aero_data variables
+         moment2_conc( : ) = m2( : )
+         moment3_conc( : ) = m3( : )
+         wet_moments_flag = .False.
+
+      End If
+
+      Return
+      End Subroutine calcmoments
+
+C
+C-----------------------------------------------------------------------
+      Subroutine CHECK_AERO_ICBC( IBCON, AE_MASS_UNIT, STAT, AER_PAR, LMODE )
+
+C Subroutine corrects the scale factors for number, surface area when a 
+C change has happened to the mass of any boundary condition species.
+C Eventually this code should perform a similar operation for the
+C initial conditions, but this is somewhat complicated and needs to be
+C thought through more.
+C
+C Inputs:  IBCON - the actual initial or boundary conditions from the
+C                  calling routine
+C          ICBC_FAC - The scale factor used to modify IBCON right before
+C                     this routine is called
+C
+C 11 May 16  B.Murphy  Program Written
+C
+C-----------------------------------------------------------------------
+      Use AEROMET_DATA, only : pi, f6pi
+
+      Implicit None
+
+      REAL, INTENT(INOUT)        :: IBCON( : )
+      LOGICAL, INTENT( IN ) :: AE_MASS_UNIT  ! FALSE for KGM3 input
+                                             ! TRUE  for UGM3 input
+      INTEGER, INTENT(OUT)       :: STAT     ! 0 - Distribution is ok
+                                             ! 1 - Distribution is problematic
+      REAL, INTENT(OUT) :: AER_PAR( 2, N_MODE, 5 ) !Track the modal parameters   (N, M2, M3, dg, sg) -Before
+                                                   !before and after the BC      (N, M2, M3, dg, sg) -After
+                                                   !check routine               
+      INTEGER, INTENT(OUT) :: LMODE  !Identifies the problematic mode
+
+      REAL, PARAMETER  :: F1PI = 1.0 / pi
+      REAL, PARAMETER  :: ONE_THIRD  = 1.0 / 3.0
+      REAL, PARAMETER  :: TWO_THIRDS = 2.0 / 3.0
+
+
+C Local variables:
+
+      INTEGER   :: IMODE
+      REAL      :: NUM, M2, M3, l2sg, dg, sg
+      REAL, Parameter :: KGPMG = 1.0E-9 !Kilogram per microgram m-3
+
+      LMODE   = 0
+      STAT    = 0
+      AER_PAR = 0.0
+      dg      = 0.0
+      sg      = 0.0
+       
+      CALL MAP_AERO()
+
+      !Loop Through Each Aerosol Mode. Sum up the third moment, then
+      !calculate the Dg and Sg of the mode and check to make sure they
+      !are valid
+      DO IMODE = 1,N_MODE
+         NUM = SUM( IBCON( : ), MASK = ( LBCMODE( IMODE,: ) .AND. LBCNUM ) )
+         M2  = SUM( IBCON( : ), MASK = ( LBCMODE( IMODE,: ) .AND. LBCSRF ) ) * F1PI
+
+         M3 = SUM( IBCON( : ) * AEROCGRID_RHOINV * F6PI, MASK = ( LBCMASS .AND. LBCMODE( IMODE,: ) )  )
+
+         IF ( AE_MASS_UNIT ) M3 = M3 * KGPMG
+
+         AER_PAR ( 1, IMODE, 1 ) = NUM
+         AER_PAR ( 1, IMODE, 2 ) = M2
+         AER_PAR ( 1, IMODE, 3 ) = M3
+         AER_PAR ( 1, IMODE, 4 ) = 0.    
+         AER_PAR ( 1, IMODE, 5 ) = 0.    
+
+         IF ( M3 .LT. 1.0e-30 ) THEN
+             STAT = 4
+             LMODE = IMODE
+         ELSE IF ( NUM .LT. 1.0e-30 .OR. M2 .LT. 1.0e-30 ) THEN
+             STAT = 3
+             LMODE = IMODE
+         ELSE                  
+             l2sg = ( ONE_THIRD * LOG( NUM ) + TWO_THIRDS * LOG( M3 ) - LOG( M2 ))
+
+             IF ( l2sg .LT. MIN_L2SG .OR. l2sg .GT. MAX_L2SG ) THEN 
+                  STAT = 2
+                  LMODE = IMODE
+             ELSE
+
+                  dg   = ( M3 / NUM * EXP( -4.5 * l2sg ) )  ** ( ONE_THIRD )
+                  sg   = EXP( SQRT( l2sg ) )
+                  AER_PAR( 1, IMODE, 4 ) = dg
+                  AER_PAR( 1, IMODE, 5 ) = sg
+
+                  IF ( dg .LT. MIN_DIAM_G( IMODE )  .OR. dg .GT. MAX_DIAM_G( IMODE ) ) THEN
+                      STAT = 1
+                      LMODE = IMODE
+                  ENDIF
+              ENDIF     
+         ENDIF
+
+         !Save Modal Properties After the Check
+         AER_PAR( 2, IMODE, 1 ) = NUM
+         AER_PAR( 2, IMODE, 2 ) = M2
+         AER_PAR( 2, IMODE, 3 ) = M3
+         AER_PAR( 2, IMODE, 4 ) = dg
+         AER_PAR( 2, IMODE, 5 ) = sg
+
+         IF ( STAT .GT. 0 .AND. STAT .LT. 4 ) THEN
+           !Rewrite Boundary Condition Number and Surface Area to Satisfy
+           !Default Size Parameters
+           l2sg = DEF_L2SG( IMODE )
+           NUM = M3 * ( EXP( -4.5 * l2sg ) ) / ( DEF_DIAM( IMODE ) ) ** 3
+           dg   = ( M3 / NUM * EXP( -4.5 * l2sg ) ) ** ( ONE_THIRD )
+           sg   = EXP( SQRT( l2sg ) )
+           
+           !First Number Concentration
+           WHERE( LBCMODE( IMODE,: ) .AND. LBCNUM ) IBCON = NUM
+           
+           !Then Surface Area Concentration
+           M2 = EXP( ONE_THIRD * LOG( NUM ) + TWO_THIRDS * LOG( M3 ) - l2sg )
+           WHERE( LBCMODE( IMODE,: ) .AND. LBCSRF ) IBCON = M2 * F1PI
+         
+           !Save Modal Properties After the Check
+           AER_PAR( 2, IMODE, 1 ) = NUM
+           AER_PAR( 2, IMODE, 2 ) = M2
+           AER_PAR( 2, IMODE, 3 ) = M3
+           AER_PAR( 2, IMODE, 4 ) = dg
+           AER_PAR( 2, IMODE, 5 ) = sg
+
+         ELSEIF ( STAT .EQ. 4 ) THEN
+           WHERE( LBCMODE( IMODE,: ) .AND. LBCNUM ) IBCON = conmin  !Number
+           WHERE( LBCMODE( IMODE,: ) .AND. LBCSRF ) IBCON = conmin  !Second Moment
+           WHERE( LBCMODE( IMODE,: ) .AND. LBCMASS) IBCON = conmin  !Third Moment
+           !Save Modal Properties After the Check
+           AER_PAR( 2, IMODE, 1 ) = conmin
+           AER_PAR( 2, IMODE, 2 ) = conmin
+           AER_PAR( 2, IMODE, 3 ) = conmin
+           AER_PAR( 2, IMODE, 4 ) = 0.
+           AER_PAR( 2, IMODE, 5 ) = 0.
+         ENDIF
+
+      ENDDO
+
+      End Subroutine CHECK_AERO_ICBC
+C:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+      End Module aero_data

--- a/DOCS/Known_Issues/CMAQv5.2-i5/SOA_DEFN.F
+++ b/DOCS/Known_Issues/CMAQv5.2-i5/SOA_DEFN.F
@@ -1,0 +1,2405 @@
+
+!------------------------------------------------------------------------!
+!  The Community Multiscale Air Quality (CMAQ) system software is in     !
+!  continuous development by various groups and is based on information  !
+!  from these groups: Federal Government employees, contractors working  !
+!  within a United States Government contract, and non-Federal sources   !
+!  including research institutions.  These groups give the Government    !
+!  permission to use, prepare derivative works of, and distribute copies !
+!  of their work in the CMAQ system to the public and to permit others   !
+!  to do so.  The United States Environmental Protection Agency          !
+!  therefore grants similar permission to use the CMAQ system software,  !
+!  but users are requested to provide copies of derivative works or      !
+!  products designed to operate in the CMAQ system to the United States  !
+!  Government without restrictions as to use by others.  Software        !
+!  that is used with the CMAQ system but distributed under the GNU       !
+!  General Public License or the GNU Lesser General Public License is    !
+!  subject to their copyright restrictions.                              !
+!------------------------------------------------------------------------!
+C:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+      Module soa_defn
+
+C  Defines aerosol species arrays and parameters required in SOA processing.
+
+C  Contains:
+C     Subroutine extract_soa
+C     Subroutine update_soa
+C     Function findVapor
+C     Function findOrgprod
+C     Subroutine orgaer
+
+C  Revision History:
+C     First version was coded in April 2010 by Steve Howard with
+C     Prakash Bhave, Jeff Young, and Sergey Napelenok.
+C
+C HP  03/11/11 Updated monoterpene SOA alphas and Cstars to Carlton et al. 2010 values
+C HP  07/24/11 Changed aromatic SOA alphas for consistency with updated reaction counters
+C               BNZ, TOL, XYL numbers now match Ng et al. 2007 Atmos. Chem. Phys.
+C 08 Jun 12 J.Young: remove full character blank padding for GNU Fortran (GCC) 4.1.2
+C 13 Aug 13 H. Pye: Xylene and toluene low-NOx yields switched. Values now
+C               follow experimental data of Ng et al. 2007 ACP as shown in Table 3.
+C               Values in Table 6 of Ng et al. (previously used) are incorrect.
+C 18 Dec 13 G.Sarwar: added orgprod parent names based on RACM2
+C 07 Jul 14 B.Hutzell: replaced mechanism include file(s) with fortran module
+C 21 Jul 14 B.Hutzell: used ifdef statement to make oligomerization
+C                      optional because process represented in chemical
+C                      mechanism
+C 26 Sep 14 H. Pye: Added isoprene + NO3 SOA (see mech.def, no changes
+C                   here). When IEPOX uptake present in gas phase for
+C                   cb05e51, replace preivous acid enhanced isoprene SOA
+C                   with IEPOX uptake SOA now handled as a heterogeneous
+C                   rxn. For saprc07tic_ae6i, perform more detailed
+C                   IEPOX and MAE uptake and do not do Carlton et al. 2010
+C                   acid enhancement. Note that saprc07tic_ae6i is a research
+C                   version and it is unclear how duplicative AISO1+AISO2+their oligomers
+C                   are with  IEPOX+MAE uptake and their oligomers.
+C                   Both pathways occur with sarpc07tic_ae6i. To turn AISO1+AISO2
+C                   oligomers off, set "Decay" in vaporspc to 0.0 for SV_ISO1/2.
+C 27 Sep 14 H. Pye: Added alkane and PAH SOA (Pye and Pouliot 2012 ES&T)
+C 15 Jul 15 G. Sarwar: updated SOA from alkane, PAH, and isoprene for RACM2
+C 03/03/16  D. Luecken: added capability for CB6
+C 24 Mar 16 G. Sarwar: updated for CB05EH51
+C    May 16 B. Murphy, H. Pye: updated treatment of aerosol moments
+C
+C-----------------------------------------------------------------------
+      Implicit None
+
+      Integer, Parameter :: n_vapor_list = 28   ! # of potential partitioning SVOCs
+      Integer, Parameter :: n_orgprod    = 13   ! # of ROG rxn counter species
+      Integer, Save      :: n_vapor             ! # of actual simulated SOA vapors
+
+      Type vapor_type
+         Character( 16 ) :: name
+         Real            :: alpha       ! Mass-based stoichiometric coefficients [ug/m^3]/[ug/m^3]
+         Real            :: cstar       ! Effective saturation concentrations [ug/m^3] at 298 K
+         Real            :: enth        ! Enthalphy of Vaporization [J/mol]
+         Character( 16 ) :: soa_name    ! Species name
+         Character(  1 ) :: soa_origin  ! A = Anthropogenic; B = Biogenic
+         Real            :: soa_decay   ! Factor used in oligomerization
+         Character( 16 ) :: drog_name   ! Precursor name
+      End Type vapor_type
+
+      Type( vapor_type ), Allocatable, Save :: vaporspc( : )
+
+      Type( vapor_type ), Save :: vaporlist( n_vapor_list ) = (/
+C
+C                   Name       Alpha     CStar    Enth      SOA          Decay    Drog
+C                                                          Name    Origin         Name
+C                  -------    -------   -------- -------  ------     --   ----   -------
+     & vapor_type('SV_ALK1 ',  0.0334,   0.1472,  53.0E3, 'AALK1J ', 'A', 12.0, 'ALKRXN  '),
+     & vapor_type('SV_ALK2 ',  0.2164,  51.8775,  53.0E3, 'AALK2J ', 'A', 12.0, 'ALKRXN  '),
+     & vapor_type('SV_XYL1 ',  0.0310,   1.3140,  32.0E3, 'AXYL1J ', 'A',  8.0, 'XYLNRXN '),
+     & vapor_type('SV_XYL2 ',  0.0900,  34.4830,  32.0E3, 'AXYL2J ', 'A',  8.0, 'XYLNRXN '),
+     & vapor_type('SV_TOL1 ',  0.0580,   2.3260,  18.0E3, 'ATOL1J ', 'A',  7.0, 'TOLNRXN '),
+     & vapor_type('SV_TOL2 ',  0.1130,  21.2770,  18.0E3, 'ATOL2J ', 'A',  7.0, 'TOLNRXN '),
+     & vapor_type('SV_BNZ1 ',  0.0720,   0.3020,  18.0E3, 'ABNZ1J ', 'A',  6.0, 'BNZNRXN '),
+     & vapor_type('SV_BNZ2 ',  0.8880, 111.1100,  18.0E3, 'ABNZ2J ', 'A',  6.0, 'BNZNRXN '),
+     & vapor_type('SV_PAH1 ',  0.2100,   1.6598,  18.0E3, 'APAH1J ', 'A', 10.0, 'PAHNRXN '),
+     & vapor_type('SV_PAH2 ',  1.0700, 264.6675,  18.0E3, 'APAH2J ', 'A', 10.0, 'PAHNRXN '),
+     & vapor_type('SV_TRP1 ',  0.1393,  14.7920,  40.0E3, 'ATRP1J ', 'B', 10.0, 'TRPRXN  '),
+     & vapor_type('SV_TRP2 ',  0.4542, 133.7297,  40.0E3, 'ATRP2J ', 'B', 10.0, 'TRPRXN  '),
+     & vapor_type('MTNO3   ',     0.0,     12.0,  40.0E3, 'AMTNO3J', 'B', 10.0, '        '),
+     & vapor_type('ISOPNN  ',     0.0,     8.9,   40.0E3, 'AISOPNNJ','B', 5.0,  '        '),
+     & vapor_type('SV_ISO1 ',  0.2320, 116.0100,  40.0E3, 'AISO1J ', 'B',  5.0, 'ISOPRXN '),
+     & vapor_type('SV_ISO2 ',  0.0288,   0.6170,  40.0E3, 'AISO2J ', 'B',  5.0, 'ISOPRXN '),
+     & vapor_type('SV_SQT  ',  1.5370,  24.9840,  40.0E3, 'ASQTJ  ', 'B', 15.0, 'SESQRXN '),
+     & vapor_type('LV_PCSOG',  1.0   ,   1.0e-5,  40.0E3, 'APCSOJ ', 'A', 10.0, 'PCSOARXN'),
+     & vapor_type('VLVPO1  ',  0.0000,    1.e-1,  96.0E3, 'ALVPO1J', 'A',  0.0, '        '),
+     & vapor_type('VSVPO1  ',  0.0000,    1.e+0,  85.0E3, 'ASVPO1J', 'A',  0.0, '        '),
+     & vapor_type('VSVPO2  ',  0.0000,    1.e+1,  74.0E3, 'ASVPO2J', 'A',  0.0, '        '),
+     & vapor_type('VSVPO3  ',  0.0000,    1.e+2,  63.0E3, 'ASVPO3J', 'A',  0.0, '        '),
+     & vapor_type('VIVPO1  ',  0.0000,    1.e+3,  52.0E3, 'AIVPO1J', 'A',  0.0, '        '),
+     & vapor_type('VLVOO1  ',  0.0000,    1.e-2, 107.0E3, 'ALVOO1J', 'A',  0.0, '        '),
+     & vapor_type('VLVOO2  ',  0.0000,    1.e-1,  96.0E3, 'ALVOO2J', 'A',  0.0, '        '),
+     & vapor_type('VSVOO1  ',  0.0000,    1.e+0,  85.0E3, 'ASVOO1J', 'A',  0.0, '        '),
+     & vapor_type('VSVOO2  ',  0.0000,    1.e+1,  74.0E3, 'ASVOO2J', 'A',  0.0, '        '),
+     & vapor_type('VSVOO3  ',  0.0000,    1.e+2,  63.0E3, 'ASVOO3J', 'A',  0.0, '        ')/)
+
+C Required species
+      Character( 16 ), Private, Parameter :: req_sviso1  = 'SV_ISO1'
+      Character( 16 ), Private, Parameter :: req_sviso2  = 'SV_ISO2'
+      Character( 16 ), Private, Parameter :: req_mtno3   = 'MTNO3'
+      Character( 16 ), Private, Parameter :: req_isopnn  = 'ISOPNN'
+      Character( 16 ), Private, Parameter :: req_aeiso1  = 'AISO1'
+      Character( 16 ), Private, Parameter :: req_aeiso2  = 'AISO2'
+      Character( 16 ), Private, Parameter :: req_aeiso3  = 'AISO3'
+      Character( 16 ), Private, Parameter :: req_aeolga  = 'AOLGA'
+      Character( 16 ), Private, Parameter :: req_aeolgb  = 'AOLGB'
+      Character( 16 ), Private, Parameter :: req_aeorgc  = 'AORGC'
+      Character( 16 ), Private, Parameter :: req_amtno3  = 'AMTNO3'
+      Character( 16 ), Private, Parameter :: req_aisopnn = 'AISOPNN'
+
+C Indices of required species
+      Integer :: iso1_idx
+      Integer :: iso2_idx
+      Integer :: mtno3_idx
+      Integer :: isopnn_idx
+      Integer :: amtno3_idx
+      Integer :: aisopnn_idx
+      Integer :: aiso1_idx
+      Integer :: aiso2_idx
+      Integer :: aiso3_idx
+      Integer :: aolga_idx
+      Integer :: aolgb_idx
+      Integer :: aorgc_idx
+
+      Real, Allocatable    :: vapor_mw  ( : )   ! Molecular weights
+      Real, Allocatable    :: vapor_conc( : )   ! vapor concentration
+      Integer, Allocatable :: drog_map  ( : )   ! drog mapping assignments
+
+C orgprod species
+
+      Type orgprod_type
+         Character( 16 ) :: name
+         Character( 16 ) :: parent
+         Character( 16 ) :: aerospc      ! Non-volatile species name
+         Real            :: alphaH       ! Stoichiometric coefficients for non-volatile aromatic SOA [ug/m^3]/[ug/m^3]
+      End Type orgprod_type
+
+C   This default orgprod table is for CB05, parent names are changed in subroutine
+C   extract_soa for the SAPRC99 and SAPRC07T mechanisms
+C
+
+      Type( orgprod_type ), Save      :: orgprod( n_orgprod ) = (/
+C                      Name      Parent     Aerospc  AlphaH
+C                     -------    -------    ------   ------
+     & orgprod_type( 'ALKRXN  ', 'SOAALK ', '      ', 0.000 ),
+     & orgprod_type( 'XYLNRXN ', 'XYL    ', '      ', 0.000 ),
+     & orgprod_type( 'XYLHRXN ', 'XYL    ', 'AXYL3J', 0.360 ),
+     & orgprod_type( 'TOLNRXN ', 'TOL    ', '      ', 0.000 ),
+     & orgprod_type( 'TOLHRXN ', 'TOL    ', 'ATOL3J', 0.300 ),
+     & orgprod_type( 'BNZNRXN ', 'BENZENE', '      ', 0.000 ),
+     & orgprod_type( 'BNZHRXN ', 'BENZENE', 'ABNZ3J', 0.370 ),
+     & orgprod_type( 'PAHNRXN ', 'NAPH   ', '      ', 0.000 ),
+     & orgprod_type( 'PAHHRXN ', 'NAPH   ', 'APAH3J', 0.730 ),
+     & orgprod_type( 'TRPRXN  ', 'TRPRXN ', '      ', 0.000 ),
+     & orgprod_type( 'ISOPRXN ', 'ISOPRXN', '      ', 0.000 ),
+     & orgprod_type( 'SESQRXN ', 'SESQRXN', '      ', 0.000 ),
+     & orgprod_type( 'PCSOARXN', 'PCVOC  ', '      ', 0.000 ) /)
+
+
+      Real    :: orgprod_mw     ( n_orgprod )  ! Mol weight of reactive organic gases
+      Real    :: orgprod_conc   ( n_orgprod )  ! orgprod concentration
+      Integer :: orgprod_aeroMap( n_orgprod )  ! orgprod pointers to aerospc
+      Integer, Allocatable :: soa_aeroMap    ( : )    ! soa pointers to aerospc
+
+
+C mapping variables used for loading and unloading to CGRID array
+      Integer, Allocatable :: vapor_map( : )     ! pointers of vapor species to CGRID
+      Integer              :: orgprod_map( n_orgprod ) ! pointers of orgprod species to CGRID
+
+      Logical, Private, Save :: mapped              = .False.
+      Logical, Private, Save :: IEPOX_SOA_mechanism = .False. ! IEPOX uptake in mechanism reactions?
+      Logical, Private, Save :: RXNS_eflag          = .False. ! error flag for RXNS modules used
+      Logical, Private, Save :: SOA_eflag           = .False. ! error flag for soa_defn
+     
+!     Integer, Save :: pfc = 0   ! possible false soabisect convergence counter
+
+      Character( 16 ), Private, Save :: pname = 'Soa_Defn        '
+      Integer, Private, Save :: logdev
+      Integer, Private, External :: setup_logdev
+
+      Contains
+
+C-----------------------------------------------------------------------
+      Subroutine extract_soa( conc )
+
+C  Extracts the required soa data from CGRID into the conc array.
+
+C  Revision History:
+C     First version was coded in April 2010 by Steve Howard with
+C     Prakash Bhave, Jeff Young, and Sergey Napelenok.
+C
+C SH  03/10/11 Renamed met_data to aeromet_data
+C SR  03/25/11 Replaced I/O API include files with UTILIO_DEFN
+C HP  09/27/14 alk_factor removed, updated for alkane/PAH SOA.
+C              Conversion of reacted alkane to dodecane equivalent
+C              is handled in mech.def. A factor of 0.47 is in use and
+C              reflects the fact that alkane SOA precursor
+C              emissions are dominated by compounds smaller than dodecane.
+C-----------------------------------------------------------------------
+
+      Use rxns_data       ! chemical mechanism data
+      Use aero_data       ! aero species
+      Use aeromet_data    ! air and met variables
+      Use cgrid_spcs      ! CGRID mechanism species
+      Use utilio_defn
+
+      Implicit None
+
+C Includes:
+
+C Arguments:
+      Real, Intent( In ) :: conc( : )
+
+C Local Variables:
+      Character( 300 ) :: xmsg
+      Real            :: gasconv
+      Real            :: vtmp
+      Integer         :: n, g
+      Integer         :: spc
+      Integer         :: naerosol_volatile
+      Integer         :: aerosol_to_vaporlist( n_vapor_list )
+      Integer         :: vapor_to_vaporlist( n_vapor_list )
+
+      Real, Save :: alk_factor = 1.00
+
+      If ( .Not. mapped ) Then
+
+         logdev = setup_logdev()
+
+C Before Anything Else, the VaporSpc Array must be populated with
+C the species from VaporList that have been identified in the GC
+C namelist or in the NR namelist.
+          n_vapor = 0
+          Do spc = 1,n_vapor_list
+             n = 0
+             g = 0
+             n = index1( vaporlist( spc )%name, n_nr_n2ae, nr_n2ae )
+             g = index1( vaporlist( spc )%name, n_gc_g2ae, gc_g2ae )
+             If ( n .Gt. 0 .Or. g .Gt. 0 ) Then
+                 n_vapor = n_vapor + 1
+                 vapor_to_vaporlist( n_vapor ) = spc
+             End If
+          End Do
+
+#ifdef verbose_soa
+          write(logdev,'(a,i3)')'SOA_DEFN: n_vapor = ',n_vapor
+#endif
+          Allocate ( vaporspc  ( n_vapor ))
+          Allocate ( vapor_mw  ( n_vapor ))
+          Allocate ( vapor_conc( n_vapor ))
+          Allocate ( drog_map  ( n_vapor ))
+          Allocate ( SOA_AeroMap  ( n_vapor ))
+          Allocate ( vapor_map  ( n_vapor ))
+
+          Do spc = 1,n_vapor
+!             vaporspc( spc ) = vaporlist( aerosol_to_vaporlist( spc ) )
+             vaporspc( spc ) = vaporlist( vapor_to_vaporlist( spc ) )
+#ifdef verbose_soa
+             write(logdev,'(a,i3,3(1x,a))')'SOA_DEFN: n, vapor, aero_spc, precursor = ',
+     &       spc, vaporspc(spc)%name,vaporspc(spc)%soa_name,vaporspc(spc)%drog_name
+#endif
+          End Do
+
+C Check GC or NR namelist contains precursor for each vapor used if the vapor has a
+C precursor
+          Do spc = 1, n_vapor
+            If( Len_Trim( vaporspc( spc )%drog_name ) .Lt. 1 ) Cycle
+            n = index1( vaporspc( spc )%drog_name, n_gc_spc, gc_spc )
+            If ( n .Lt. 1 ) Then
+              n = index1( vaporspc( spc )%drog_name, n_nr_spc, nr_spc )
+              If ( n .Lt. 1 ) Then
+!                 xmsg = 'FATAL: SOA Precursor, ' // Trim( vaporspc( spc )%drog_name )
+!     &               // '. is not found among the species in GC or NR namelist'
+!     &               // ' used. Required for modeling vapor, '
+!     &               // Trim( vaporspc( spc )%name )
+                SOA_eflag  = .True.
+                write(logdev,99903)Trim( vaporspc( spc )%drog_name ),
+     &          Trim( vaporspc( spc )%name )
+!                Call m3warn( pname, 0, 0, xmsg )
+              End If
+            End If
+         End Do
+
+C Check that the soa species found in the AE namelist have their vapor
+C phase as model species
+          Do spc = 1,n_vapor_list
+             n = 0
+             g = 0
+             n = index1( vaporlist( spc )%soa_name, n_ae_spc, ae_spc )
+             If ( n .Gt. 0 ) Then ! vapor phase
+!                 write(logdev,*)'found soa species:',TRIM( ae_spc(n) ),
+!     &           ' Search for vapor species:',Trim( vaporlist( spc )%name )
+                 g = index1( vaporlist( spc )%name, n_nr_spc, nr_spc )
+                 If( g .Lt. 1 ) Then
+                    g = index1( vaporlist( spc )%name, n_gc_spc, gc_spc )
+                    If( g .Lt. 1 ) Then
+!                      xmsg = 'FATAL: SOA Vapor, ' // Trim( vaporlist( spc )%name )
+!     &                     // ', is not found among the species in the NR or GC'
+!     &                     // ' namelist used. Required for modeling '
+!     &                     // Trim ( vaporlist( spc )%soa_name ) // '.'
+                      SOA_eflag  = .True.
+                      write(logdev,99902)Trim( vaporlist( spc )%name ), 
+     &                Trim ( vaporlist( spc )%soa_name )
+!                      Call m3warn( pname, 0, 0, xmsg )
+                    End If
+                 End If
+!                 If( g .Gt. 0 ) Then
+!                    write(logdev,*)'found vapor species:', Trim( vaporlist( spc )%name )
+!                End If
+             End If
+         End Do
+
+C Build mapping to CGRID for each vapor species
+C Add option to have species in GC.nml (for real semivolatiles)
+         vapor_mw = 0.0
+         vapor_map = 0
+         Do spc = 1, n_vapor
+            If( vaporspc( spc )%alpha .Gt. 0.0 ) Then
+               n = index1( vaporspc( spc )%name, n_nr_n2ae, nr_n2ae )
+               If ( n .Ne. 0 ) Then
+                  vapor_map( spc ) = nr_strt - 1 + nr_n2ae_map( n )
+                  vapor_mw( spc ) = nr_molwt( nr_n2ae_map( n ) )
+               Else
+                  xmsg = 'FATAL: ' // Trim( vaporspc( spc )%name )
+     &                 // ' is not found in the N2AE values of NR namelist'
+     &                 // ' used. '
+                  SOA_eflag  = .True.
+                  Call m3warn( pname, 0, 0, xmsg )
+!                 Call m3exit( pname, 0, 0, xmsg, xstat3 )
+               End If
+            Else ! vaporspc is a real species in GC (alpha=0 )
+               n = index1( vaporspc( spc )%name, n_gc_g2ae, gc_g2ae )
+               If ( n .Ne. 0 ) Then
+                  vapor_map( spc ) = gc_strt - 1 + gc_g2ae_map( n )
+                  vapor_mw( spc ) = gc_molwt( gc_g2ae_map( n ) )
+               Else
+                  xmsg = 'FATAL: ' // Trim( vaporspc( spc )%name )
+     &                 // ' is not found in the G2AE values of GC namelist'
+     &                 // ' used. '
+                  SOA_eflag  = .True.
+                  Call m3warn( pname, 0, 0, xmsg )
+!                 Call m3exit( pname, 0, 0, xmsg, xstat3 )
+               End If
+            End If
+         End Do
+
+#ifdef verbose_soa
+         write(logdev,'(a16,1x,a4,1x,a7)')"    vaporspc    ","INDX","Mol.Wei"
+         Do spc = 1, n_vapor
+           write(logdev,'(a16,1x,i4,1x,f7.2)')vaporspc( spc )%name, vapor_map( spc ), 
+     &                                        vapor_mw( spc )
+         End Do
+#endif
+
+C define orgprod parent names based on mechanism dependence
+C if they differ from above declarations and
+C determine if gas-phase IEPOX uptake occurs for the mechanism
+            If ( INDEX( MECHNAME, 'SAPRC07TIC_AE6I' ) .Gt. 0 ) Then
+               orgprod( 2 )%parent = 'MXYL'
+               orgprod( 3 )%parent = 'MXYL'
+               orgprod( 4 )%parent = 'TOLUENE'
+               orgprod( 5 )%parent = 'TOLUENE'
+               orgprod( 8 )%parent = 'NAPHTHAL'
+               orgprod( 9 )%parent = 'NAPHTHAL'
+               IEPOX_SOA_mechanism = .True.
+            Else If ( INDEX( MECHNAME, 'SAPRC07TB' ) .Gt. 0 ) Then
+               orgprod( 2 )%parent     = 'MXYL'
+               orgprod( 3 )%parent     = 'MXYL'
+               orgprod( 4 )%parent     = 'TOLUENE'
+               orgprod( 5 )%parent     = 'TOLUENE'
+               orgprod( 8 )%parent     = 'NAPHTHAL'
+               orgprod( 9 )%parent     = 'NAPHTHAL'
+               IEPOX_SOA_mechanism = .True.
+            Else If ( INDEX( MECHNAME, 'CRIe' ) .Gt. 0 ) Then
+               orgprod( 2 )%parent     = 'MXYL'
+               orgprod( 3 )%parent     = 'MXYL'
+               orgprod( 4 )%parent     = 'TOLUENE'
+               orgprod( 5 )%parent     = 'TOLUENE'
+               orgprod( 8 )%parent     = 'NAPHTHAL'
+               orgprod( 9 )%parent     = 'NAPHTHAL'
+            Else If ( INDEX( MECHNAME, 'SAPRC07TC' ) .Gt. 0 ) Then
+               orgprod( 2 )%parent     = 'MXYL'
+               orgprod( 3 )%parent     = 'MXYL'
+               orgprod( 4 )%parent     = 'TOLUENE'
+               orgprod( 5 )%parent     = 'TOLUENE'
+               orgprod( 8 )%parent     = 'NAPHTHAL'
+               orgprod( 9 )%parent     = 'NAPHTHAL'
+               IEPOX_SOA_mechanism = .True.
+            Else If( INDEX(MECHNAME, 'RACM2') .Gt. 0) Then
+! Changed by Golam Sarwar, 07/15/2015 for CMAQv51
+               orgprod( 2 )%parent     = 'XYM'
+               orgprod( 3 )%parent     = 'XYM'
+               orgprod( 4 )%parent     = 'TOL'
+               orgprod( 5 )%parent     = 'TOL'
+               IEPOX_SOA_mechanism = .True.
+            Else If( INDEX(MECHNAME, 'CB05TUCL') .Gt. 0) Then
+               orgprod( 2 )%parent = 'XYLMN'
+               orgprod( 3 )%parent = 'XYLMN'
+            Else If( INDEX(MECHNAME, 'CB05E51') .Gt. 0) Then
+               orgprod( 2 )%parent = 'XYLMN'
+               orgprod( 3 )%parent = 'XYLMN'
+               IEPOX_SOA_mechanism = .True.
+            Else If( INDEX(MECHNAME, 'CB6R3') .Gt. 0) Then
+               orgprod( 2 )%parent = 'XYLMN'
+               orgprod( 3 )%parent = 'XYLMN'
+               IEPOX_SOA_mechanism = .True.
+            Else If( INDEX(MECHNAME, 'CB05EH51') .Gt. 0) Then
+               orgprod( 2 )%parent = 'XYLMN'
+               orgprod( 3 )%parent = 'XYLMN'
+               IEPOX_SOA_mechanism = .True.
+            Else 
+               xmsg =  'FATAL: The ' // MECHNAME // ' mechanism '
+     &             // ' is not supported in this version of the model.'
+     &             // ' Change CCTM build script to use a mechanism based on '
+     &             // ' mechanisms available in currect CMAQ repository or '
+     &             // ' Change MECHNAME to one of the repository mechanisms.'
+               RXNS_eflag  = .True.
+               Call m3warn( pname, 0, 0, xmsg )
+!              Call m3exit( pname, 0, 0, xmsg, xstat3 )
+            End If
+
+! SOA_DEFN NO LONGER HAS VERSION CONSTRAINTS ON SPECIES
+! This SOA_DEFN works for AE6 and AE6i versions of aero
+!            If( INDEX( MECHNAME, '_AE6_' ) .EQ. 0 ) then
+!                  xmsg =  'Using AERO6 option and the Mechanism, '
+!     &                // Trim( MECHNAME ) // ', is not based on AERO6 '
+!                 Call m3exit( pname, 0, 0, xmsg, xstat3 )
+!            End If
+
+
+C Build mapping to CGRID for each ORGPROD species and find MW of parent
+
+         orgprod_map = 0
+         Do spc = 1, n_orgprod
+            n = index1( orgprod( spc )%name, n_gc_g2ae, gc_g2ae )
+            If ( n .Ne. 0 ) Then
+               orgprod_map( spc ) = gc_strt - 1 + gc_g2ae_map( n )
+               n = index1( orgprod( spc )%parent, n_gc_spc, gc_spc )
+               If ( n .Ne. 0 ) Then
+                  orgprod_mw( spc ) = gc_molwt( n )
+               Else
+                  xmsg = 'FATAL: Species ' // orgprod( spc )%parent
+     &                 // ' in ORGPROD parent name is not in the G2AE values'
+     &                 // ' of the GC namelist for the ' // TRIM ( MECHNAME ) 
+     &                 // ' mechanism '
+                  SOA_eflag  = .True.
+                  Call m3warn( pname, 0, 0, xmsg )
+!                 Call m3exit( pname, 0, 0, xmsg, xstat3 )
+               End If
+            End If
+         End Do
+
+#ifdef verbose_soa
+         write(logdev,'(2(a16),1x,a4,1x,a7)')"    orgprod    ","    parent    ","INDX","Mol.Wei"
+         Do spc = 1, n_orgprod
+           If ( orgprod_map( spc ) .Lt. 1 )Cycle
+           write(logdev,'(2(a16),1x,i4,1x,f7.2)')orgprod( spc )%name,orgprod( spc )%parent, 
+     &                                        orgprod_map( spc ),orgprod_mw( spc ) 
+         End Do
+#endif
+
+C Find indices of required species
+         iso1_idx   = findVapor( req_sviso1 )
+         iso2_idx   = findVapor( req_sviso2 )
+         aiso1_idx  = findAero( req_aeiso1, .True. )
+         aiso2_idx  = findAero( req_aeiso2, .True. )
+         aiso3_idx  = findAero( req_aeiso3, .True. )
+         aolga_idx  = findAero( req_aeolga, .True. )
+         aolgb_idx  = findAero( req_aeolgb, .True. )
+         aorgc_idx  = findAero( req_aeorgc, .True. )
+
+#ifdef verbose_soa
+      ! Mandatory Species
+         Write( logdev,'( /5x, a )' ) 'soa_defn: required species'
+         Write( logdev,'( 5x, a, i4 )' ) 'iso1_idx:   ', iso1_idx 
+         Write( logdev,'( 5x, a, i4 )' ) 'iso2_idx:   ', iso2_idx 
+         Write( logdev,'( 5x, a, i4 )' ) 'aiso1_idx:  ', aiso1_idx
+         Write( logdev,'( 5x, a, i4 )' ) 'aiso2_idx:  ', aiso2_idx
+         Write( logdev,'( 5x, a, i4 )' ) 'aiso3_idx:  ', aiso3_idx
+         Write( logdev,'( 5x, a, i4 )' ) 'aolga_idx:  ', aolga_idx
+         Write( logdev,'( 5x, a, i4 )' ) 'aolgb_idx:  ', aolgb_idx
+         Write( logdev,'( 5x, a, i4 )' ) 'aorgc_idx:  ', aorgc_idx
+#endif
+         ! Look for Additional Isoprene Product Species if AE6i is being
+         ! used
+         If ( INDEX( MECHNAME,"SAPRC07TIC_AE6I" ) .Ne. 0 ) Then
+           mtno3_idx  = findVapor( req_mtno3  )
+           isopnn_idx = findVapor( req_isopnn )
+           amtno3_idx  = findAero( req_amtno3, .True. )
+           aisopnn_idx = findAero( req_aisopnn,.True. )
+#ifdef verbose_soa
+           Write( logdev,'( /5x, a )' )
+     &      'SAPRC07TIC_AE6I soa_defn: required species'
+           Write( logdev,'( 5x, a, i4 )' ) 'mtno3_idx:   ', mtno3_idx  
+           Write( logdev,'( 5x, a, i4 )' ) 'isopnn_idx:  ', isopnn_idx 
+           Write( logdev,'( 5x, a, i4 )' ) 'amtno3_idx:  ', amtno3_idx 
+           Write( logdev,'( 5x, a, i4 )' ) 'aisopnn_idx: ', aisopnn_idx
+#endif
+         End If
+
+
+C Build mapping array of Semivolatile Vapors (vaporspc) to the Aerosol
+C Species they correspond to (aerospc is used inside findAero)
+         soa_aeroMap = 0
+#ifdef verbose_soa
+           Write( logdev,'( /5x, a )' )
+     &      'soa_defn: vapor species'
+#endif     
+         Do spc = 1, n_vapor
+            If ( vaporspc( spc )%soa_name .Ne. ' ' ) Then
+               soa_aeroMap( spc ) = findAero( vaporspc( spc )%soa_name, .True. )
+#ifdef verbose_soa
+           Write( logdev,'( 5x, a20, i4 )' ) Trim(vaporspc( spc )%soa_name) // ':', 
+     &                                       soa_aeroMap( spc )
+#endif
+               If( soa_aeroMap( spc ) .Lt. 1 ) write(logdev,99904) Trim( vaporspc( spc )%name )
+            End If
+         End Do
+
+
+C Build Mapping array of Reactive variables that track production rates
+C of condensable gases (orgprod) to any nonvolatile species they yield
+C (aerospc is used inside findAero)
+         orgprod_aeroMap = 0
+#ifdef verbose_soa
+           Write( logdev,'( /5x, a )' )
+     &      'soa_defn: orgprod_aero species'
+#endif     
+         Do spc = 1, n_orgprod
+            If ( orgprod( spc )%aerospc .Ne. ' ' ) Then
+               orgprod_aeroMap( spc ) = findAero( orgprod( spc )%aerospc, .True. )
+#ifdef verbose_soa
+           Write( logdev,'( 5x, a20, i4 )' ) Trim(orgprod( spc )%aerospc) // ':', 
+     &                                       orgprod_aeroMap( spc )
+#endif
+               If( orgprod_aeroMap( spc ) .Lt. 1 ) write(logdev,99905) Trim( orgprod( spc )%name )
+            End If
+         End Do
+
+
+C Build mapping array of sources of Semivolatile Vapors (vaporspc) to the
+C Reactive variables that store their production rates (orgprod)
+         drog_map = 0
+#ifdef verbose_soa
+           Write( logdev,'( /5x, a )' )
+     &      'soa_defn: drog species'
+#endif     
+         Do spc = 1, n_vapor
+            If ( vaporspc( spc )%drog_name .Ne. ' ' ) Then
+               drog_map( spc ) = findOrgprod( vaporspc( spc )%drog_name )
+#ifdef verbose_soa
+           Write( logdev,'( 5x, a20, i4 )' ) Trim(vaporspc( spc )%drog_name) // ':', 
+     &                                       drog_map( spc )
+#endif
+               If( drog_map( spc ) .Lt. 1 ) write(logdev,99905) Trim( orgprod( spc )%name )
+            End If
+         End Do
+
+         If( AE_eflag .Or. SOA_eflag .Or. RXNS_eflag )Then
+             If( AE_eflag .Or. SOA_eflag )Write(logdev,99901)Trim( mechname )
+             xmsg = 'The FATAL errors found in namelist used. Check '
+     &          //  'the log of exiting processor if more details are needed.'
+             Call m3exit( pname, 0, 0, xmsg, xstat3 )
+         End If 
+
+         mapped = .True.
+
+      End If     ! mapping condition
+
+C Compute gas conversion constant
+      gasconv = airdens * inv_mwair
+
+C Copy grid cell concentrations of vapor species
+      vapor_conc = 0.0
+
+      Do spc = 1, n_vapor
+         n = vapor_map( spc )
+         If ( n .Ne. 0 ) Then
+            vtmp = gasconv * vapor_mw( spc )
+            vapor_conc( spc ) = Max( conc( n ) * vtmp, min_gasconc )
+         End If
+      End Do
+
+C Copy grid cell concentrations of ORGPROD species
+      orgprod_conc = 0.0
+      Do spc = 1, n_orgprod
+         n = orgprod_map( spc )
+         If ( n .Ne. 0 ) Then
+            orgprod_conc( spc ) = Max( conc( n ), min_gasconc )
+         End If
+      End Do
+
+C Adjust ALK orgprod for fraction that produces SOA
+!      orgprod_conc( 1 ) = alk_factor * orgprod_conc( 1 )
+
+99901 Format(/'FATAL Error(s) found in the namelist(s) used. Check that '
+     &     /  'these namelists contain the data as the files in '
+     &     /  'the respository version of the mechanism: ', a / )
+99902 Format('FATAL: SOA Vapor, ', a, ', is not found among the species in '
+     &        / 'the NR or GC namelist used. Required for modeling ', a / )
+99903 Format( 'FATAL: SOA Precursor, ', a,  '. is not found among the species',
+     &         / 'in GC or NR namelist used. Required for modeling vapor, ', a / )
+99904 Format(1X,'aerosol product from namelist species: ', a /)
+99905 Format(1X,'aerosol by-product from namelist species : ', a /)
+C99906 Format(1X,'precursor from namelist species : ', a /)
+  
+
+      Return
+      End Subroutine extract_soa
+
+C-----------------------------------------------------------------------
+      Subroutine update_soa( conc )
+
+C  Populates CGRID from the conc array with updated SOA values.
+
+C  Revision History:
+C     First version was coded in April 2010 by Steve Howard with
+C     Prakash Bhave, Jeff Young, and Sergey Napelenok.
+C
+C SH  03/10/11 Renamed met_data to aeromet_data
+C SR  03/25/11 Replaced I/O API include files with UTILIO_DEFN
+C-----------------------------------------------------------------------
+
+      Use aeromet_data    ! air and met variables
+      Use utilio_defn
+
+      Implicit None
+
+C Arguments:
+      Real, Intent( Out ) :: conc( : )
+
+C Local Variables:
+      Character( 80 ) :: xmsg
+      Real            :: gasconv
+      Real            :: vtmp
+      Integer         :: n
+      Integer         :: spc
+
+      If ( .Not. mapped ) Then
+         xmsg = 'CGRID Species has not been mapped'
+         Call m3exit( pname, 0, 0, xmsg, xstat3 )
+      End If
+
+C Compute gas conversion constant
+      gasconv = airdens * inv_mwair
+
+C Copy vapor_conc back to grid cell concentrations
+      Do spc = 1, n_vapor
+         n = vapor_map( spc )
+         If ( n .Ne. 0 ) Then
+            vtmp = vapor_mw( spc ) * gasconv
+            conc( n ) = Max ( vapor_conc( spc ) / vtmp, min_gasconc )
+            ! Write( *,'(a,i5,g16.6)' ) vaporspc( spc )%name, n, conc( n )
+         End If
+      End Do
+
+      Return
+      End Subroutine update_soa
+
+C-----------------------------------------------------------------------
+      Function findVapor( vname ) Result ( ndx )
+
+C  Finds the index of 'required' semivolatile species in the vaporspc list
+
+C  Revision History:
+C     First version was coded in April 2010 by Steve Howard with
+C     Prakash Bhave, Jeff Young, and Sergey Napelenok.
+C
+C SR  03/25/11 Replaced I/O API include files with UTILIO_DEFN
+C-----------------------------------------------------------------------
+
+      Use utilio_defn
+
+      Implicit None
+
+C Arguments:
+      Character( 16 ) :: vname
+      Integer ndx
+
+C Local Variables:
+      Character( 80 ) :: xmsg
+      Integer         :: spc
+
+      ndx = 0
+      Do spc = 1, n_vapor
+         If ( vaporspc( spc )%name .Eq. vname ) Then
+            ndx = spc
+            Return
+         End If
+      End Do
+
+!      xmsg = 'Required Species ' // Trim( vname ) // ' not found in [vapor names] array'
+      xmsg = 'FATAL:' // Trim( vname )
+     &    // ' is not found in the G2AE or N2AE values of GC or namelists'
+      SOA_eflag  = .True.
+      Call m3warn( pname, 0, 0, xmsg )
+!     Call m3exit( pname, 0, 0, xmsg, xstat3 )
+
+      Return
+      End Function findVapor
+
+C-----------------------------------------------------------------------
+      Function findOrgprod( vname ) result ( ndx )
+
+C  Finds the index of 'required' organic product species in the orgprod list
+
+C  Revision History:
+C     First version was coded in April 2010 by Steve Howard with
+C     Prakash Bhave, Jeff Young, and Sergey Napelenok.
+C
+C SR  03/25/11 Replaced I/O API include files with UTILIO_DEFN
+C-----------------------------------------------------------------------
+
+      Use utilio_defn        ! i/o api
+
+      Implicit None
+
+C Arguments:
+      Character( 16 ) :: vname
+      Integer ndx
+
+C Local Variables:
+      Character( 80 ) :: xmsg
+      Integer         :: spc
+
+      Do spc = 1, n_orgprod
+         ! If ( Index( orgprod( spc )%name, Trim( vname ) ) .Gt. 0 ) Then
+         If ( orgprod( spc )%name .Eq. vname ) Then
+            ndx = spc
+            ! Write( *,'(a,i5)' ) vname, ndx
+            Return
+         End If
+      End Do
+
+!      xmsg = 'Required Species ' // Trim( vname )
+!     &     // ' Not found in [orgprod names] array'
+      xmsg = 'FATAL:' // Trim( vname )
+     &    // ' is not found in the G2AE or N2AE values of GC or namelists'
+      SOA_eflag  = .True.
+      Call m3warn( pname, 0, 0, xmsg )
+!     Call m3exit( pname, 0, 0, xmsg, xstat3 )
+
+      Return
+      End Function findOrgprod
+
+C-----------------------------------------------------------------------
+      Subroutine orgaer( dt, layer )
+
+C Updates CGRID via several pathways for secondary organic aerosol (SOA)
+C formation, as recommended by Edney et al. (2007).  These include SOA
+C formation from isoprene, monoterpenes, sesquiterpenes, long alkanes, and
+C aromatics (incl. benzene).
+
+C Input includes the concentrations of reactive organic gases (ROG)
+C that were oxidized during the time step (ORGPROD), the vapor-phase
+C concentration of each semi-volatile organic compound, the
+C concentration of each SOA species, and the concentration of primary
+C organic aerosol (all concentrations are stored in the CBLK array).
+C Output includes updated concentrations of SOA species, vapor-phase
+C semi-volatile organic compounds, and moments of the accumulation
+C mode.  The geometric mean diameter of the accumulation mode is also
+C updated.  All SOA formation is restricted to the accumulation mode.
+
+C This code relies on 12 counter species to be incorporated in the
+C gas-phase chemical mechanisms to track the amounts of individual
+C ROG that reacted during the current time step (i.e., NPREC=10).
+C The arrays of length = NPREC include:
+C       (1) "long" alkanes  (ALKRXN)
+C       (2) low-yield aromatics, high-NOx pathway (XYLNRXN)
+C       (3) low-yield aromatics, low-NOx pathway (XYLHRXN)
+C       (4) high-yield aromatics, high-NOx pathway (TOLNRXN)
+C       (5) high-yield aromatics, low-NOx pathway (TOLHRXN)
+C       (6) benzene, high-NOx pathway (BNZNRXN)
+C       (7) benzene, low-NOx pathway (BNZHRXN)
+C       (8) monoterpenes (TRPRXN)
+C       (9) isoprene (ISOPRXN)
+C      (10) sesquiterpenes (SESQRXN)
+C      (11) PAHs/naphthalene, high-NOx pathway (PAHNRXN)
+C      (12) PAHs/naphthalene, low-NOx pathway (PAHHRXN)
+
+C In total, 15 organic species are allowed to partition between the
+C vapor and particulate phases (i.e., NCVAP=12). The arrays of
+C length = NCVAP include:
+C           alkane (2 semi-volatile products)
+C           low-yield aromatics, high-NOx pathway (2 products)
+C           high-yield aromatics, high-NOx pathway (2 products)
+C           benzene, high-NOx pathway (2 products)
+C           monoterpenes (2 products)
+C           isoprene (2 products)
+C           sesquiterpenes (1 product)
+C           PAHs/naphthalene, high-NOx pathway (2 products)
+
+C Equilibrium partitioning calculations are based on the absorptive
+C partitioning model of Pankow (1994) that was extended by Odum et
+C al. (1996).  Saturation vapor pressures (cstar) and mass-based
+C stoichiometric yield coefficients (alpha) are obtained from smog-
+C chamber studies.  Saturation vapor pressures are modified as a
+C function of temperature using eqn 6 of Sheehan & Bowman (2001).
+
+C If the pre-existing organic aerosol concentration is zero,
+C gas/particle equilibrium is established only after the organic gas
+C concentration reaches the threshold value defined in eqn 9 of
+C Schell et al. (2001).  Until this threshold value is reached,
+C organic vapors do not partition to the particle phase.  Once the
+C organic gas/particle equilibrium has been established, gas and
+C particle-phase concentrations of each condensible species are
+C calculated iteratively using a globally convergent variation of
+C Newton's method (SUBROUTINE NEWT), as described in eqn 8 of Schell
+C et al. (2001).
+
+C In addition to the various pathways of semi-volatile SOA formation
+C treated in previous versions of the model, four types of non-
+C volatile SOA are considered here:
+C   (1) aromatic and PAH-derived SOA under low-NOx conditions
+C   (2) oligomerization of all particle-phase semi-volatile material
+C   (3) SOA formed by in-cloud oxidation  (SUBROUTINE AQCHEM)
+C   (4) isoprene IEPOX-derived SOA under acidic conditions (AEROSOL_CHEMISTRY)
+
+C Previous code revision history:
+C   Originally coded August 1, 2001 by Dr. Francis S. Binkowski
+
+C   Revised April 4, 2003 by Gerald Gipson to allow for evaporation
+C   of organics from aerosols. Now total vapor + aerosol phase is
+C   repartitioned at each time step and totorgsw ( Mo ) does not
+C   include oldsoa.
+
+C   Revised July 14, 2003 by Dr. Prakash V. Bhave
+C   - changed cstar(2,3) from 10.103 & 90.925 to 111.11 & 1000.0
+C     because smog chamber data of Kalberer et al. were collected
+C     at 298 K (not 310 K, as was previously assumed)
+C   - changed mw_vap(9,10) from 184 g/mol to 177 g/mol, to be
+C     consistent with mwsoa_b
+C   - modified threshold criteria for establishing gas/particle
+C     equilibrium by removing the loose criterion involving "mtot"
+C   - changed variable names to reflect that the combined vapor +
+C     aerosol concentrations are now being repartitioned during
+C     each time step (not just the newly formed SVOC's)
+C   - added documentation and removed extraneous lines of code
+
+C   Revised December 4, 2003 by Dr. Francis S. Binkowski
+C   - output variables ORGRATE and ORGBRATE removed and replaced
+C     by SOA_A and SOA_B, the newly equilibrated values of
+C     Anthropogenic and Biogenic SOA, respectively.  These are non-
+C     negative values.
+C   - variable jj also removed
+
+C   Revised January 8, 2004 by Dr. Prakash V. Bhave
+C   - removed the output variable YIELD.  It has no physical meaning
+C     after the 12/04/2003 revisions.
+
+C   Revised January 12, 2004 by Dr. Chris G. Nolte
+C   - for computational efficiency, modified the initial caer guess
+C     used as input to NEWT.  If NEWT returns check .eq. true, then
+C     NEWT is called again with a guess of caer = 0.5*ctot
+C   - removed ITS parameter from NEWT call vector
+C   - fixed bug where concentrations less than TOLMIN (i.e., 1.0E-12)
+C     were reset to 1.0e-30
+C   - removed extraneous code related to "Pandis method" of SVOC
+C     partitioning when threshold criterion is not met (i.e.,
+C     insufficient organic matter to establish gas/particle
+C     equilibrium)  ** results unaffected by this change
+C
+C   Revised September 7, 2007 by Dr. Sergey L. Napelenok
+C   - Replaced old SOA species (SOA_A, SOA_B) with an array of
+C     precursor-specific SOA species.  Replaced OLDSOA_A and OLDSOA_B
+C     with an array (OLDSOA).  Updated call vector accordingly.
+C   - Deleted nole* and nbio* variables (now obsolete)
+C   - Increased the dimension of several arrays to accommodate new
+C     SOA precursors (benzene, sesquiterpenes) and pathways (low-NOx,
+C     acid-catalyzed, oligomers, in-cloud)
+C
+C   Revised November 29, 2007 by Dr. Prakash V. Bhave
+C   - Renamed subroutine from ORGAER3 to ORGAER5
+C   - Modified M2 and M3 calculations to account for the updated
+C     definition of DRY aerosol (which now includes non-volatile SOA)
+C   - Updated Hvap and corresponding cstar values
+C   - Added parameters for SOA from isoprene and sesquiterpenes
+C   - Updated aromatic SOA scheme to include semi-volatile and non-
+C     volatile products that form under high-NOx and low-NOx
+C     conditions, respectively
+C   - Added oligomerization process
+C   - Added enhancement of isoprene SOA under acidic conditions
+C
+C   Revised June 2, 2008 by Dr. Prakash V. Bhave
+C   - Changed h_vap of benzene SOA to match that of toluene SOA, based
+C     on consultation with Dr. Ed Edney and Dr. Tad Kleindienst.
+
+C   Revised June 5, 2008 by Drs. Prakash Bhave and Sergey Napelenok
+C   - Simplified the code for conserving low-volatility isoprene
+C     oxidation products and removed a minor bug in the acid-induced
+C     isoprene SOA calculation.
+C
+C   Revised September 9, 2008 by Dr. Prakash V. Bhave
+C   - Increased alpha values for SV_TRP1, SV_TRP2, and SV_SQT by a
+C     factor of 1.3 to correct for the implicit assumption of unit
+C     density in those SOA yield parameters.
+C   - Reduced SOA/SOC ratio of AISO1 and AISO2 from 2.5 to 1.6, and
+C     increased SOA/SOC ratio of AISO3 from 2.5 to 2.7.  Accordingly,
+C     the molar masses of AISO1 and AISO2 were decreased to 96 g/mol
+C     and the molar mass of AISO3 was increased to 162.
+C
+C   Revised September 26, 2014 by Dr. Havala Pye
+C   - Removed previous acid enhanced isoprene SOA. Acid catalyzed
+C     isoprene SOA now follows Pye et al. 2013 ES&T uptake of IEPOX.
+C     See AEROSOL_CHEMISTRY and mech.def for IEPOX SOA.
+C   - Allowed for alternate method to NEWT for solving partitioning
+C     equations
+
+C References:
+C   1. Edney, E.O., T.E. Kleindienst, M. Lewandowski, and J.H.
+C      Offenberg, Updated SOA chemical mechanism for the Community
+C      Multi-Scale Air Quality model, EPA 600/X-07/025, U.S. EPA,
+C      Research Triangle Park, NC, 2007.
+
+C   2. Pankow, J. F., An absorption model of gas/particle partitioning
+C      of organic compounds in the atmosphere, Atmos. Environ., Vol 28,
+C      No 2, 185-188, 1994.
+
+C   3. Odum, J. R., T. Hoffmann, F. Bowman, D. Collins, R. C. Flagan,
+C      and J. H. Seinfeld, Gas/particle partitioning and secondary
+C      organic aerosol yields, Environ. Sci. Technol., Vol 30, No 8,
+C      2580-2585, 1996.
+
+C   4. Sheehan, P. E. and F. M. Bowman, Estimated effects of temperature
+C      on secondary organic aerosol concentrations, Environ. Sci.
+C      Technol., Vol 35, No 11, 2129-2135, 2001.
+
+C   5. Schell, B., I. J. Ackermann, H. Hass, F. S. Binkowski, and
+C      A. Abel, Modeling the formation of secondary organic aerosol
+C      within a comprehensive air quality modeling system, J. Geophys.
+C      Res., Vol 106, No D22, 28275-28293, 2001.
+
+C   6. Strader, R., F. Lurmann, and S. N. Pandis, Evaluation of
+C      secondary organic aerosol formation in winter, Atmos. Environ.,
+C      Vol 33, 4849-4863, 1999.
+
+C   7. Ng, N. L., J. H. Kroll, A. W. H. Chan, P. S. Chhabra, R. C.
+C      Flagan, and J. H. Seinfeld, Secondary organic aerosol formation
+C      from m-xylene, toluene, and benzene, Atmos. Chem. Phys., Vol 7,
+C      3909-3922, 2007a.
+
+C   8. Griffin, R. J., D. R. Cocker III, R. C. Flagan, and J. H.
+C      Seinfeld, Organic aerosol formation from the oxidation of
+C      biogenic hydrocarbons, J. Geophys. Res., Vol 104, No D3,
+C      3555-3567, 1999.
+
+C   9. Bian, F. and F. M. Bowman, Theoretical method for lumping
+C      multicomponent secondary organic aerosol mixtures, Environ.
+C      Sci. Technol., Vol 36, No 11, 2491-2497, 2002.
+
+C  10. Offenberg, J. H., T. E. Kleindienst, M. Jaoui, M. Lewandowski,
+C      and E. O. Edney, Thermal properties of secondary organic
+C      aerosols, Geophys. Res. Lett., Vol 33, L03816, doi:10.1029/
+C      2005GL024623, 2006.
+
+C  11. Bahreini, R., M. D. Keywood, N. L. Ng, V. Varutbangkul, S. Gao,
+C      R. C. Flagan, J. H. Seinfeld, D. R. Worsnop, and J. L. Jimenez,
+C      Measurements of secondary organic aerosol from oxidation of
+C      cycloalkenes, terpenes, and m-xylene using an Aerodyne aerosol
+C      mass spectrometer, Environ. Sci. Technol., Vol 39, 5674-5688,
+C      2005.
+
+C  12. Alfarra, M. R., D. Paulsen, M. Gysel, A. A. Gaforth, J. Dommen,
+C      A. S. H. Prevot, D. R. Worsnop, U. Baltensperger, and H. Coe,
+C      A mass spectrometric study of secondary organic aerosols formed
+C      from the photooxidation of anthropogenic and biogenic precursors
+C      in a reaction chamber, Atmos. Chem. Phys., Vol 6, 5279-5293,
+C      2006.
+
+C  13. Ng, N. L., P. S. Chhabra, A. W. H. Chan, J. D. Surratt, J. H.
+C      Kroll, A. J. Kwan, D. C. McCabe, P. O. Wennberg, A. Sorooshian,
+C      S. M. Murphy, N. F. Dalleska, R. C. Flagan, and J. H. Seinfeld,
+C      Effect of NOx level on secondary organic aerosol (SOA) formation
+C      from the photooxidation of terpenes, Atmos. Chem. Phys., Vol 7,
+C      5159-5174, 2007b.
+
+C  14. Kostenidou, E., R. K. Pathak, and S. N. Pandis, An algorithm for
+C      the calculation of secondary organic aerosol density combining
+C      AMS and SMPS data, Aerosol Sci. Technol., Vol 41, 1002-1010,
+C      2007.
+
+C  15. Offenberg, J. H., C. W. Lewis, M. Lewandowski, M. Jaoui, T. E.
+C      Kleindienst, and E. O. Edney, Contributions of toluene and
+C      alpha-pinene to SOA formed in an irradiated toluene/alpha-pinene/
+C      NOx/air mixture: comparison of results using 14C content and SOA
+C      organic tracer methods, Environ. Sci. Technol., Vol 41, 3972-
+C      3976, 2007.
+
+C  16. Henze, D. K. and J. H. Seinfeld, Global secondary organic aerosol
+C      from isoprene oxidation, Geophys. Res. Lett., Vol 33, L09812,
+C      doi:10.1029/2006GL025976, 2006.
+
+C  17. Kleindienst, T. E., M. Jaoui, M. Lewandowski, J. H. Offenberg,
+C      C. W. Lewis, P. V. Bhave, and E. O. Edney, Estimates of the
+C      contributions of biogenic and anthropogenic hydrocarbons to
+C      secondary organic aerosol at a southeastern US location, Atmos.
+C      Environ., Vol 41, 8288-8300, 2007.
+
+C  18. Kalberer, M., D. Paulsen, M. Sax, M. Steinbacher, J. Dommen,
+C      A. S. H. Prevot, R. Fisseha, E. Weingartner, V. Frankevich,
+C      R. Zenobi, and U. Baltensperger, Identification of polymers as
+C      major components of atmospheric organic aerosols, Science, Vol
+C      303, 1659-1662, 2004.
+
+C  19. Turpin, B. J. and H.-J. Lim, Species contributions to PM2.5 mass
+C      concentrations: revisiting common assumptions for estimating
+C      organic mass, Aero. Sci. Technol., Vol 35, 602-610, 2001.
+
+C  20. Surratt, J. D., M. Lewandowski, J. H. Offenberg, M. Jaoui, T. E.
+C      Kleindienst, E. O. Edney, and J. H. Seinfeld, Effect of acidity
+C      on secondary organic aerosol formation from isoprene, Environ.
+C      Sci. Technol., Vol 41, 5363-5369, 2007.
+
+C  21. Pye et al., Epoxide pathways improve model prediction of isoprene
+C      markers and reveal key role of acidity in aerosol formation,
+C      Environ. Sci. Technol., 2013.
+
+
+C Revision History:
+C    First orgaer version was coded in April 2010 by Steve Howard with
+C    Prakash Bhave, Jeff Young, and Sergey Napelenok.
+C
+C SH  03/10/11 Renamed met_data to aeromet_data
+C SR  03/25/11 Replaced I/O API include files with UTILIO_DEFN
+C HOTP 05Aug15 Made the calculation for total number of organic moles more robust
+C BNM 11/09/15 Added Some Comments to the SOA Scheme
+C-----------------------------------------------------------------------
+
+C Key Subroutines/Functions called:  newt, soabisection
+
+      Use aero_data
+      Use aeromet_data
+      Use utilio_defn
+      Use rxns_data, only : MECHNAME
+
+      Implicit None
+
+C Arguments:
+      Real    :: dt            ! Synchronization time step [ s ]
+      Integer :: layer         ! model layer number
+
+
+C Local variables:
+      Logical, Save :: first_time = .True.
+      Integer, Save :: logdev
+      Character( 300 ) :: xmsg
+      Integer       :: i, im, indx
+
+      Real, Save :: mwpoa                     ! Molecular weight of POA [ g/mol ]
+
+      Real, Allocatable, Save ::  mw_vap_m1( : )     ! Inverse MW of SVOCs [ mol/g ]
+
+      Real, Save ::  drog_ppm2ug( n_orgprod ) ! [ ppm per ug/m3 ] for ORGPROD at
+                                              ! reference temperature and pressure
+
+C Parameters & variables for adjusting cstar to ambient conditions
+      Real, Parameter :: tref   = 298.0          ! reference temperature [ K ]
+      Real, Parameter :: trefm1 = 1.0 / tref     ! inverse of reference temperature
+      Real, Parameter :: prefm1 = 1.0 / stdatmpa ! inverse of reference pressure
+      Real, Parameter :: rgas1  = 1.0 / rgasuniv ! reciprocal of universal gas constant
+      Real, Parameter :: kolig  = 0.69314718 / 72000.0  ! 20h half-life of oligomerization rate [ 1/s ]
+      Real, Parameter :: olgrat = 2.1            ! SOA/SOC ratio for oligomers
+      Real, Parameter :: kacid  = 0.00361        ! acid-induced enhancement factor
+      Real, Parameter :: threshmin = 1.0E-19     ! small positive number
+      Real, Parameter :: ctolmin = 1.0E-06
+      Real, Parameter :: convfac_298 = 101325.0 * rgas1 * trefm1  ! P/RT at 1 atm and 298 K [ mole/m**3 ]
+      Real, Parameter :: difforg = 9.36e-6  ! Diffusivity of organics [m2 s-1]
+      Real, Parameter :: alphorg = 1.0      ! accomodation coefficient
+
+      Real convfac
+      Real tt1, tt2      ! temperature-related factors
+      Real tempcorr      ! temperature correction factor for cstar
+
+C Variables used in oligomerization calculations
+      Real expdt         ! non-dimensional loss coefficient
+      Real nsvpa         ! particle-phase anthropogenic SVOC [ umolC/m3 ]
+      Real nsvpb         ! particle-phase biogenic SVOC [ umolC/m3 ]
+
+C Variables used in acid-enhanced isoprene SOA calculations
+      Real hplus         ! accumulation-mode H+ conc [ nmol/m3 ]
+      Real aiso12        ! particle-phase isoprene SVOC [ ug/m3 ]
+      Real vviso         ! vapor-phase isoprene SVOC [ ug/m3 ]
+      Real xiso3         ! newly produced AISO3J [ ug/m3 ]
+      Real isofrac       ! ratio for depletion of vapor-phase products
+
+C Variables used in equilibrium partitioning calculations
+      Real drog( n_orgprod ) ! change in precursor conc [ ug/m3 ]
+      Real totrog( n_vapor ) ! drog conc mapped to each SVOC [ ug/m3 ]
+      Real(8) GRtmp( n_mode )   ! Dummy variable for accurate treatment of growth to specific moment
+      Real GR3( n_vapor,n_mode ) ! 3rd Moment Growth for each mode and compound
+      Real GR3FRAC( n_vapor,n_mode ) ! Fraction of each mode growing/shrinking
+      Real c0    ( n_vapor ) ! cstar at AIRTEMP [ ug/m3 ]
+      Real caer0 ( n_vapor ) ! SVOC conc before current time step [ ug/m3 ]
+      Real ctoti ( n_vapor ) ! SVOC conc before current time step [ ug/m3 ]
+      Real prod  ( n_vapor ) ! SVOC generated during current step [ ug/m3 ]
+      Real ctotf ( n_vapor ) ! SVOC conc after current time step [ ug/m3 ]
+      Real caer  ( n_vapor ) ! SVOC conc in aerosol phase [ ug/m3 ]
+      Real dcaer ( n_vapor ) ! Change in SVOC conc after partitioning happens[ ug/m3 ]
+      Real cbar_org(n_vapor) ! On-line molecular speed of each organic
+      Real dv_org            ! On-line gas-phase diffusivity of each organic
+      Real totorgsw          ! POA + non-volatile SOA [ umole/m3 ]
+      Real totorg            ! SOA + POA before time step [ umole/m3 ]
+      Real threshold         ! criterion for establishing gas/part equil.
+      Real faer              ! fraction of total in aerosol, intermediate value
+      Logical check          ! flag to indicate if NEWT subroutine
+                             ! converged to a spurious root
+      Real totaer            ! total aerosol-phase mass of each semivolaitle component
+      Real Phi               ! mass fraction of a semivolatile component
+                             ! in each mode
+
+C Variables for updating 2nd and 3rd moments
+      Real(8) m0_init( 2 )  ! initial 0 moment, wet [ mom/m3 ]
+      Real(8) m1wet_init( 2 )  ! initial 1st moment, wet [ mom/m3 ]
+      Real(8) m2wet_initD( 2 )  ! initial 2nd moment, wet [ mom/m3 ]
+      Real m3wet_init( 2 )  ! initial 3rd moment, wet [ mom/m3 ]
+      Real m2wet_init( 2 )  ! initial 2nd moment, wet [ mom/m3 ]
+      Real m3wet_final( 2 )  ! final 3rd moment with updated SOA [ mom/m3 ]
+      Real m2wet_final( 2 )  ! final 2nd moment with updated SOA [ mom/m3 ]
+
+C Added for new SOA bisection (hotp 7/6/11)
+      Real               :: lowb, upb, orgmoles      ! lower bound, upper bound, total aerosol moles
+      Logical, Parameter :: newtpartition = .False.   ! true to use original method, false to use new bisection
+
+C-----------------------------------------------------------------------
+
+      If ( first_time )  Then
+         first_time = .False.
+         logdev = setup_logdev()
+
+C Set unit conversion and inverse mw constants
+         drog_ppm2ug( : ) = orgprod_mw( : ) * convfac_298
+         Allocate( mw_vap_m1( n_vapor ) )
+         mw_vap_m1( : ) = 1.0 / vapor_mw( : )
+         mwpoa = aerospc_mw( apoc_idx )
+
+      End If ! first_time
+
+C Set temperature factors
+      tt1 = tref / airtemp
+      tt2 = trefm1 - 1.0 / airtemp
+      convfac = tt1 * airpres * prefm1
+
+C Set Mass Transfer Properties (although each condensing organic
+C will have its own diffusivity and molecular speed, just assume
+C as a first guess that they are all uniform and given by a rep-
+C resentative compound.
+      Dv_org = difforg * ( STDATMPA / AIRPRES ) * ( AIRTEMP / 273.16 ) ** 1.75
+      cbar_org( : ) = SQRT(8.0 * RGASUNIV * AIRTEMP / ( PI * vapor_mw(:) * 1.0E-3 ) )
+ 
+C Compute 3rd moment, 2nd moment. moment_conc arrays are wet
+      Call calcmoments ( .true. )
+      Call getpar( FIXED_sg )
+
+      m3wet_init( : ) = moment3_conc( 1:2 )
+      m2wet_init( : ) = moment2_conc( 1:2 )
+        
+      GR3( :,: ) = 0.0
+      m0_init( : )    = Real( moment0_conc( 1:2 ), 8 )
+      m2wet_initD( : ) = Real( m2wet_init( 1:2 ), 8 )
+
+      Do im = 1,2
+        m1wet_init( im ) = m0_init( im ) * aeromode_diam( im ) * 
+     &                         exp( 0.5d0 * aeromode_lnsg( im ) ** 2.0d0 )
+
+        Do i = 1, n_vapor
+          If ( aero_missing( soa_aeroMap( i ),im ) ) Cycle
+          
+          Call HCOND3( m0_init( im ), m1wet_init( im ),
+     &                 m2wet_initD( im ), Dv_org, alphorg, cbar_org(i), GRtmp )
+          GR3( i,im ) = Real( GRtmp( 2 ), 4 )
+        End Do
+      End Do
+      
+      ! Calculate fraction of mass transfer to/from each mode
+      GR3FRAC( :,: ) = 0.0
+      Where ( GR3( :,1 ) .gt. 0. ) 
+     &    GR3FRAC( :,1 ) = GR3( :,1 ) / ( GR3(:,1) + GR3(:,2) ) ! Aitken Growth
+      Where ( GR3( :,2 ) .gt. 0. )
+     &    GR3FRAC( :,2 ) = GR3( :,2 ) / ( GR3(:,1) + GR3(:,2) ) ! Accumulation Growth
+
+C Initialize drog from ORGPROD and change units to [ ug / m**3 ]
+      drog( : ) = orgprod_conc( : ) * drog_ppm2ug( : ) * convfac
+
+C Assignment of drog to totrog. This moving mass from the reactive
+C gas tracer species to the array that will be multiplied by alpha
+C to give newly formed semivolatile vapors.
+      totrog( : ) = 0.0
+      Do i = 1, n_vapor
+         If ( drog_map( i ) .Gt. 0 ) Then
+           totrog( i ) = drog( drog_map( i ) )
+         End If
+      End Do
+
+C Transfer non-volatile products directly to aerospc_conc array (2nd mode)
+      Do i = 1, n_orgprod
+         If ( orgprod_aeroMap( i ) .Gt. 0 ) Then
+            aerospc_conc( orgprod_aeroMap( i ),2 ) =
+     &      aerospc_conc( orgprod_aeroMap( i ),2 )
+     &      + orgprod( i )%alphaH * drog( i )
+         End If
+      End Do
+
+#ifdef Oligo_aero
+C Oligomerization
+
+C Convert semi-volatile SOA to non-volatile oligomers by an exponential decay
+C process that conserves carbon mass.
+
+      nsvpa = 0.0
+      nsvpb = 0.0
+
+      Do i = 1, n_vapor
+         If( soa_aeroMap( i ) .lt. 1 )Cycle
+         If ( vaporspc( i )%soa_origin .Eq. 'A' )
+     &      nsvpa = nsvpa + aerospc_conc( soa_aeroMap( i ),2 )
+     &            * mw_vap_m1( i ) * vaporspc( i )%soa_decay
+         If ( vaporspc( i )%soa_origin .Eq. 'B' )
+     &      nsvpb = nsvpb + aerospc_conc( soa_aeroMap( i ),2 )
+     &            * mw_vap_m1( i ) * vaporspc( i )%soa_decay
+      End Do
+
+      expdt = exp( - kolig * dt )
+
+      Do i = 1, n_vapor
+         If( soa_aeroMap( i ) .lt. 1 )Cycle
+         aerospc_conc( soa_aeroMap( i ),2 ) =
+     &   aerospc_conc( soa_aeroMap( i ),2 ) * expdt
+      End Do
+
+      aerospc_conc( aolga_idx,2 ) = aerospc_conc( aolga_idx,2 )
+     &                            + 12.0 * nsvpa * ( 1.0 - expdt ) * olgrat
+      aerospc_conc( aolgb_idx,2 ) = aerospc_conc( aolgb_idx,2 )
+     &                            + 12.0 * nsvpb * ( 1.0 - expdt ) * olgrat
+
+#endif
+C Compute molar concentrations of non-volatile organic material and total
+C organic material; in future code updates, molecular weights of non-volatile
+C SOA species should be inherited from the include files or namelists to avoid
+C hard-coded values.
+
+      totorgsw = 0.0  
+
+      ! First Sum Up POA Species if this the NON-Volatile POA Mechanism
+      If ( INDEX( MECHNAME, 'NVPOA' ) .Ne. 0 ) Then
+         totorgsw = ( aerospc_conc(   apoc_idx,1 ) + aerospc_conc(   apoc_idx,2 )) / aerospc_mw( apoc_idx )
+     &             +( aerospc_conc( apncom_idx,1 ) + aerospc_conc( apncom_idx,2 )) / aerospc_mw( apncom_idx )
+      End If
+
+      ! Sum Up Nonvolatile OA. This is just a couple of SOA products.
+      ! They are in the orgprd table.
+      Do i = 1, n_aerospc
+         If(  aerospc( i )%tracer ) Cycle
+         If ( aerospc( i )%nonVol_soa ) Then
+            totorgsw = totorgsw + aerospc_conc( i,2 ) / aerospc_mw( i )
+         End If
+      End Do
+
+      ! Sum Up all other OA species. This is most of them. They are in
+      ! the vaporspc table.
+      totorg = totorgsw
+      Do i = 1, n_vapor
+         If( soa_aeroMap( i ) .lt. 1 ) Cycle
+         totorg = totorg + ( aerospc_conc( soa_aeroMap( i ),2 ) + 
+     &              aerospc_conc( soa_aeroMap( i ),1 ) ) * mw_vap_m1( i )
+      End Do
+
+C Initialize ctoti as sum of vapor-phase and particle-phase SVOCs
+C Note: all of these CBLK species are in [ug/m**3]
+      Do i = 1, n_vapor
+         If( soa_aeroMap( i ) .lt. 1 ) Cycle
+         ctoti( i ) = vapor_conc( i ) + aerospc_conc( soa_aeroMap( i ),2 )  
+     &                + aerospc_conc( soa_aeroMap( i ),1 )
+         caer0( i ) = aerospc_conc( soa_aeroMap( i ),2 )  
+     &                + aerospc_conc( soa_aeroMap( i ),1 )
+      End Do
+
+C Equilibrium Partitioning Calculations
+
+C Initial guess of caer is computed as follows:
+C    From eqn (8) of Schell et al. (2001)
+C    caer = ctotf - c0 * (caer/MW) / totorg
+C    Assuming totorg doesn't change during the timestep,
+C    caer * (1 + c0/MW / totorg) = ctotf
+C    caer = ctotf / ( 1 + c0/MW / totorg )
+
+      threshold = 0.0  ! This threshold will be compared to the
+                       ! saturation concentration to determine whether
+                       ! or not OA partitioning is even likely.
+      upb = 0.0  ! Upper bound for bisection method
+
+      Do i = 1, n_vapor
+         tempcorr   = tt1 * Exp( vaporspc( i )%enth * rgas1 * tt2 )
+         c0( i )    = vaporspc( i )%cstar * tempcorr        ! Satn Conc.
+         prod( i )  = vaporspc( i )%alpha * totrog( i )     ! Total Vapor Produced
+         ctotf( i ) = ctoti( i ) + prod( i )                ! Vapor + Particle
+         threshold  = threshold +  ctotf( i ) / c0( i )
+         faer       = totorg                                ! initial fraction in aerosol
+     &              / (totorg + c0( i ) * mw_vap_m1( i ) )  
+         caer( i )  = ctotf( i ) * faer                     ! initial amount in aerosol
+         upb        = upb + ctotf( i) * mw_vap_m1( i )      ! upper: all moles (semi and nonvolatile)
+      End Do
+
+C Check If gas/particle equilibrium can be established
+      If ( ( threshold .Gt. 1.0 ) .Or. ( totorgsw .Gt. threshmin ) ) Then
+
+C Perform one of two methods for partitioning
+        If ( newtpartition ) Then
+
+C METHOD1
+C Calculate new SOA by partitioning. This method uses a globally convergent
+C Newton-Raphson method coded by Dr Benedikt Schell to solve the nonlinear
+C quadratic system shown in eqn 8 of Schell et al:
+C    A(i)  * caer(i) ** 2 + B * caer(i) + C(i) = 0.0,
+C    where B(i) contains the sum of all caer(j), for j not equal to i.
+
+         Call newt( layer, caer, n_vapor, check,
+     &              ctotf, c0, mw_vap_m1, totorgsw )
+         If ( check ) Then
+C Try again with initial guess of 50/50 gas/aerosol split.
+            Do i = 1, n_vapor
+               caer( i ) = 0.5 * ctotf( i )
+            End Do
+            Call newt( layer, caer, n_vapor, check,
+     &                 ctotf, c0, mw_vap_m1, totorgsw )
+            If ( check ) Then
+               Write( xmsg,'( A,I4 )' ) ' *** Problem in NEWT at Layer = ', layer
+               Call m3exit( pname, 0, 0, xmsg, xstat3 )
+            End If
+         End If
+
+C METHOD2
+C      Calculate new SOA by partitioning.
+C      Method uses bisection method to solve for total number of moles
+C      of orgaic aerosol. Caer is then calculated based on that number.
+        Else
+
+C        Solve for total number of organic moles in aerosol (hotp 7/5/11)
+         lowb      = totorgsw   ! lower: moles of nonvolatile
+         upb       = lowb + upb ! upper: all moles (semi and nonvolatile)
+         upb       = upb * ( 1.0 + 1e-7*n_vapor ) ! prevent numerical issues
+         If ( abs( upb - lowb ) .Lt. threshmin ) Then
+            ! no SOA to partition
+            orgmoles = ( lowb + upb ) / 2.0
+         Else
+            orgmoles  = soabisect( lowb, upb, totorgsw, c0, ctotf, vapor_mw )
+         End If
+
+C        Determine concentration of each semivoltile (hotp 7/5/11)
+         Do i = 1, n_vapor
+            faer    = vapor_mw(i) * orgmoles / ( c0(i) + vapor_mw(i) * orgmoles )
+            caer(i) = ctotf(i) * faer
+         End Do
+
+C End SOA paritioning solver METHOD selection
+        End If
+
+C Constrain caer to values between conmin and ctotf
+        Do i = 1, n_vapor
+
+           If ( soa_aeroMap( i ) .Lt. 1 )Then
+               caer( i ) = 0.0
+               Cycle
+           End If
+
+           If ( caer( i ) .Lt. 0.0 ) Then
+                  Write( logdev,* ) 'caer negative at i: ', i, caer( i ),
+     &                              ' reset to evapmin'
+           End If
+           caer( i ) = max( caer(i), evapmin )
+
+           If ( caer( i ) - ctotf( i ) .Gt. ctolmin ) Then
+               Write( logdev,* ) 'caer-ctotf exceeds ctolmin at i = ', i
+               Write( logdev,* ) 'caer: ', caer( i ), ' ctotf: ', ctotf( i )
+               Write( logdev,* ) 'caer reset to ctotf'
+               caer( i ) = ctotf( i )
+           End If
+
+           indx = soa_aeroMap( i )
+
+           ! Calculate total change in OA Species Concentration
+           dcaer( i ) = caer( i ) - caer0( i )  
+
+           ! Sum the total aerosol mass of this compound across all
+           ! aerosol modes
+           totaer = max( sum( aerospc_conc( indx,: ) , mask = 
+     &                 .NOT.aero_missing( indx,: ) ), conmin )
+    
+           ! Transfer the semivolatile mass
+           Do im = 1,2
+              If ( aero_missing( soa_aeroMap( i ),im ) ) Cycle
+              If ( dcaer( i ) .lt. 0.0 ) Then
+                 ! Evaporate using mode-dependent mass fraction
+                 Phi = aerospc_conc( indx,im ) / totaer
+                 aerospc_conc( indx,im ) = 
+     &                aerospc_conc( indx,im ) + dcaer( i ) * Phi
+              Else
+                 ! Condense using mode-dependent condensaiton flux 
+                 ! fraction
+                 aerospc_conc( indx,im ) = aerospc_conc( indx,im ) 
+     &                + dcaer( i ) * GR3FRAC( i,im )
+              End If
+           End Do
+        End Do  ! Partitioning Vapor Loop
+ 
+      Else   ! threshold not exceeded; no material transferred to aerosol phase
+        
+        caer = 0.0
+        Do i = 1, n_vapor
+            If ( soa_aeroMap( i ) .Lt. 1 ) Cycle
+            indx = soa_aeroMap( i )
+            aerospc_conc( indx, 1:n_mode ) = conmin
+            Do im = 1, n_mode
+              If ( .Not. aero_missing( indx,im ) ) Then
+                  caer( i ) =  conmin + caer( i )
+              End If
+            End Do
+        End Do
+
+      End If    ! check on equilibrium threshold
+
+C Update Vapor-Phase Organic Species
+      vapor_conc( : ) = ctotf( : ) - caer( : )
+
+
+C Acid-induced Isoprene SOA if IEPOX uptake is not considered mechanism reactions
+      If ( .Not. IEPOX_SOA_mechanism ) Then
+
+C Particle-phase acidity is parameterized by the air concentration of hydrogen
+C ion in the particle phase (hplus).  This is computed by electroneutrality,
+C and is bounded so that it cannot fall below zero (acid-neutral) nor above the
+C range of experimental conditions (530 nmol/m3) tested by Surratt et al.
+C (2007).  In future code updates, molecular weights of inorganic ions should
+C be inherited from include or namelist files to avoid hard-coded values.
+
+      hplus = 0.0
+      Do i = 1, n_aerospc
+         If ( aerospc( i )%tracer ) Cycle
+         hplus = hplus - 1000.0 * aerospc( i )%charge * aerospc_conc( i,2 )
+     &         / aerospc_mw( i )
+      End Do
+      hplus = Min( 530.0, Max ( 0.0, hplus ) ) ! restrict extrapolation
+
+C Compute amount of acid-enhanced isoprene SOA that is produced during the current
+C time step (xiso3) using the normalized expression derived from Surratt et al. (2007)
+
+      aiso12 = aerospc_conc( aiso1_idx, 2 ) + aerospc_conc( aiso2_idx, 2 )
+      xiso3  = kacid * hplus * aiso12 - aerospc_conc( aiso3_idx,2 )
+
+C Update CBLK(VISO3J) while conserving the total concentration of low-volatility
+C isoprene-derived products.  Since the acid-enhanced product is assumed to be
+C non-volatile, only positive values of xiso3 are considered below.  Also, xiso3
+C is not allowed to exceed the vapor-phase concentration of isoprene SVOC.  We assume
+C the xiso3 mass is depleted from the 2 vapor-phase isoprene products in quantities
+C proportional to their equilibrium concentrations.  The factor of 2.7/1.6 accounts
+C for the enhancement in the OM/OC ratio when isoprene SOA is formed in the presence
+C of SO2, based on the lab experiments of Kleindienst et al. (2007)
+
+      If ( xiso3 .Gt. 0.0 ) Then
+         vviso = vapor_conc( iso1_idx ) + vapor_conc( iso2_idx )
+         xiso3  = Min( xiso3, vviso )
+         aerospc_conc( aiso3_idx,2 ) = aerospc_conc( aiso3_idx,2 ) + xiso3 * ( 2.7 / 1.6 )
+         isofrac = vapor_conc( iso1_idx ) / vviso
+         vapor_conc( iso1_idx ) = vapor_conc( iso1_idx ) - isofrac * xiso3
+         vapor_conc( iso2_idx ) = vapor_conc( iso2_idx ) - ( 1.0 - isofrac ) * xiso3
+      End If
+
+      End If ! IEPOX not present for uptake
+
+C Update 3rd moment, 2nd moment, and Dg in CBLK array by assuming that SOA
+C condensation/evaporation does not affect the geometric standard deviation.
+
+      ! Get new third moment of all species, do not get second moment
+      ! directly from the calcmoments diagnostic. Instead, update it
+      ! manually to account for condensation in ORGAER.
+      Call calcmoments( .true. )
+      m3wet_final( : ) = moment3_conc( 1:2 )
+      m2wet_final( 1 ) = m2wet_init( 1 ) * ( m3wet_final( 1 ) / m3wet_init( 1 ) ) ** ( 2.0 / 3.0 )
+      m2wet_final( 2 ) = m2wet_init( 2 ) * ( m3wet_final( 2 ) / m3wet_init( 2 ) ) ** ( 2.0 / 3.0 )
+      moment2_conc( 1:2 )  = m2wet_final( : )
+
+      Return
+      End Subroutine orgaer
+
+C-----------------------------------------------------------------------
+      SUBROUTINE NEWT( LAYER, X, N, CHECK,
+     &                 CTOT, CSAT, IMWCV, MINITW )
+
+C  Description:
+C   This subroutine and the underlying subprograms constitute Dr.
+C   Benedikt Schell's SOA model.
+C
+C  Adopted from Numerical Recipes in FORTRAN, Chapter 9.7, 2nd ed.
+C
+C  Given an initial guess X(1:N) for a root in N dimensions, find
+C  the root by a globally convergent Newton's method. The vector of
+C  functions to be zeroed, called FVEC(1:N) in the routine below, is
+C  returned by a user-supplied subroutine that must be called FUNCV
+C  and have the declaration SUBROUTINE FUNCV(N,X,FVEC). The output
+C  quantity CHECK is false on a normal return and true if the
+C  routine has converged to a local minimum of the function FMINV
+C  defined below. In this case, user should try restarting from a
+C  different initial guess.
+C
+C  Key Subroutines Called: FDJAC, FMINV, LNSRCH, LUBKSB, LUDCMP
+C
+C  Revision History:
+C     In CMAQ v4.3 - v4.7.1, this subroutine was embedded in a separate
+C     Fortran module entitled SOA_NEWT.  Below, the Revision History from
+C     the SOA_NEWT module has been merged with the Revision History from
+C     this specific subroutine.
+C
+C CGN 01/12/04 removed ITS from call vector, added documentation, and
+C     removed extraneous lines of code
+C
+C SLN 09/18/07 updated NP and NPREC for compatibility with new SOA module
+C
+C PVB 11/19/07 renamed NP to NCVAP for consistency with ORGAER5 subroutine
+C
+C SH  02/10/10 embedded the old Fortran module, SOA_NEWT, into a new module,
+C     SOA_DEFN, so all SOA-related code can be found in one file.  Renamed
+C     NCVAP to n_vapor.  Its value is now set in SOA_DEFN (instead of inside
+C     this subroutine).  Added TOLX to the call vector of Subroutine LNSRCH,
+C     since that parameter is now set in this subroutine (instead of in the
+C     Fortran module).
+C
+C  References:
+C   1. Schell, B., I. J. Ackermann, H. Hass, F. S. Binkowski, and
+C      A. Abel, Modeling the formation of secondary organic aerosol
+C      within a comprehensive air quality modeling system, J. Geophys.
+C      Res., Vol 106, No D22, 28275-28293, 2001.
+
+      IMPLICIT NONE
+
+C  Arguments
+
+      INTEGER LAYER      ! model layer
+      INTEGER N          ! dimension of problem
+      REAL X( N )        ! initial guess of CAER
+      LOGICAL CHECK
+      REAL CTOT( N )     ! total concentration GAS + AER + PROD
+      REAL CSAT( N )     ! saturation conc. of cond. vapor [ug/m^3]
+      REAL IMWCV( N )    ! inverse molecular weights
+      REAL MINITW        ! weighted initial mass
+
+C  Following Numerical recipes
+
+      Integer NN
+      REAL :: FVEC( N )               ! vector of functions to be zeroed
+      ! COMMON /NEWTV/ FVEC(n_vapor), NN
+      ! SAVE /NEWTV/
+
+C  Parameters
+      INTEGER, PARAMETER :: MAXITS = 100  ! maximum number of iterations
+      REAL, PARAMETER :: TOLF = 1.0E-09   ! convergence criterion on fxn values
+      REAL, PARAMETER :: TOLMIN = 1.0E-12 ! criterion whether spurious conver-
+                                          ! gence to a minimum has occurred
+      REAL, PARAMETER :: TOLX = 1.0E-10   ! convergence criterion on delta_x
+      REAL, PARAMETER :: STPMX = 100.0    ! scaled maximum step length allowed
+
+C  Local variables
+      REAL :: CT( N ), CS( N ), IMW( N ), M
+      ! REAL CS
+      ! REAL IMW
+      ! REAL M
+      ! COMMON /NEWTINP/ CT( N_VAPOR ), CS( N_VAPOR ), IMW( N_VAPOR ), M
+      ! SAVE /NEWTINP/
+
+      INTEGER I, ITS, J, INDX( N_VAPOR )
+      REAL D, DEN, F, FOLD, STPMAX, SUM, TEMP, TEST
+      REAL FJAC( N_VAPOR,N_VAPOR )
+      REAL G( N_VAPOR), P( N_VAPOR ), XOLD( N_VAPOR )
+!     EXTERNAL FDJAC
+
+C-----------------------------------------------------------------------
+
+      CHECK = .FALSE.
+      M = MINITW
+      DO I = 1, N
+         CT( I ) = CTOT( I )
+         CS( I ) = CSAT( I )
+         IMW( I ) = IMWCV( I )
+      END DO
+
+      NN = N
+      CALL FMINV( X,F,NN,FVEC,CT,CS,IMW,M )  ! The vector FVEC is also computed by this call
+      TEST = 0.0              ! Test for initial guess being a root. Use more
+                              ! stringent test than simply TOLF.
+      DO I = 1, N
+         IF ( ABS( FVEC( I ) ) .GT. TEST ) TEST = ABS( FVEC( I ))
+      END DO
+
+      IF ( TEST .LT. 0.01 * TOLF ) RETURN  ! initial guess is a root
+      SUM = 0.0                    ! Calculate STPMAX for line searches
+      DO I = 1, N
+         SUM = SUM + X( I ) ** 2
+      END DO
+      STPMAX = STPMX * MAX( SQRT( SUM ), FLOAT( N ) )
+      DO ITS = 1, MAXITS           ! start of iteration loop
+         CALL FDJAC( N, X, FJAC, CT, CS, IMW, M )  ! get Jacobian
+         DO I = 1, N               ! compute Delta f for line search
+            SUM = 0.0
+            DO J = 1, N
+               SUM = SUM + FJAC( J,I ) * FVEC( J )
+            END DO
+            G( I ) = SUM
+         END DO
+         DO I = 1, N               ! store X
+            XOLD( I ) = X( I )
+         END DO
+         FOLD = F                  ! store F
+         DO I = 1, N               ! right-hand side for linear equations
+            P( I ) = -FVEC( I )
+         END DO
+         CALL LUDCMP( FJAC, N, INDX, D ) ! solve linear equations by LU decomposition
+         CALL LUBKSB( FJAC, N, INDX, P )
+         CALL LNSRCH( CTOT,
+     &                N, XOLD, FOLD, G,  ! LNSRCH returns new X and F. It also
+     &                P, X, F, STPMAX,   ! calculates FVEC at the new X when it
+     &                TOLX, CHECK, FVEC,
+     &                CT, CS, IMW, M)      ! calls FMINV
+         TEST = 0.0
+         DO I = 1, N
+            IF ( ABS( FVEC( I ) ) .GT. TEST ) TEST = ABS( FVEC( I ) )
+         END DO
+         IF ( TEST .LT. TOLF ) THEN
+            CHECK = .FALSE.
+            RETURN
+         END IF
+         IF ( CHECK ) THEN        ! Check for gradient of F zero,
+            TEST = 0.0            ! i.e., spurious convergence.
+            DEN = MAX( F, 0.5 * N )
+            DO I = 1, N
+               TEMP = ABS( G( I ) ) * MAX( ABS( X( I ) ), 1.0 ) / DEN
+               IF ( TEMP .GT. TEST ) TEST = TEMP
+            END DO
+            IF ( TEST .LT. TOLMIN ) THEN
+               CHECK = .TRUE.
+            ELSE
+               CHECK = .FALSE.
+            END IF
+            RETURN
+         END IF
+         TEST = 0.0             ! Test for convergence on delta_x
+         DO I = 1, N
+            TEMP = ( ABS( X( I ) - XOLD( I ) ) ) / MAX( ABS( X( I ) ), 1.0 )
+            IF ( TEMP .GT. TEST ) TEST = TEMP
+         END DO
+         IF ( TEST .LT. TOLX ) RETURN
+      END DO
+      WRITE( *,'(a,i2)' ) 'MAXITS exceeded in NEWT ! Layer: ', LAYER
+      END SUBROUTINE NEWT
+
+C-----------------------------------------------------------------------
+      SUBROUTINE FDJAC( N, X, FJAC, CT, CS, IMW, M )
+
+C  Description:
+C    Get the Jacobian of the function
+
+C          ( a1 * X1^2 + b1 * X1 + c1 )
+C          ( a2 * X2^2 + b2 * X2 + c2 )
+C          ( a3 * X3^2 + b3 * X3 + c3 )
+C   F(X) = ( a4 * X4^2 + b4 * X4 + c4 ) = 0.0
+C          ( ........................ )
+C          ( aN * XN^2 + bN * XN + cN )
+C
+C    a_i = IMW_i
+C    b_i = SUM(X_j * IMW_j)_j.NE.i + CSAT_i * IMW_i  + M
+C          - CTOT_i * IMW_i
+C
+C    c_i = - CTOT_i * [ SUM(X_j * IMW_j)_j.NE.i + M ]
+C
+C           delta F_i    ( 2. * a_i * X_i + b_i          If i .EQ. j
+C   J_ij = ----------- = (
+C           delta X_j    ( ( X_i  - CTOT_i ) * IMW_j     If i .NE. j
+
+C Revision History:
+C   CGN 01/12/04 changed B1 & B2 to scalars
+C   SH  02/10/10 renamed NCVAP to n_vapor. Value is inherited from SOA_DEFN.
+
+      IMPLICIT NONE
+
+      INTEGER N                 ! dimension of problem
+      REAL X( N )               ! initial guess of CAER
+
+      REAL CT( N )
+      REAL CS( N )
+      REAL IMW( N )
+      REAL M
+
+      REAL FJAC( N,N )
+
+      INTEGER I, J              ! loop index
+      REAL A( N_VAPOR )
+      REAL B( N_VAPOR )
+      REAL B1
+      REAL B2
+      REAL SUM_JNEI
+
+      DO I = 1, N
+         A( I ) = IMW( I )
+         SUM_JNEI = 0.0
+         DO J = 1, N
+            SUM_JNEI = SUM_JNEI + X( J ) * IMW( J )
+         END DO
+         B1 = SUM_JNEI - ( X( I ) * IMW( I ) )
+         B2 = ( CS( I ) - CT( I ) ) * IMW( I ) + M
+         B( I ) = B1 + B2
+      END DO
+      DO J = 1, N
+         DO I = 1, N
+            IF ( I .EQ. J ) THEN
+               FJAC( I,J ) = 2.0 * A( I ) * X( I ) + B( I )
+            ELSE
+               FJAC( I,J ) = ( X( I ) - CT( I ) ) * IMW( J )
+            END IF
+         END DO
+      END DO
+
+      RETURN
+      END SUBROUTINE FDJAC
+
+C-----------------------------------------------------------------------
+      SUBROUTINE FMINV( X,F,N,FVEC, CT, CS, IMW, M )
+
+C Description:
+C    Returns f = 0.5 * F*F at X. SR FUNCV(N,X,F) is a fixed-name,
+C    user-supplied routine that returns the vector of functions at X.
+C    The common block NEWTV communicates the function values back to
+C    NEWT.
+
+C Adopted from Numerical Recipes in FORTRAN, Chapter 9.7, 2nd ed.
+
+C Key Subroutines Called: FUNCV
+
+C Revision History:
+C   YOJ 07/31/02 changed FUNCTION FMIN to SUBROUTINE FMINV to avoid errors
+C       with (some) compilers
+C   SH  02/10/10 renamed NCVAP to n_vapor. Value is inherited from SOA_DEFN.
+
+      IMPLICIT NONE
+
+      INTEGER N
+
+      REAL X( * ), F
+      REAL :: FVEC( N ), CT( N ), CS( N ), IMW( N ), M
+
+      INTEGER I
+      REAL SUM
+      CALL FUNCV( N, X, FVEC, CT, CS, IMW, M )
+      SUM = 0.0
+      DO I = 1, N
+         SUM = SUM + FVEC( I ) ** 2
+      END DO
+      F = 0.5 * SUM
+      RETURN
+      END SUBROUTINE FMINV
+
+C-----------------------------------------------------------------------
+      SUBROUTINE FUNCV( N, X, FVEC, CT, CS, IMW, M )
+
+C Description:
+C   From Equation (8) of Schell et al., 2001:
+C     Caer,i = Ctot,i - Csat,i * (Caer,i/MWi) /
+C                             ( sum_j (Caer,j/MWj) + Cinit/MWinit)
+C   Let Xi  = Caer,i
+C       a_i = 1 / MWi
+C       M   = Cinit/MWinit
+C       CTi = Ctot,i
+C       CSi = Csat,i
+C   Then,
+C       Xi  = CTi - CSi * (a_i * Xi) / ( sum_j (a_j * Xj) + M )
+C
+C   Multiply above equation by sum_j(a_j*Xj) + M and group terms
+C       a_i Xi^2 + ( sum_jnei (a_j*Xj) + M + CSi*a_i - CTi*a_i ) Xi
+C                - CTi * ( sum_jnei (a_j*Xj) + M ) = 0
+C
+C   This equation is of the form F(X) = a_i*Xi^2 + b_i*Xi + c_i = 0.
+C     F(X) is stored as FVEC in this subroutine.
+C
+C   See also FDJAC.
+
+C Key Subroutines Called: none
+
+C Revision History:
+C CGN 01/12/04  Added documentation, removed extraneous lines of code
+C SH  02/10/10 renamed NCVAP to n_vapor.  Value is inherited from SOA_DEFN
+
+C References:
+C   1. Schell, B., I. J. Ackermann, H. Hass, F. S. Binkowski, and
+C      A. Abel, Modeling the formation of secondary organic aerosol
+C      within a comprehensive air quality modeling system, J. Geophys.
+C      Res., Vol 106, No D22, 28275-28293, 2001.
+
+      IMPLICIT NONE
+
+      INTEGER N
+      REAL X( * )
+      REAL FVEC( N )
+
+      REAL CT( N )
+      REAL CS( N )
+      REAL IMW( N )
+      REAL M
+
+      INTEGER I, J
+      REAL SUM_JNEI
+      REAL A( N_VAPOR )
+      REAL B( N_VAPOR )
+      REAL C( N_VAPOR )
+
+      DO I = 1, N
+         A( I ) = IMW( I )
+         SUM_JNEI = 0.0
+         DO J  = 1, N
+            SUM_JNEI = SUM_JNEI + X( J ) * IMW( J )
+         END DO
+         SUM_JNEI = SUM_JNEI - ( X( I ) * IMW( I ) )
+         B( I ) = SUM_JNEI + M + ( CS( I ) - CT( I ) ) * IMW( I )
+         C( I ) = -CT( I ) * ( SUM_JNEI + M )
+         FVEC( I ) = X( I ) * ( A( I ) * X( I ) + B( I ) ) + C( I )
+      END DO
+
+      RETURN
+      END SUBROUTINE FUNCV
+
+C-----------------------------------------------------------------------
+      SUBROUTINE LNSRCH( CTOT,
+     &                   N, XOLD, FOLD, G, P,
+     &                   X, F, STPMAX, TOLX, CHECK, FVEC,
+     &                   CT, CS, IMW, M )
+
+C Description:
+C   Given an n-dimensional point XOLD(1:N), the value of the function
+C   and gradient there, FOLD and G(1:N), and a direction P(1:N),
+C   finds a new point X(1:N) along the direction P from XOLD where
+C   the function FUNC has decreased 'sufficiently'. The new function
+C   value is returned in F. STPMAX is an input quantity that limits
+C   the length of the steps so that you do not try to evaluate the
+C   function in regions where it is undefined or subject to overflow.
+C   P is usually the Newton direction. The output quantity CHECK is
+C   false on a normal exit. It is true when X is too close to XOLD.
+C   In a minimization algorithm, this usually signals convergence and
+C   can be ignored. However, in a zero-finding algorithm the calling
+C   program should check whether the convergence is spurious.
+C
+C  Adopted from Numerical Recipes in FORTRAN, Chapter 9.7, 2nd ed.
+
+C Key Subroutines Called: FUNCV
+
+C Revision History:
+C   SH  02/10/10 added TOLX to the call vector.  In previous versions, this
+C       parameter was declared in the Module SOA_NEWT (which contained this
+C       subroutine).
+
+      IMPLICIT NONE
+
+      INTEGER N
+      REAL TOLX
+      LOGICAL CHECK
+      REAL F, FOLD, STPMAX
+      REAL G( N ), P( N ), X( N ), XOLD( N )
+      REAL CTOT( N )
+      REAL, PARAMETER :: ALF = 1.E-04
+      REAL, PARAMETER :: CONMIN = 1.E-30
+      REAL :: FVEC( N ), CT( N ), CS( N ), IMW( N ), M
+
+      INTEGER I
+      REAL A, ALAM, ALAM2, ALAMIN, B, DISC
+      REAL F2, FOLD2, RHS1, RHS2, SLOPE
+      REAL SUM, TEMP, TEST, TMPLAM
+
+      CHECK = .FALSE.
+      SUM = 0.0
+      DO I = 1, N
+         SUM = SUM + P( I ) * P( I )
+      END DO
+      SUM = SQRT( SUM )
+      IF ( SUM .GT. STPMAX ) THEN
+         DO I = 1, N
+            P( I ) = P( I ) * STPMAX / SUM
+         END DO
+      END IF
+      SLOPE = 0.0
+      DO I = 1, N
+         SLOPE = SLOPE + G( I ) * P( I )
+      END DO
+      TEST = 0.0
+      DO I = 1, N
+         TEMP = ABS( P( I ) ) / MAX( ABS( XOLD( I ) ), 1.0 )
+         IF ( TEMP .GT. TEST ) TEST = TEMP
+      END DO
+      ALAMIN = TOLX / TEST
+      ALAM = 1.0
+
+101   CONTINUE
+
+C  avoid negative concentrations and set upper limit given by CTOT.
+
+      DO I = 1, N
+         X( I ) = XOLD( I ) + ALAM * P( I )
+         IF ( X( I ) .LE. 0.0 )       X( I ) = CONMIN
+         IF ( X( I ) .GT. CTOT( I ) ) X( I ) = CTOT( I )
+      END DO
+      CALL FMINV( X,F,N,FVEC,CT,CS,IMW,M )
+      IF ( ALAM .LT. ALAMIN ) THEN
+         DO I = 1, N
+            X( I ) = XOLD( I )
+         END DO
+         CHECK = .TRUE.
+         RETURN
+      ELSE IF ( F .LE. FOLD + ALF * ALAM * SLOPE ) THEN
+         RETURN
+      ELSE
+         IF ( ALAM .EQ. 1.0 ) THEN
+            TMPLAM = -SLOPE / ( 2.0 * ( F - FOLD - SLOPE ) )
+         ELSE
+            RHS1 = F - FOLD - ALAM * SLOPE
+            RHS2 = F2 - FOLD2 - ALAM2 * SLOPE
+            A = ( RHS1 / ALAM ** 2 - RHS2 / ALAM2 ** 2 ) / ( ALAM - ALAM2 )
+            B = ( -ALAM2 * RHS1 / ALAM ** 2 + ALAM * RHS2 / ALAM2 ** 2 )
+     &        / ( ALAM - ALAM2 )
+            IF ( A .EQ. 0.0 ) THEN
+               TMPLAM = -SLOPE / ( 2.0 * B )
+            ELSE
+               DISC  = B * B - 3.0 * A * SLOPE
+               TMPLAM = ( -B + SQRT( DISC ) ) / ( 3.0 * A )
+            END IF
+            IF ( TMPLAM .GT. 0.5 * ALAM ) TMPLAM = 0.5 * ALAM
+         END IF
+      END IF
+      ALAM2 = ALAM
+      F2 = F
+      FOLD2 = FOLD
+      ALAM = MAX( TMPLAM, 0.1 * ALAM )
+      GO TO 101
+
+      END SUBROUTINE LNSRCH
+
+C-----------------------------------------------------------------------
+      SUBROUTINE LUBKSB( A, N, INDX, B )
+
+C Description:
+C   Solves the set of N linear equations A * X = B. Here A is input,
+C   not as the matrix A but rather as its LU decomposition,
+C   determined by the routine LUDCMP. B(1:N) is input as the right-
+C   hand side vector B, and returns with the solution vector X. A, N,
+C   and INDX are not modified by this routine and can be left in
+C   place for successive calls with different right-hand sides B.
+C   This routine takes into account the possibility that B will begin
+C   with many zero elements, so it is efficient for use in matrix
+C   inversion.
+C
+C  Adopted from Numerical Recipes in FORTRAN, Chapter 2.3, 2nd ed.
+C
+C Key Subroutines Called: none
+C
+C Revision History:
+C    call vector modified to remove NCVAP and set dimensions to N.
+
+      IMPLICIT NONE
+
+      INTEGER N, INDX( N )
+      REAL A( N,N ), B( N ) ! A now has dimension NxN.
+
+      INTEGER I, II, J, LL
+      REAL SUM
+
+      II = 0
+      DO I = 1, N
+         LL = INDX( I )
+         SUM = B( LL )
+         B( LL ) = B( I )
+         IF ( II .NE. 0 ) THEN
+            DO J = II, I-1
+               SUM = SUM - A( I,J ) * B( J )
+            END DO
+         ELSE IF ( SUM .NE. 0 ) THEN
+            II = I
+         END IF
+         B( I ) = SUM
+      END DO
+      DO I = N, 1, -1
+         SUM = B( I )
+         DO J = I+1, N
+            SUM = SUM - A( I,J ) * B( J )
+         END DO
+         B( I ) = SUM / A( I,I )
+      END DO
+
+      RETURN
+      END SUBROUTINE LUBKSB
+
+C-----------------------------------------------------------------------
+      SUBROUTINE LUDCMP( A, N, INDX, D )
+
+C Description:
+C   Given a matrix A(1:N,1:N), with physical dimension N by N, this
+C   routine replaces it by the LU decomposition of a rowwise
+C   permutation of itself. A and N are input. A is output arranged as
+C   in equation (2.3.14) above; INDX(1:N) is an output vector that
+C   records vector that records the row permutation effected by the
+C   partial pivoting; D is output as +-1 depending on whether the
+C   number of row interchanges was even or odd, respectively. This
+C   routine is used in combination with SR LUBKSB to solve linear
+C   equations or invert a matrix.
+C
+C  Adopted from Numerical Recipes in FORTRAN, Chapter 2.3, 2nd ed.
+
+C  Equation (2.3.14) Numerical Recipes, p 36:
+C   | b_11 b_12 b_13 b_14 |
+C   | a_21 b_22 b_23 b_24 |
+C   | a_31 a_32 b_33 b_34 |
+C   | a_41 a_42 a_43 b_44 |
+
+C Key Subroutines Called: None
+
+C Revision History:
+C    call vector modified to remove NCVAP
+C    all dimensions now depend upon N only
+
+      IMPLICIT NONE
+
+      INTEGER N, INDX( N )
+!     INTEGER NMAX
+!     PARAMETER ( NMAX = 10 )   ! largest expected N
+      REAL D, A( N,N )     ! note that A now has dimension NxN
+                           ! NCVAP is ignored
+      REAL, PARAMETER :: TINY = 1.0E-20
+
+      INTEGER I, IMAX, J, K
+      REAL AAMAX, DUM, SUM, VV( N )
+
+      D = 1.0
+      DO I = 1, N
+         AAMAX = 0.0
+         DO J = 1, N
+            IF ( ABS(A( I,J ) ) .GT. AAMAX ) AAMAX = ABS( A( I,J ) )
+         END DO
+         IF ( AAMAX .EQ. 0.0 ) THEN
+            WRITE( *,'(a)' ) '*** Singular matrix in ludcmp!'
+!           STOP
+         END IF
+         VV( I ) = 1.0 / AAMAX
+      END DO
+      DO J = 1, N
+         DO I = 1, J-1
+            SUM = A( I,J )
+            DO K = 1, I-1
+               SUM = SUM - A( I,K ) * A( K,J )
+            END DO
+            A( I,J ) = SUM
+         END DO
+         AAMAX = 0.0
+         DO I = J, N
+            SUM = A( I,J )
+            DO K = 1, J-1
+               SUM = SUM - A( I,K ) * A( K,J )
+            END DO
+            A( I,J ) = SUM
+            DUM = VV( I ) * ABS( SUM )
+            IF ( DUM .GE. AAMAX ) THEN
+               IMAX = I
+               AAMAX = DUM
+            END IF
+         END DO
+         IF ( J .NE. IMAX ) THEN
+            DO K = 1, N
+               DUM = A( IMAX,K )
+               A( IMAX,K ) = A( J,K )
+               A( J,K ) = DUM
+            END DO
+            D = -D
+            VV( IMAX ) = VV( J )
+         END IF
+         INDX( J ) = IMAX
+         IF ( A( J,J ) .EQ. 0.0 ) A( J,J ) = TINY
+         IF ( J .NE. N ) THEN
+            DUM = 1.0 / A( J,J )
+            DO I = J+1, N
+               A( I,J ) = A( I,J ) * DUM
+            END DO
+         END IF
+      END DO
+
+      RETURN
+      END SUBROUTINE LUDCMP
+
+C-----------------------------------------------------------------------
+      Function soabisect( lowerb, upperb, nonvolmol, cstaratt, totsemivol,
+     &                    mlwt) RESULT ( nroot )
+
+C     Determines the root of an equation, nroot, that is located
+C     between the lowerb and upperb. The equation of interest is defined
+C     in the function soaequation. Before calling soabisect, the threshold 
+C     for SOA should have already been checked which should ensure a solution.
+C     The recommended lower bound is the number of moles of nonvolatile aerosol
+C     and the recommended upper bound is the total number of organic moles
+C
+C     History
+C     Created 7/2011 by HOT Pye
+
+      Use utilio_defn
+
+      Implicit None
+
+C     Function arguments
+      Real, Intent(IN) :: lowerb, upperb      ! lower bound, upper bound 
+      Real, Intent(IN) :: nonvolmol           ! nonvolatile aerosol in moles = POA + non-voltile SOA
+      Real, Intent(IN) :: cstaratt(n_vapor)   ! Cstars at T of interest
+      Real, Intent(IN) :: totsemivol(n_vapor) ! total semivolatile to partition in ug/m3 (gas+aer+newlyformed)
+      Real, Intent(IN) :: mlwt(n_vapor)       ! molecular weight of semivolatiles 
+
+C     Parameters for solution convergenc
+      Real             :: FRACTOL = 1.0e-6    ! Solution converged if abs(old-new)/new < FRACTOL
+!     Real             :: ABSTOL  = 1.0e-10   ! Solution converged if there are less than ABSTOL umol/m3 in aerosol
+      Real             :: ABSTOL  = 1.0e-08   ! Solution converged if there are less than ABSTOL umol/m3 in aerosol
+
+C     Result
+      Real             :: nroot               ! solution (final nguess)
+
+C     Local variables
+      Real             :: nguess              ! current guess for total moles organic aerosol
+      Real             :: oldn, lower, upper, flower, fnguess ! intermediate values
+      Real             :: fupper              ! function evaluated at upper bound
+      Real             :: ea                  ! difference b/w old and new guesses (umol/m3)
+      Real             :: test                ! to detect sign change
+      Integer          :: iter                ! counter to prevent infinite loops
+      Character( 120 ) :: xmsg
+
+C     Store current lower and upper bound, evaluate at lower bound 
+      lower  = lowerb
+      upper  = upperb
+      flower = soaequation( nonvolmol, cstaratt, totsemivol, mlwt, lowerb )
+      fupper = soaequation( nonvolmol, cstaratt, totsemivol, mlwt, upperb )
+
+C     First guess: solution at upperb
+      nguess = upperb
+
+C     Counter of iterations to prevent infinite loops
+      iter = 0
+
+C     Iterate until the number of moles changes by less than fractol (percent) or
+C     abstol (absolute) amount
+      Do
+
+        If ( flower * fupper .gt. 0.0 ) Then
+           ! function does not change sign between bounds
+#ifdef verbose_soa
+           nroot = soabisect_debug(lowerb, upperb, nonvolmol, cstaratt, totsemivol, mlwt)
+           Write( xmsg,'(a,2(1pe15.5))' )
+     &           'Error: no solution between bounds in soa bisection:', flower, fupper
+#else
+           xmsg = 'Error: no solution between bounds in soa bisection'
+#endif
+           Call m3exit( pname, 0, 0, xmsg, xstat3)
+        End If
+
+        iter   = iter + 1
+        oldn   = nguess                     ! store last guess
+        nguess = ( lower + upper ) / 2.0e0  ! new guess is halfway b/w old lower and upper
+        fnguess = soaequation( nonvolmol, cstaratt, totsemivol, mlwt, nguess ) ! function evaluated at new guess
+        If ( nguess .ne. 0.0 ) Then            ! safe division
+           ea = Abs( nguess - oldn ) / nguess  ! fractional diff b/w 2 guesses
+        Else
+#ifdef verbose_soa
+          nroot = soabisect_debug(lowerb, upperb, nonvolmol, cstaratt, totsemivol, mlwt)
+          Write( xmsg,'(a,1pe15.5)' )
+     &       'Warning: number of organic aerosol moles going to zero in soa bisection:',
+     &        nroot
+#else
+          xmsg = 'Warning: number of organic aerosol moles going to zero in soa bisection'
+#endif
+          Call m3exit( pname, 0, 0, xmsg, xstat3 )
+        End If
+
+        test = fnguess * flower
+        If ( test .Lt. 0.0 ) Then         ! if function changes sign b/w guess and lower, guess becomes upper
+          upper  = nguess
+          fupper = fnguess
+        Else If ( test .Gt. 0.0 ) Then    ! if function does not change sign, guess becomes lowerbound
+          lower  = nguess
+          flower = fnguess
+        Else If ( flower .Eq. 0.0 ) Then  ! if the lower bound is the root
+          ea      = 0.0
+          nguess  = lower
+          fnguess = flower
+        Else If ( fnguess .Eq. 0.0 ) Then ! guess is the root
+          ea      = 0.0
+        End If
+
+        ! solution found if error is less than ABSTOL/100 % or N bounded by values less than ABSTOL
+        If ( ( ea .Lt. FRACTOL ) .Or. ( ( upper + lower ) .Lt. ABSTOL ) ) Then
+          nroot = nguess
+          ! double check that the function is approximately zero
+          fnguess = soaequation( nonvolmol, cstaratt, totsemivol, mlwt, nguess ) ! function evaluated at new guess
+          If ( Abs( fnguess ) .Gt. 1.0e-03 ) Then
+!           pfc = pfc + 1
+#ifdef verbose_soa
+            nroot = soabisect_debug(lowerb, upperb, nonvolmol, cstaratt, totsemivol, mlwt)
+!           Write( xmsg,'(a,2(1pe15.5,i8))' )
+!    &      'Warning: possible false convergence in soa bisection:', fnguess, nroot, pfc
+            Write( xmsg,'(a,2(1pe15.5))' )
+     &      'Warning: possible false convergence in soa bisection:', fnguess, nroot
+            Call m3warn( pname, 0, 0, xmsg )
+#else
+            xmsg = 'Warning: possible false convergence in soa bisection'
+#endif
+!           Call m3warn( pname, 0, 0, xmsg )
+          End If
+
+          Return
+        End If
+
+        If ( iter .Gt. 1000000 ) Then ! stop infinite loop
+#ifdef verbose_soa
+          nroot = soabisect_debug(lowerb, upperb, nonvolmol, cstaratt, totsemivol, mlwt)
+          Write( xmsg,'(a,i9,1pe15.5)' )
+     &      'Error: too many iterations in soa bisection', iter, nroot
+#else
+          xmsg = 'Error: too many iterations in soa bisection'
+#endif
+          Call m3exit( pname, 0, 0, xmsg, xstat3 )
+        End If
+      End Do
+
+      End Function soabisect
+
+C-----------------------------------------------------------------------
+      Function soaequation( nonvmol, cstar, semivol, mlwt, currentN ) Result ( eqnerror )
+
+C     Evaluates the following function of total aerosol moles, N
+C     Function evaluates to zero at equilibrium 
+C     
+C                      totalsemivol_i        mols nonvolatile POA + SOA
+C     f(N) = sum_i (  ----------------   ) + ---------------------------  - 1.0 
+C                     cstar_i + mw_i*N                  N
+C
+C     History
+C     Created 7/2011 HOT Pye
+
+      Implicit None
+
+C     Function inputs and output
+      Real, INTENT(IN) :: nonvmol, currentN                ! nonvolatile moles, total moles
+      Real, INTENT(IN) :: mlwt(n_vapor)                    ! molecular weights of semivolatiles
+      Real, INTENT(IN) :: semivol(n_vapor), cstar(n_vapor) ! semivolatile mass, sat conc in ug/m3
+      Real             :: eqnerror                         ! result, deviation from 0.0 in equation
+
+C     Local variables
+      Real             :: temptot                          ! temporary total
+      Integer          :: i                                ! counter
+
+C     Compute function value for current value of N 
+      temptot = 0.0e0
+      Do i = 1, n_vapor
+         temptot = temptot + semivol(i) / ( cstar(i) + mlwt(i) * currentN )
+      End Do
+      eqnerror = temptot + nonvmol / currentN - 1.0e0
+
+      End function soaequation
+
+C-----------------------------------------------------------------------
+      Function soabisect_debug( lowerb, upperb, nonvolmol, cstaratt, totsemivol,
+     &                          mlwt) RESULT ( nroot )
+
+      Use utilio_defn
+
+      Implicit None
+
+C     Function arguments
+      Real, Intent(IN) :: lowerb, upperb      ! lower bound, upper bound
+      Real, Intent(IN) :: nonvolmol           ! nonvolatile aerosol in moles = POA + non-voltile SOA
+      Real, Intent(IN) :: cstaratt(:)   ! Cstars at T of interest
+      Real, Intent(IN) :: totsemivol(:) ! total semivolatile to partition in ug/m3 (gas+aer+newlyformed)
+      Real, Intent(IN) :: mlwt(:)       ! molecular weight of semivolatiles
+
+C     Parameters for solution convergenc
+      Real             :: FRACTOL = 1.0e-6    ! Solution converged if abs(old-new)/new < FRACTOL
+      Real             :: ABSTOL  = 1.0e-10   ! Solution converged if there are less than ABSTOL umol/m3 in aerosol
+
+C     Result
+      Real             :: nroot               ! solution (final nguess)
+
+C External functions:
+      Integer, External :: setup_logdev
+
+C     Local variables
+      Logical, Save    :: first_time = .True.
+      Integer, Save    :: logdev
+
+      Real             :: nguess              ! current guess for total moles organic aerosol
+      Real             :: oldn, lower, upper, flower, fnguess ! intermediate values
+      Real             :: fupper              ! function evaluated at upper bound
+      Real             :: ea                  ! difference b/w old and new guesses (umol/m3)
+      Real             :: test                ! to detect sign change
+      Integer          :: iter                ! counter to preventinfinite loops
+      Character( 120 ) :: xmsg
+
+      If ( first_time )  Then
+        first_time = .False.
+        logdev = setup_logdev()
+      End If
+
+C     Store current lower and upper bound, evaluate at lower bound
+      lower  = lowerb
+      upper  = upperb
+      flower = soaequation( nonvolmol, cstaratt, totsemivol, mlwt, lowerb )
+      fupper = soaequation( nonvolmol, cstaratt, totsemivol, mlwt, upperb )
+
+C     First guess: solution at upperb
+      nguess = upperb
+
+C     Counter of iterations to prevent infinite loops
+      iter = 0
+
+C     Iterate until the number of moles changes by less than fractol
+C     (percent) or abstol (absolute) amount
+      Do
+
+        If ( flower * fupper .Gt. 0.0 ) Then
+          ! function does not change sign between bounds
+          xmsg = 'Error: no solution between bounds in soa bisection'
+          Write( logdev,* ) xmsg
+        End If
+
+        iter    = iter + 1
+        oldn    = nguess                    ! store last guess
+        nguess  = ( lower + upper ) / 2.0e0 ! new guess is halfway b/w old lower and upper
+        fnguess = soaequation( nonvolmol, cstaratt, totsemivol, mlwt, nguess ) ! function evaluated at new guess
+
+        Write( logdev,* ), 'iter   ', iter
+        Write( logdev,* ), 'Lower= ', lower, flower
+        Write( logdev,* ), 'Upper= ', upper, fupper
+        Write( logdev,* ), 'Guess= ', nguess, fnguess
+
+        If ( nguess .Ne. 0.0 ) Then           ! safe division
+          ea = ABS( nguess - oldn )/nguess   ! fractional diff b/w 2guesses
+        Else
+          xmsg = 'Error: number of organic aerosol moles going to zero in soa bisection'
+          Write( logdev,* ) xmsg
+        End If
+
+        Write( logdev,* ) 'error', ea
+        test = fnguess * flower
+        If ( test .Lt. 0.0 ) Then           ! if function changes sign b/w guess and lower, guess becomes upper
+          upper  = nguess
+          fupper = fnguess
+        Else If ( test .Gt. 0.0 ) Then      ! if function does not change sign, guess becomes lowerbound
+          lower  = nguess
+          flower = fnguess
+        Else If ( flower .Eq. 0.0 ) Then    ! if the lower bound is the root
+          ea      = 0.0
+          nguess  = lower
+          fnguess = flower
+        Else If ( fnguess .Eq. 0.0 ) Then   ! guess is the root
+          ea      = 0.0
+        End If
+
+        ! solution found if error is less than ABSTOL/100 % or N bounded
+        ! by values less than 1e-08
+        If ( ( ea .Lt. FRACTOL ) .Or. ( ( upper + lower ) .Lt. ABSTOL ) ) then
+          nroot = nguess
+          ! double check that the function is approximately zero
+          fnguess = soaequation( nonvolmol, cstaratt, totsemivol, mlwt, nguess ) ! function evaluated at new guess
+          If ( Abs( fnguess ) .Gt. 1.0e-03 ) Then
+             xmsg = 'Warning: possible false convergence in soa bisection'
+             Write( logdev,* ) xmsg
+          End If
+
+          Return
+        End If
+
+        If ( iter .Gt. 1000000 ) Then ! stop infinite loops
+          !print*,'current lower, upper, and N: ',lower, upper, nguess
+          xmsg = 'Error: too many iterations in soa bisection'
+          Write( logdev,* ) xmsg
+        End If
+      End Do
+
+      End Function soabisect_debug
+
+!-----------------------------------------------
+
+      End Module soa_defn

--- a/DOCS/Known_Issues/CMAQv5.2-i5/aero_driver.F
+++ b/DOCS/Known_Issues/CMAQv5.2-i5/aero_driver.F
@@ -1,0 +1,852 @@
+
+!------------------------------------------------------------------------!
+!  The Community Multiscale Air Quality (CMAQ) system software is in     !
+!  continuous development by various groups and is based on information  !
+!  from these groups: Federal Government employees, contractors working  !
+!  within a United States Government contract, and non-Federal sources   !
+!  including research institutions.  These groups give the Government    !
+!  permission to use, prepare derivative works of, and distribute copies !
+!  of their work in the CMAQ system to the public and to permit others   !
+!  to do so.  The United States Environmental Protection Agency          !
+!  therefore grants similar permission to use the CMAQ system software,  !
+!  but users are requested to provide copies of derivative works or      !
+!  products designed to operate in the CMAQ system to the United States  !
+!  Government without restrictions as to use by others.  Software        !
+!  that is used with the CMAQ system but distributed under the GNU       !
+!  General Public License or the GNU Lesser General Public License is    !
+!  subject to their copyright restrictions.                              !
+!------------------------------------------------------------------------!
+
+
+C RCS file, release, date & time of last delta, author, state, [and locker]
+C $Header: /project/yoj/arc/CCTM/src/aero/aero5/aero_driver.F,v 1.11 2012/01/19 13:12:57 yoj Exp $
+
+C >>> 08/04/2000 Changes necessary to be able to read and process
+C two different types of emissions files.
+C the first type is the existing opperational PM2.5 & PM10 unspeciated
+C file. The new file format has speciated emissions.
+C >>> This version uses the FORTRAN 90 feature for runtime memory
+C allocation.
+
+C 1/12/99 David Wong at LM:
+C   -- introduce new variable MY_NUMBLKS (eliminate NUMBLKS)
+C   -- re-calculate NOXYZ accordingly
+C FSB Updated for inclusion of surface area / second moment
+C 25 Sep 00 (yoj) various bug fixes, cleanup to coding standards
+C   Jeff - Dec 00 - move CGRID_MAP into f90 module
+C FSB/Jeff - May 01 - optional emissions processing
+C   Jerry Gipson - Jun 01 - added SOA linkages for saprc99
+C   Bill Hutzell - Jun 01 - simplified CBLK mapping
+C   Jerry Gipson - Jun 03 - modified for new soa treatment
+C   Jerry Gipson - Aug 03 - removed SOA prod form alkenes & added
+C       emission adjustment factors for ALK & TOL ( RADM2 & SAPRC99 only)
+C   Shawn Roselle - Jan 04
+C   - removed SOA from transported aerosol surface area
+C   - fixed bug in calculation of wet parameters.  Previously, DRY aerosol
+C      parameters were being written to the AERDIAG files and mislabeled
+C      as WET.
+C   Prakash Bhave - May 04
+C   - changed AERODIAG species (added RH; removed M0 & M2dry)
+C   Jeff Young - Jan 05 - dyn alloc
+C   - establish both horizontal & vertical domain specifications in one module
+c   Uma Shankar and Prakash Bhave - Jun 05
+c   - added code to handle the following species: ANAI, ANAJ, ANAK, ACLI,
+c     ACLJ, ACLK, ASO4K, AH2OK, ANO3K, and HCL; removed code for ASEAS
+c   - removed obsolete MW variables
+C   Prakash Bhave - Jul 05 - added PM25 mass-fraction calculations
+C   Jeff Young - Feb 06 - trap fractional humidity above 0.005
+C   Prakash Bhave - Apr 06 - added GAMMA_N2O5 to the AEROPROC call vector
+C       and the aerosol diagnostic file
+C   Prakash Bhave - May 06 - changed units of DG variables from m to um in
+C       the aerosol diagnostic file as suggested by Dr. Bill Hutzell
+C   Sergey Napelenok - Sep 07 - SOA updates
+C   - added code to handle the following species: AALKJ, ATOL1J, ATOL2J,
+C     ATOL3J, AXYL1J, AXYL2J, AXYL3J, ABNZ1J, ABNZ2J, ABNZ3J, AISO1J, AISO2J,
+C     AISO3J, ATRP1J, ATRP2J, ASQTJ, AORGCJ, TOLNRXN, TOLHRXN, XYLNRXN,
+C     XYLHRXN, BNZNRXN, BNZHRXN, ISOPRXN, and SESQRXN
+C   - removed following species: AORGAI, AORGAJ, AORGBI, AORGBJ, OLIRXN,
+C     CSLRXN, TOLRXN, XYLRXN
+C   Prakash Bhave - Oct 07 - SOA updates
+C   - added semi-volatile vapors to the CBLK array; moved ppm -> ug/m3 unit
+C     conversion from the ORGAER subroutine to this program
+C   - updated definition of DRY aerosol to include nonvolatile SOA species
+C   - removed adjustment factors for TOLAER (SPTOL, RDTOL) because benzene is
+C     now an explicit species so all of the reacted TOL can produce SOA
+C   - removed code to handle TERPSP (obsolete); renamed TERPRXN as TRPRXN
+C   David Wong - Jan 08 - rearranged calculation of dry 3rd moments to avoid
+C      NaN on some compilers (using the M3SUBT variable)
+C   Prakash Bhave - Jan 08 - updated MECHNAME check from AE4 to AE5
+C   Golam Sarwar -  Mar 08 - added a heterogeneous reaction producing HONO
+C   Jim Kelly - Apr 08 - coarse mode updates
+C   - added code to account for new species (ANH4K & SRFCOR) and variable
+C     coarse std. deviation
+C   - removed MW coding now located in AERO_INFO.f
+C   - added FIXED_sg flag for call to GETPAR
+C   Jeff Young - Aug 10 - convert for Namelist redesign (replace include files)
+C   Steve Howard - Mar 11 - Renamed met_data to aeromet_data
+C   S.Roselle- Mar 11 - replaced I/O API include files with UTILIO_DEFN
+C   David Wong - Aug 11 - put in twoway model implementation
+C   David Wong - Oct 11 - extended the twoway implementation to handle finer
+C                         time resolution
+C
+C   Bill Hutzell - Sept 13 - inserted module for AEROSOL_CHEMISTRY to support
+C                            diagnostic outputs on reaction gamma and yield 
+C                            values 
+C   HOT Pye - Jan 13 - Additional information for IEPOX aerosol 
+C                      written to AERODIAG file
+C   David Wong - Aug 15 - Used IO_PE_INCLUSIVE rather than MYPE to facilitate
+C                         parallel I/O implementation
+C                       - Used a new logical variable, FIRST_CTM_VIS_1 to
+C                         determine when to open CTM_VIS_1 
+C  B.Hutzell 22 Feb 16 - Added test to determine to write diagnostics from aerosol
+C                        chemistry
+C  H Pye and B Murphy April 2016 - Updated dry/wet moment process to use
+C                        Extract_aero and Update_aero for getting moment/saving surface area
+C  D. Wong 10 May 2016 - added calculation of average PMDIAG species w.r.t.
+C                        environment variable CTM_PMDIAG, APMDIAG_BLEV_ELEV, 
+C                        and AVG_PMDIAG_SPCS
+C                      - added calculation of average visibility species w.r.t.
+C                        environment variable CTM_AVISDIAG
+C                      - renamed AERODIAM to PMDIAG and CTM_AERDIAG to CTM_PMDIAG
+C                      - added flexibility to handle AE6 and AE6i
+C                      - renamed DIAM to PMDIAG
+C  D. Wong 19 May 2016 - renamed ACONC_END_TIME to AVG_FILE_ENDTIME
+C                      - updated the way to define NUM_PMDIAG_SPC
+C                      - set CTM_PMDIAG default value to .TRUE.
+C:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+      SUBROUTINE AERO ( CGRID, JDATE, JTIME, TSTEP )
+
+      USE GRID_CONF           ! horizontal & vertical domain specifications
+
+      USE RXNS_DATA
+      USE AERO_DATA           ! aero variable data
+      USE PRECURSOR_DATA      ! gas phase aero precursor data
+      USE SOA_DEFN            ! gas soa data
+      USE AEROMET_DATA        ! air properties data, eg., T, P, RH includes CONST.EXT
+      USE AOD_DEFN            ! IMPROVE reconstructed method AOD
+      USE UTILIO_DEFN
+      USE CGRID_SPCS
+      USE AEROSOL_CHEMISTRY, ONLY : GAMMA_N2O5IJ, GAMMA_N2O5K, YCLNO2IJ, YCLNO2K, 
+     &                              GAMMA_IEPOX, GAMMA_IMAE, KPARTIEPOX, AERO_CHEM_SET
+      USE PMDIAG_DATA_MODULE
+
+      IMPLICIT NONE
+
+C *** Includes:
+
+      INCLUDE SUBST_FILES_ID  ! file name parameters (req IOPARMS)
+
+C *** Arguments:
+
+C *** CGRID is conc field (including gas and aerosol variables)
+      REAL, POINTER :: CGRID( :,:,:,: )              !  concentrations
+      INTEGER      JDATE        ! Current model date , coded YYYYDDD
+      INTEGER      JTIME        ! Current model time , coded HHMMSS
+      INTEGER      TSTEP( 3 )   ! time step vector (HHMMSS)
+                                ! TSTEP(1) = local output step
+                                ! TSTEP(2) = sciproc sync. step (chem)
+                                ! TSTEP(3) = twoway model time step w.r.t. wrf time
+                                !            step and wrf/cmaq call frequency
+
+      INTEGER, SAVE :: LOGDEV             ! unit number for the log file
+
+C *** Local Variables:
+
+      CHARACTER( 16 ), SAVE :: PNAME = 'AERO_DRIVER'
+      CHARACTER( 16 ) :: VNAME            ! variable name
+      CHARACTER( 96 ) :: XMSG = ' '
+
+      INTEGER   MDATE, MTIME, MSTEP  ! julian date, time and
+                                     ! timestep in sec
+      INTEGER   C, R, L, V, N        ! loop counters
+      INTEGER   SPC                  ! species loop counter
+      INTEGER   STRT, FINI           ! loop induction variables
+      INTEGER   ALLOCSTAT            ! memory allocation status
+
+      LOGICAL   LERROR               ! Error flag
+
+C *** Grid Description
+      REAL DX1                 ! Cell x-dimension
+      REAL DX2                 ! Cell y-dimension
+      INTEGER GXOFF, GYOFF     ! global origin offset from file
+C for INTERPX
+      INTEGER, SAVE :: STRTCOLMC3, ENDCOLMC3, STRTROWMC3, ENDROWMC3
+
+C *** Variable to set time step for writing visibility file
+      INTEGER, SAVE :: WSTEP  = 0   ! local write counter
+      LOGICAL, SAVE :: WRITETIME = .FALSE. ! local write flag
+
+C *** meteorological variables
+      REAL PRES   ( NCOLS,NROWS,NLAYS )  ! Atmospheric pressure [ Pa ]
+      REAL TA     ( NCOLS,NROWS,NLAYS )  ! Air temperature [ K ]
+      REAL DENS   ( NCOLS,NROWS,NLAYS )  ! Air density [ kg/m**-3 ]
+      REAL QV     ( NCOLS,NROWS,NLAYS )  ! Water vapor mixing ratio [ kg/kg ]
+
+C *** variables computed and output but not carried in CGRID
+
+C *** visibility variables
+      INTEGER, PARAMETER :: N_AE_VIS_SPC = 4
+      INTEGER, PARAMETER :: IDCVW1 = 1 ! visual range in deciview (Mie)
+      INTEGER, PARAMETER :: IBEXT1 = 2 ! extinction [ 1/km ] (Mie)
+      INTEGER, PARAMETER :: IDCVW2 = 3 ! visual range in deciview (Reconst)
+      INTEGER, PARAMETER :: IBEXT2 = 4 ! extinction [ 1/km ] (Reconst)
+      REAL VIS_SPC( NCOLS,NROWS,N_AE_VIS_SPC )  ! Visual range information
+      REAL, ALLOCATABLE, SAVE :: AVIS_SPC( :,:,: ) ! average Visual range information
+
+C *** aerosol size distribution variables
+!     REAL DIAM_SPC( NCOLS,NROWS,NLAYS,39 )
+      REAL, ALLOCATABLE, SAVE :: PMDIAG_SPC( :,:,:,: )
+      REAL, ALLOCATABLE, SAVE :: A_PMDIAG_SPC( :,:,:,: )
+      CHARACTER( 16 ) :: V_LIST( 2 )
+
+      INTEGER, SAVE :: N_APMDIAG_STEP
+      INTEGER, SAVE :: A_NLAYS
+      CHARACTER( 32 ) :: APMDIAG_BLEV_ELEV = 'APMDIAG_BLEV_ELEV'
+
+C *** atmospheric properties
+      REAL XLM             ! atmospheric mean free path [ m ]
+      REAL AMU             ! atmospheric dynamic viscosity [ kg/m s ]
+
+C *** mass fraction of each mode less than Specified Aerodynamic Diameters
+      REAL fPM1 ( N_MODE )  ! PM1 fraction
+      REAL fPM25( N_MODE )  ! PM2.5 fraction
+      REAL fPM10( N_MODE )  ! PM10 fraction
+      REAL fAMS ( N_MODE )  ! AMS Transmission Fraction
+
+C *** visual range information
+      REAL BLKDCV1         ! block deciview (Mie)
+      REAL BLKEXT1         ! block extinction [ km**-1 ] (Mie)
+
+      REAL BLKDCV2         ! block deciview (Reconstructed)
+      REAL BLKEXT2         ! block extinction [ km**-1 ] (Reconstructed)
+
+      INTEGER, SAVE :: N_VIS_STEP
+
+C *** other internal aerosol variables
+      INTEGER IND                         ! index to be used with INDEX1
+
+C *** synchronization time step [ s ]
+      REAL DT
+
+C *** variables to set up for "dry transport "
+      REAL M3_WET( N_MODE ), M3_DRY( N_MODE )   ! third moment with and without water
+      REAL M2_WET( N_MODE ), M2_DRY( N_MODE )   ! second moment with and without water
+
+C *** variables aerosol diagnostic file flag
+      INTEGER      STATUS            ! ENV... status
+      CHARACTER( 80 ) :: VARDESC     ! environment variable description
+
+C *** environment variable for PMDIAG APMDIAG file
+      CHARACTER( 16 ), SAVE :: CTM_PMDIAG   = 'CTM_PMDIAG'
+      CHARACTER( 16 ), SAVE :: CTM_APMDIAG  = 'CTM_APMDIAG'
+      CHARACTER( 16 ), SAVE :: CTM_AVISDIAG = 'CTM_AVISDIAG'
+
+C *** flag for PMDIAG and APMDIAG file [F], default
+      LOGICAL, SAVE :: PMDIAG
+      LOGICAL, SAVE :: APMDIAG
+      LOGICAL, SAVE :: AVISDIAG
+
+C *** first pass flag
+      LOGICAL, SAVE :: FIRSTIME = .TRUE.
+      LOGICAL, SAVE :: FIRST_CTM_VIS_1 = .TRUE.
+
+C *** ratio of molecular weights of water vapor to dry air = 0.622015
+      REAL, PARAMETER :: EPSWATER = MWWAT / MWAIR
+
+C *** dry moment factor
+      REAL, PARAMETER :: TWOTHIRDS = 2.0 / 3.0
+
+      LOGICAL :: TIME_TO_CALL_FEEDBACK_WRITE
+      LOGICAL, SAVE :: CMAQ_WRF_FEEDBACK
+
+C *** Statement Function **************
+      REAL ESATL ! arithmetic statement function for vapor pressure [Pa]
+      REAL TT
+C *** Coefficients for the equation, ESATL defining saturation vapor pressure
+      REAL, PARAMETER :: AL = 610.94
+      REAL, PARAMETER :: BL = 17.625
+      REAL, PARAMETER :: CL = 243.04
+
+      INTEGER, SAVE :: O3
+
+      CHARACTER( 16 ) :: AVG_FILE_ENDTIME = 'AVG_FILE_ENDTIME'
+      LOGICAL, SAVE :: END_TIME = .FALSE.
+
+      REAL, ALLOCATABLE, SAVE :: TEMP_DATA(:)
+
+C *** values of AL, BL, and CL are from:
+C     Alduchov and Eskridge, "Improved Magnus Form Approximations of
+C                            Saturation Vapor Pressure,"
+C                            Jour. of Applied Meteorology, vol. 35,
+C                            pp 601-609, April, 1996.
+
+      ESATL( TT ) = AL * EXP( BL * ( TT - 273.15 ) / ( TT - 273.15 + CL ) )
+
+C *** End Statement Function  ********
+
+      logical, save :: now = .true.
+
+      INTERFACE
+         SUBROUTINE GET_ENVLIST ( ENV_VAR, NVARS, VAL_LIST )
+            CHARACTER( * ),  INTENT ( IN )  :: ENV_VAR
+            INTEGER,         INTENT ( OUT ) :: NVARS
+            CHARACTER( 16 ), INTENT ( OUT ) :: VAL_LIST( : )
+         END SUBROUTINE GET_ENVLIST
+      END INTERFACE
+
+#ifdef twoway
+      INTERFACE
+        SUBROUTINE FEEDBACK_WRITE (C, R, L, CGRID_DATA, O3_VALUE, JDATE, JTIME)
+          REAL, INTENT( IN ) :: CGRID_DATA(:), O3_VALUE
+          INTEGER, INTENT( IN ) :: C, R, L, JDATE, JTIME
+        END SUBROUTINE FEEDBACK_WRITE
+      END INTERFACE
+#endif
+
+C ------------------ begin body of AERO_DRIVER -------------------------
+
+      IF ( FIRSTIME ) THEN
+         FIRSTIME = .FALSE.
+         LOGDEV = INIT3()
+
+         IF ( INDEX(MECHNAME, 'SAPRC07TIC_AE6I_AQ') .GT. 0 ) THEN
+            NUM_PMDIAG_SPC = 41
+         ELSE
+            NUM_PMDIAG_SPC = 39
+         END IF
+
+         CALL GET_ENVLIST ( APMDIAG_BLEV_ELEV, N, V_LIST )
+         IF ( N .EQ. 0 ) THEN
+            A_NLAYS = NLAYS
+         ELSE
+           READ( V_LIST( 2 ), '( I4 )' ) A_NLAYS
+         END IF
+
+         ALLOCATE (   PMDIAG_SPC( NCOLS,NROWS,NLAYS,NUM_PMDIAG_SPC ),
+     &              A_PMDIAG_SPC( NCOLS,NROWS,A_NLAYS,NUM_PMDIAG_SPC ),
+     &              TEMP_DATA( NUM_PMDIAG_SPC ), 
+     &              AVIS_SPC( NCOLS,NROWS,N_AE_VIS_SPC ),
+     &              STAT=ALLOCSTAT)
+
+         A_PMDIAG_SPC  = 0.0
+         N_APMDIAG_STEP = 0
+
+         AVIS_SPC = 0.0
+         N_VIS_STEP = 0
+
+         END_TIME = ENVYN( AVG_FILE_ENDTIME, ' ', END_TIME, STATUS )
+
+#ifdef twoway
+! -- this is for twoway
+         VNAME = 'O3'
+         N = INDEX1( VNAME, N_GC_CONC, GC_CONC )
+         IF ( N .NE. 0 ) THEN
+            O3 = GC_STRT - 1 + GC_CONC_MAP( N )
+         ELSE
+            XMSG = 'Could not find ' // VNAME // 'in gas chem aerosol table'
+            CALL M3EXIT ( PNAME, JDATE, JTIME, XMSG, XSTAT3 )
+         END IF
+#endif
+
+C *** Get aerosol diagnostic file flag.
+         PMDIAG = .TRUE.         ! default
+         VARDESC = 'Flag for writing the aerosol diagnostic file'
+         PMDIAG = ENVYN( CTM_PMDIAG, VARDESC, PMDIAG, STATUS )
+         IF ( STATUS .NE. 0 ) WRITE( LOGDEV, '(5X, A)' ) VARDESC
+         IF ( STATUS .EQ. 1 ) THEN
+            XMSG = 'Environment variable improperly formatted'
+            CALL M3EXIT( PNAME, JDATE, JTIME, XMSG, XSTAT2 )
+         ELSE IF ( STATUS .EQ. -1 ) THEN
+            XMSG = 'Environment variable set, but empty ... Using default:'
+            WRITE( LOGDEV, '(5X, A, I9)' ) XMSG, JTIME
+         ELSE IF ( STATUS .EQ. -2 ) THEN
+            XMSG = 'Environment variable not set ... Using default:'
+            WRITE( LOGDEV, '(5X, A, I9)' ) XMSG, JTIME
+         END IF
+
+C *** Get aerosol average diagnostic file flag.
+         APMDIAG = .FALSE.         ! default
+         VARDESC = 'Flag for writing the aerosol diagnostic file'
+         APMDIAG = ENVYN( CTM_APMDIAG, VARDESC, APMDIAG, STATUS )
+         IF ( STATUS .NE. 0 ) WRITE( LOGDEV, '(5X, A)' ) VARDESC
+         IF ( STATUS .EQ. 1 ) THEN
+            XMSG = 'Environment variable improperly formatted'
+            CALL M3EXIT( PNAME, JDATE, JTIME, XMSG, XSTAT2 )
+         ELSE IF ( STATUS .EQ. -1 ) THEN
+            XMSG = 'Environment variable set, but empty ... Using default:'
+            WRITE( LOGDEV, '(5X, A, I9)' ) XMSG, JTIME
+         ELSE IF ( STATUS .EQ. -2 ) THEN
+            XMSG = 'Environment variable not set ... Using default:'
+            WRITE( LOGDEV, '(5X, A, I9)' ) XMSG, JTIME
+         END IF
+
+C *** Get aerosol average diagnostic file flag.
+         AVISDIAG = .FALSE.         ! default
+         VARDESC = 'Flag for writing the aerosol diagnostic file'
+         AVISDIAG = ENVYN( CTM_AVISDIAG, VARDESC, AVISDIAG, STATUS )
+         IF ( STATUS .NE. 0 ) WRITE( LOGDEV, '(5X, A)' ) VARDESC
+         IF ( STATUS .EQ. 1 ) THEN
+            XMSG = 'Environment variable improperly formatted'
+            CALL M3EXIT( PNAME, JDATE, JTIME, XMSG, XSTAT2 )
+         ELSE IF ( STATUS .EQ. -1 ) THEN
+            XMSG = 'Environment variable set, but empty ... Using default:'
+            WRITE( LOGDEV, '(5X, A, I9)' ) XMSG, JTIME
+         ELSE IF ( STATUS .EQ. -2 ) THEN
+            XMSG = 'Environment variable not set ... Using default:'
+            WRITE( LOGDEV, '(5X, A, I9)' ) XMSG, JTIME
+         END IF
+
+C *** Get AOD diagnostic file flag.
+         AOD = .FALSE.         ! default
+         VARDESC = 'Flag for writing the IMPROVE network AOD diagnostic file'
+         AOD = ENVYN( CTM_AOD, VARDESC, AOD, STATUS )
+         IF ( STATUS .NE. 0 ) WRITE( LOGDEV, '(5X, A)' ) VARDESC
+         IF ( STATUS .EQ. 1 ) THEN
+            XMSG = 'Environment variable improperly formatted'
+            CALL M3EXIT( PNAME, JDATE, JTIME, XMSG, XSTAT2 )
+         ELSE IF ( STATUS .EQ. -1 ) THEN
+            XMSG = 'Environment variable set, but empty ... Using default:'
+            WRITE( LOGDEV, '(5X, A, I9)' ) XMSG, JTIME
+         ELSE IF ( STATUS .EQ. -2 ) THEN
+            XMSG = 'Environment variable not set ... Using default:'
+            WRITE( LOGDEV, '(5X, A, I9)' ) XMSG, JTIME
+         END IF
+
+C *** Open the met files.
+         IF ( .NOT. OPEN3( MET_CRO_3D, FSREAD3, PNAME ) ) THEN
+            XMSG = 'Could not open  MET_CRO_3D  file '
+            CALL M3EXIT ( PNAME, JDATE, JTIME, XMSG, XSTAT1 )
+         END IF
+
+         IF ( .NOT. OPEN3( MET_CRO_2D, FSREAD3, PNAME ) ) THEN
+            XMSG = 'Could not open  MET_CRO_2D file '
+            CALL M3EXIT ( PNAME, JDATE, JTIME, XMSG, XSTAT1 )
+         END IF
+
+C *** Set up file structure for visibility file. It has two variables,
+C     visual range in deciview units (dimensionless) and extinction in
+C     units of (1/km) and is for layer 1 only.
+         IF ( IO_PE_INCLUSIVE ) THEN
+            CALL OPVIS ( JDATE, JTIME, TSTEP( 1 ) )
+            IF ( AVISDIAG ) CALL OPAVIS ( JDATE, JTIME, TSTEP( 1 ) )
+         END IF
+
+C *** Open the aerosol parameters file (diameters and standard deviations).
+
+         IF ( PMDIAG .AND. IO_PE_INCLUSIVE ) CALL OPPMDIAG ( JDATE, JTIME, TSTEP( 1 ) )
+         IF ( APMDIAG ) CALL OPAPMDIAG ( JDATE, JTIME, TSTEP( 1 ) )
+
+         IF ( AOD ) THEN
+C *** Set up for AOD processing
+            IF ( .NOT. AOD_INIT( JDATE, JTIME, TSTEP( 1 ) ) ) THEN
+               XMSG = 'Failure initializing dust emission processing'
+               CALL M3EXIT( PNAME, JDATE, JTIME, XMSG, XSTAT2 )
+            END IF
+         END IF
+
+C *** Get domain decomp info from the MET_CRO_3D file
+         CALL SUBHFILE ( MET_CRO_3D, GXOFF, GYOFF,
+     &                   STRTCOLMC3, ENDCOLMC3, STRTROWMC3, ENDROWMC3 )
+
+#ifdef twoway
+         CMAQ_WRF_FEEDBACK = ENVYN( 'CMAQ_WRF_FEEDBACK', ' ', .FALSE., STATUS )
+         IF ( STATUS .EQ. 1 ) THEN
+            PRINT *, 'Environment variable improperly formatted'
+            STOP
+         ELSE IF ( STATUS .EQ. -1 ) THEN
+            PRINT *, 'Environment variable set, but empty ... Using default:'
+         ELSE IF ( STATUS .EQ. -2 ) THEN
+            PRINT *, 'Environment variable not set ... Using default:'
+         END IF
+#endif
+
+      END IF    ! FIRSTIME
+
+      MDATE  = JDATE
+      MTIME  = JTIME
+      MSTEP = TIME2SEC( TSTEP( 2 ) )
+      CALL NEXTIME ( MDATE, MTIME, SEC2TIME( MSTEP / 2 ) )
+
+      WSTEP = WSTEP + TIME2SEC( TSTEP( 2 ) )
+      IF ( WSTEP .GE. TIME2SEC( TSTEP( 1 ) ) ) WRITETIME = .TRUE.
+
+C *** Set floating point synchronization time step:
+      DT = FLOAT( MSTEP ) ! set time step in seconds
+
+C *** Get Meteorological Variables
+
+C *** pressure [Pa]
+      VNAME = 'PRES'
+      IF ( .NOT. INTERPX( MET_CRO_3D, VNAME, PNAME,
+     &                    STRTCOLMC3,ENDCOLMC3, STRTROWMC3,ENDROWMC3, 1,NLAYS,
+     &                    MDATE, MTIME, PRES ) ) THEN
+         XMSG = 'Could not interpolate '// TRIM( VNAME ) // ' from MET_CRO_3D '
+         CALL M3EXIT ( PNAME, MDATE, MTIME, XMSG, XSTAT1 )
+      END IF
+
+C *** temperature [K]
+      VNAME = 'TA'
+      IF ( .NOT. INTERPX( MET_CRO_3D, VNAME, PNAME,
+     &                    STRTCOLMC3,ENDCOLMC3, STRTROWMC3,ENDROWMC3, 1,NLAYS,
+     &                    MDATE, MTIME, TA ) ) THEN
+         XMSG = 'Could not interpolate '// TRIM( VNAME ) // ' from MET_CRO_3D '
+         CALL M3EXIT ( PNAME, MDATE, MTIME, XMSG, XSTAT1 )
+      END IF
+
+C *** specific humidity [g H2O/g air]
+      VNAME = 'QV'
+      IF ( .NOT. INTERPX( MET_CRO_3D, VNAME, PNAME,
+     &                    STRTCOLMC3,ENDCOLMC3, STRTROWMC3,ENDROWMC3, 1,NLAYS,
+     &                    MDATE, MTIME, QV ) ) THEN
+         XMSG = 'Could not interpolate '// TRIM( VNAME ) // ' from MET_CRO_3D '
+         CALL M3EXIT ( PNAME, JDATE, JTIME, XMSG, XSTAT1 )
+      END IF
+
+C *** air density [kg/m3]
+      VNAME = 'DENS'
+      IF ( .NOT. INTERPX( MET_CRO_3D, VNAME, PNAME,
+     &                    STRTCOLMC3,ENDCOLMC3, STRTROWMC3,ENDROWMC3, 1,NLAYS,
+     &                    MDATE, MTIME, DENS ) ) THEN
+         XMSG = 'Could not interpolate '// TRIM( VNAME ) // ' from MET_CRO_3D '
+         CALL M3EXIT ( PNAME, MDATE, MTIME, XMSG, XSTAT1 )
+      END IF
+
+#ifdef twoway
+! call FEEDBACK_WRITE when JTIME is mulitple of WRF time step
+      IF ( CMAQ_WRF_FEEDBACK ) THEN
+         IF ( MOD( TIME2SEC(MOD( JTIME, 10000 )), TIME2SEC(TSTEP( 3 )) ) .EQ. 0 ) THEN
+            TIME_TO_CALL_FEEDBACK_WRITE = .TRUE.
+         ELSE
+            TIME_TO_CALL_FEEDBACK_WRITE = .FALSE.
+         END IF
+      END IF
+#endif
+
+C --------------------- Begin loops over grid cells --------------------------
+
+C *** initialize conc arrays
+
+      N_APMDIAG_STEP = N_APMDIAG_STEP + 1
+      N_VIS_STEP = N_VIS_STEP + 1 
+
+      DO L = 1, NLAYS
+         DO R = 1, MY_NROWS
+            DO C = 1, MY_NCOLS
+
+C *** Grid cell meteorological data.
+               AIRTEMP  = TA   ( C,R,L )
+               AIRPRES  = PRES ( C,R,L )   ! Note pascals
+               AIRQV    = QV   ( C,R,L )
+               AIRDENS  = DENS ( C,R,L )
+               H2OSATVP = ESATL( AIRTEMP )
+               H2OVP    = AIRPRES * AIRQV / ( EPSWATER  + AIRQV )
+               AIRRH    = MAX( 0.005, MIN( 0.99, H2OVP / H2OSATVP ) )
+
+C *** Extract grid cell concentrations of aero species from CGRID
+C     into aerospc_conc in aero_data module (set minimum)
+               CALL EXTRACT_AERO( CGRID( C,R,L,: ), .TRUE. )
+
+C *** Extract grid cell concentrations of gas precursors from CGRID (ppm)
+C     into precursr_conc in precursor_data
+               CALL EXTRACT_PRECURSOR( CGRID( C,R,L,: ) )
+
+C *** Calculate SO4RATE stored in module
+               SO4RATE = REAL( PRECURSOR_CONC( SULPRD_IDX ), 4 ) / DT
+ 
+               IF ( PHGRXN_IDX .GT. 0 ) THEN
+C *** Calculate PHG_RATE stored in module
+                  PHG_RATE = REAL( PRECURSOR_CONC( PHGRXN_IDX ), 4 ) / DT
+               ELSE
+                  PHG_RATE = 0.0
+               END IF
+
+C *** Extract soa concentrations from CGRID and 
+C     convert M2 to wet
+               CALL EXTRACT_SOA( CGRID( C,R,L,: ) )
+
+C *** Aerosol process routines
+               CALL AEROPROC( DT, C, R, L )
+
+C *** Update aerosol variables conc back into CGRID (set minimum) 
+C     and convert M2 to dry and save as surface area
+               CALL UPDATE_AERO( CGRID( C,R,L,: ), .TRUE. )
+
+C *** Update precursor variables conc back into CGRID
+               CALL UPDATE_PRECURSOR( CGRID( C,R,L,: ) )
+
+C *** Update gas soa concentrations back to CGRID
+               CALL UPDATE_SOA( CGRID( C,R,L,: ) )
+
+C *** OUTPUT DIAGNOSTIC INFORMATION
+C *** Get wet moment info (dry will be converted to wet)
+               CALL calcmoments( .true. )
+               CALL GETPAR( FIXED_sg ) ! update AEROMODE_DIAM,DENS,SDEV
+                   
+C *** Calculate volume fraction of each mode for measurement applications
+               DO N = 1, N_MODE
+                  ! Calculate transmission of each mode in aerosol impactors.
+                  ! Report fraction of PM1, PM2.5, and PM10.0 for all modes
+                  ! after converting to aerodynamic diameter.
+                  CALL AERO_INLET ( AEROMODE_DIAM( N ), AEROMODE_LNSG( N ),
+     &                              AEROMODE_DENS( N ), fPM1( N ), fPM25( N ),
+     &                              fPM10( N ) )
+           
+                  ! Calculate AMS Transmission Fraction. Aerosol water will
+                  ! be excluded from the calculation since AMS standard
+                  ! procedures recommend drying particles before they enter
+                  ! the intstrument.
+                  CALL AERO_AMS ( MOMENT3_CONC( N ), MOMENT2_CONC( N ),
+     &                            MOMENT0_CONC( N ), AEROSPC_CONC( AH2O_IDX,N ), 
+     &                            AEROMODE_DENS( N ),AEROSPC( AH2O_IDX)%DENSITY, 
+     &                            fAMS( N ) )
+               END DO
+
+C *** Write aerosol extinction coefficients and deciviews to visibility
+C     diagnostic array (lowest vertical layer only)
+
+               IF ( L .EQ. 1 ) THEN
+                  IF ( WRITETIME .OR. AVISDIAG) THEN
+                     CALL GETVISBY( BLKDCV1, BLKEXT1, BLKDCV2, BLKEXT2 )
+                  END IF
+                  IF ( AVISDIAG ) THEN
+                     AVIS_SPC( C,R,1 ) = AVIS_SPC( C,R,1 ) + BLKDCV1  ! Mie visual range [deciview]
+                     AVIS_SPC( C,R,2 ) = AVIS_SPC( C,R,2 ) + BLKEXT1  ! Mie aero extinction [1/km]
+                     AVIS_SPC( C,R,3 ) = AVIS_SPC( C,R,3 ) + BLKDCV2  ! Reconstructed visual range [deciview]
+                     AVIS_SPC( C,R,4 ) = AVIS_SPC( C,R,4 ) + BLKEXT2  ! Reconstructed aero extinction [1/km]
+                  END IF
+                  IF ( WRITETIME ) THEN
+                     VIS_SPC( C,R,IDCVW1 ) = BLKDCV1  ! Mie visual range [deciview]
+                     VIS_SPC( C,R,IBEXT1 ) = BLKEXT1  ! Mie aero extinction [1/km]
+                     VIS_SPC( C,R,IDCVW2 ) = BLKDCV2  ! Reconstructed visual range [deciview]
+                     VIS_SPC( C,R,IBEXT2 ) = BLKEXT2  ! Reconstructed aero extinction [1/km]
+                  END IF
+               END IF
+
+               IF ( PMDIAG .OR. APMDIAG ) THEN
+                  TEMP_DATA(  7 ) = AEROMODE_DIAM( 1 ) * 1.0E6  ! wet i-mode diam.
+                  TEMP_DATA(  8 ) = AEROMODE_DIAM( 2 ) * 1.0E6  ! wet j-mode diam.
+                  TEMP_DATA(  9 ) = AEROMODE_DIAM( 3 ) * 1.0E6  ! wet k-mode diam.
+                  TEMP_DATA( 10 ) = MOMENT2_CONC( 1 )     ! wet i-mode 2nd moment
+                  TEMP_DATA( 11 ) = MOMENT2_CONC( 2 )     ! wet j-mode 2nd moment
+                  TEMP_DATA( 12 ) = MOMENT2_CONC( 3 )     ! wet k-mode 2nd moment
+                  TEMP_DATA( 16 ) = MOMENT3_CONC( 1 )     ! wet i-mode 3rd moment
+                  TEMP_DATA( 17 ) = MOMENT3_CONC( 2 )     ! wet j-mode 3rd moment
+                  TEMP_DATA( 18 ) = MOMENT3_CONC( 3 )     ! wet k-mode 3rd moment
+                  TEMP_DATA( 20 ) = fPM1( 1 )             ! i-mode PM1 fraction
+                  TEMP_DATA( 21 ) = fPM1( 2 )             ! j-mode PM1 fraction
+                  TEMP_DATA( 22 ) = fPM1( 3 )             ! k-mode PM1 fraction
+                  TEMP_DATA( 23 ) = fPM25( 1 )            ! i-mode fine fraction
+                  TEMP_DATA( 24 ) = fPM25( 2 )            ! j-mode fine fraction
+                  TEMP_DATA( 25 ) = fPM25( 3 )            ! k-mode fine fraction
+                  TEMP_DATA( 26 ) = fPM10( 1 )            ! i-mode PM10 fraction
+                  TEMP_DATA( 27 ) = fPM10( 2 )            ! j-mode PM10 fraction
+                  TEMP_DATA( 28 ) = fPM10( 3 )            ! k-mode PM10 fraction
+                  TEMP_DATA( 29 ) = fAMS( 1 )             ! i-mode fraction transmitted through AMS
+                  TEMP_DATA( 30 ) = fAMS( 2 )             ! j-mode fraction transmitted through AMS
+                  TEMP_DATA( 31 ) = fAMS( 3 )             ! k-mode fraction transmitted through AMS
+
+                  IF ( AERO_CHEM_SET ) THEN
+                     TEMP_DATA( 32 ) = GAMMA_N2O5IJ( C,R,L ) ! fine N2O5 heterorxn probability
+                     TEMP_DATA( 33 ) = GAMMA_N2O5K( C,R,L )  ! coarse N2O5 heterorxn probability
+                     TEMP_DATA( 34 ) = YCLNO2IJ( C,R,L )     ! fine CLNO2 heterorxn yield
+                     TEMP_DATA( 35 ) = YCLNO2K( C,R,L )      ! coarse CLNO2 heterorxn yield
+                     TEMP_DATA( 36 ) = GAMMA_IEPOX( C,R,L )  ! IEPOX heterorxn uptake coeff
+                  ELSE
+                     TEMP_DATA( 32:36 ) = 0.0
+                  END IF
+                  TEMP_DATA( 37 ) = AEROMODE_DENS( 1 )    ! Aitken Mode Density [kg m-3]
+                  TEMP_DATA( 38 ) = AEROMODE_DENS( 2 )    ! Accumulation Mode Density [kg m-3]
+                  TEMP_DATA( 39 ) = AEROMODE_DENS( 3 )    ! Coarse Mode Density [kg m3-]
+                  IF ( NUM_PMDIAG_SPC .GT. 39 ) THEN ! AERO6i
+                     TEMP_DATA( 40 ) = KPARTIEPOX( C,R,L )  ! Particle-Phase Rxn Rate Constant
+                     TEMP_DATA( 41 ) = GAMMA_IMAE( C,R,L )  ! IMAE Heterorxn Uptake Coeff
+                  END IF
+               END IF
+
+C *** Calculate 2nd and 3rd moments of the "dry" aerosol distribution
+C     NOTE! "dry" aerosol excludes both H2O and SOA  (Jan 2004 --SJR)
+C     EXCEPT!  nonvolatile SOA is part of dry aerosol (Oct 2007 --PVB)
+               CALL CALCMOMENTS( .FALSE. )
+               CALL GETPAR( FIXED_sg ) ! update AEROMODE_DIAM,DENS,SDEV
+
+               IF ( PMDIAG .OR. APMDIAG ) THEN
+                  TEMP_DATA(  1 ) = EXP( AEROMODE_LNSG( 1 ) )
+                  TEMP_DATA(  2 ) = EXP( AEROMODE_LNSG( 2 ) )
+                  TEMP_DATA(  3 ) = EXP( AEROMODE_LNSG( 3 ) )
+                  TEMP_DATA(  4 ) = AEROMODE_DIAM( 1 ) * 1.0E6  ! dry i-mode diam.
+                  TEMP_DATA(  5 ) = AEROMODE_DIAM( 2 ) * 1.0E6  ! dry j-mode diam.
+                  TEMP_DATA(  6 ) = AEROMODE_DIAM( 3 ) * 1.0e6  ! dry k-mode diam.
+                  TEMP_DATA( 13 ) = MOMENT3_CONC( 1 )    ! dry i-mode 3rd moment
+                  TEMP_DATA( 14 ) = MOMENT3_CONC( 2 )    ! dry j-mode 3rd moment
+                  TEMP_DATA( 15 ) = MOMENT3_CONC( 3 )    ! dry k-mode 3rd moment
+                  TEMP_DATA( 19 ) = AIRRH                ! relative humidity
+               END IF
+
+C *** Accumulate wet diameters, 2nd, and 3rd moments to average aerosol diagnostic array
+               IF ( APMDIAG .AND. L .LE. A_NLAYS ) THEN
+                  DO V = 1, NUM_PMDIAG_SPC
+                     IF ( A_PMDIAG_SPC_MAP( V ) .EQ. 1 ) THEN
+                        A_PMDIAG_SPC( C,R,L,V ) = A_PMDIAG_SPC( C,R,L,V ) + TEMP_DATA( V )
+                     END IF
+                  END DO 
+               END IF
+
+C *** Write dry aerosol distribution parameters to aerosol diagnostic array
+               IF ( WRITETIME .AND. PMDIAG ) PMDIAG_SPC( C,R,L,: ) = TEMP_DATA
+
+#ifdef twoway
+               IF ( CMAQ_WRF_FEEDBACK ) THEN
+                  IF ( TIME_TO_CALL_FEEDBACK_WRITE ) THEN
+                     CALL FEEDBACK_WRITE ( C, R, L, CGRID(C,R,L,:), CGRID(C,R,L,O3),
+!    &                                     aeromode_diam, AEROMODE_LNSG, jdate, jtime)
+     &                                     JDATE, JTIME )
+                  END IF
+               END IF
+#endif
+
+            END DO ! loop on MY_COLS
+         END DO ! loop on MY_ROWS
+      END DO ! loop on NLAYS
+
+      IF ( WRITETIME .AND. AOD ) CALL GET_AOD( CGRID )
+
+C *** From AEROPROC call to ORGAER...
+!     If ( pfc .gt. 0 ) Then
+!        Write( xmsg,'(a,i8)' ) 'possible false convergences in soa bisection:', pfc
+!        Call m3warn( pname, 0, 0, xmsg )
+!        pfc = 0
+!     End If
+
+C *** If last call this hour, write visibility information.
+      IF ( WRITETIME ) THEN
+         MDATE = JDATE
+         MTIME = JTIME
+         CALL NEXTIME ( MDATE, MTIME, TSTEP( 2 ) )
+         WSTEP = 0
+         WRITETIME = .FALSE.
+
+#ifdef parallel_io
+         IF ( FIRST_CTM_VIS_1 ) THEN
+            FIRST_CTM_VIS_1 = .FALSE.
+            IF ( .NOT. IO_PE_INCLUSIVE ) THEN
+               IF ( .NOT. OPEN3( CTM_VIS_1, FSREAD3, PNAME ) ) THEN
+                  XMSG = 'Could not open ' // TRIM( CTM_VIS_1 )
+                  CALL M3EXIT( PNAME, JDATE, JTIME, XMSG, XSTAT1 )
+               END IF
+            END IF
+            IF ( PMDIAG ) THEN
+               IF ( .NOT. IO_PE_INCLUSIVE ) THEN
+                  IF ( .NOT. OPEN3( CTM_PMDIAG_1, FSREAD3, PNAME ) ) THEN
+                     XMSG = 'Could not open ' // TRIM( CTM_PMDIAG_1 )
+                     CALL M3EXIT( PNAME, JDATE, JTIME, XMSG, XSTAT1 )
+                  END IF
+               END IF
+            END IF
+            IF ( APMDIAG ) THEN
+               IF ( .NOT. IO_PE_INCLUSIVE ) THEN
+                  IF ( .NOT. OPEN3( CTM_APMDIAG_1, FSREAD3, PNAME ) ) THEN
+                     XMSG = 'Could not open ' // TRIM( CTM_APMDIAG_1 )
+                     CALL M3EXIT( PNAME, JDATE, JTIME, XMSG, XSTAT1 )
+                  END IF
+               END IF
+            END IF
+            IF ( AOD ) THEN
+               IF ( .NOT. IO_PE_INCLUSIVE ) THEN
+                  IF ( .NOT. OPEN3( CTM_AOD_1, FSREAD3, PNAME ) ) THEN
+                     XMSG = 'Could not open ' // TRIM( CTM_AOD_1 )
+                     CALL M3EXIT( PNAME, JDATE, JTIME, XMSG, XSTAT1 )
+                  END IF
+               END IF
+            END IF
+         END IF
+#endif
+
+         IF ( .NOT. WRITE3( CTM_VIS_1, ALLVAR3,
+     &                      MDATE, MTIME, VIS_SPC ) ) THEN
+            XMSG = 'Could not write ' // CTM_VIS_1 // ' file'
+            CALL M3EXIT ( PNAME, MDATE, MTIME, XMSG, XSTAT1 )
+         END IF
+         WRITE( LOGDEV, '( /5X, 3( A, :, 1X ), I8, ":", I6.6 )' )
+     &                  'Timestep written to', CTM_VIS_1,
+     &                  'for date and time', MDATE, MTIME
+
+C *** Write data to the aerosol diagnostic file.
+         IF ( PMDIAG ) THEN
+
+            IF ( .NOT. WRITE3( CTM_PMDIAG_1, ALLVAR3,
+     &                         MDATE, MTIME, PMDIAG_SPC ) ) THEN
+               XMSG = 'Could not write ' // CTM_PMDIAG_1 // ' file'
+               CALL M3EXIT ( PNAME, MDATE, MTIME, XMSG, XSTAT1 )
+            END IF
+
+            WRITE( LOGDEV, '( /5X, 3( A, :, 1X ), I8, ":", I6.6 )' )
+     &                     'Timestep written to', CTM_PMDIAG_1,
+     &                     'for date and time', MDATE, MTIME
+
+         END IF
+     
+C *** Write data to the AOD diagnostic file.
+         IF ( AOD ) THEN
+
+            IF ( .NOT. WRITE3( CTM_AOD_1, ALLVAR3,
+     &                         MDATE, MTIME, AOD_DATA ) ) THEN
+               XMSG = 'Could not write ' // CTM_AOD_1 // ' file'
+               CALL M3EXIT ( PNAME, MDATE, MTIME, XMSG, XSTAT1 )
+            END IF
+
+            WRITE( LOGDEV, '( /5X, 3( A, :, 1X ), I8, ":", I6.6 )' )
+     &                     'Timestep written to', CTM_AOD_1,
+     &                     'for date and time', MDATE, MTIME
+
+         END IF
+
+         IF ( APMDIAG .OR. AVISDIAG ) THEN
+            IF ( .NOT. END_TIME ) THEN   ! ending time timestamp
+               CALL NEXTIME ( MDATE, MTIME, -TSTEP(1) )
+            END IF
+         END IF
+
+C *** Write data to the average aerosol diagnostic file.
+         IF ( APMDIAG ) THEN
+
+            DO V = 1, NUM_PMDIAG_SPC
+ 
+               IF ( A_PMDIAG_SPC_MAP( V ) .EQ. 1 ) THEN
+                  A_PMDIAG_SPC( :,:,:,V ) = A_PMDIAG_SPC( :,:,:,V ) / N_APMDIAG_STEP 
+
+                  IF ( .NOT. WRITE3( CTM_APMDIAG_1, PMDIAG_SPC_RECORD( V )%SPC_NAME,
+     &                               MDATE, MTIME, A_PMDIAG_SPC( :,:,:,V ) ) ) THEN
+                     XMSG = 'Could not write ' // CTM_APMDIAG_1 // ' file'
+                     CALL M3EXIT ( PNAME, MDATE, MTIME, XMSG, XSTAT1 )
+                  END IF
+                  A_PMDIAG_SPC( :,:,:,V ) = 0.0
+               END IF
+            END DO
+
+            WRITE( LOGDEV, '( /5X, 3( A, :, 1X ), I8, ":", I6.6 )' )
+     &                     'Timestep written to', CTM_APMDIAG_1,
+     &                     'for date and time', MDATE, MTIME
+
+            N_APMDIAG_STEP = 0
+         END IF
+     
+C *** Write data to the average visibility diagnostic file.
+         IF ( AVISDIAG ) THEN
+            AVIS_SPC = AVIS_SPC / N_VIS_STEP
+            IF ( .NOT. WRITE3( CTM_AVIS_1, ALLVAR3,
+     &                         MDATE, MTIME, AVIS_SPC ) ) THEN
+               XMSG = 'Could not write ' // CTM_AVIS_1 // ' file'
+               CALL M3EXIT ( PNAME, MDATE, MTIME, XMSG, XSTAT1 )
+            END IF
+            N_VIS_STEP = 0 
+            AVIS_SPC = 0.0
+         END IF
+
+         WRITE( LOGDEV, '( /5X, 3( A, :, 1X ), I8, ":", I6.6 )' )
+     &                  'Timestep written to', CTM_AVIS_1,
+     &                  'for date and time', MDATE, MTIME
+
+      END IF   ! WRITETIME
+
+      RETURN
+      END

--- a/DOCS/Known_Issues/CMAQv5.2-i5/aero_subs.F
+++ b/DOCS/Known_Issues/CMAQv5.2-i5/aero_subs.F
@@ -1,0 +1,3328 @@
+
+!------------------------------------------------------------------------!
+!  The Community Multiscale Air Quality (CMAQ) system software is in     !
+!  continuous development by various groups and is based on information  !
+!  from these groups: Federal Government employees, contractors working  !
+!  within a United States Government contract, and non-Federal sources   !
+!  including research institutions.  These groups give the Government    !
+!  permission to use, prepare derivative works of, and distribute copies !
+!  of their work in the CMAQ system to the public and to permit others   !
+!  to do so.  The United States Environmental Protection Agency          !
+!  therefore grants similar permission to use the CMAQ system software,  !
+!  but users are requested to provide copies of derivative works or      !
+!  products designed to operate in the CMAQ system to the United States  !
+!  Government without restrictions as to use by others.  Software        !
+!  that is used with the CMAQ system but distributed under the GNU       !
+!  General Public License or the GNU Lesser General Public License is    !
+!  subject to their copyright restrictions.                              !
+!------------------------------------------------------------------------!
+
+C RCS file, release, date & time of last delta, author, state, [and locker]
+C $Header: /project/yoj/arc/CCTM/src/aero/aero6_mp/aero_subs.F,v 1.3 2012/01/26 18:44:38 sjr Exp $
+
+C what(1) key, module and SID; SCCS file; date and time of last delta:
+C %W% %P% %G% %U%
+
+C routines for aerosol formation and transformation processes
+
+C:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+      SUBROUTINE AEROPROC( DT, COL, ROW, LAYER )
+
+C-----------------------------------------------------------------------
+C  SUBROUTINE AEROPROC advances the number, second moment, and mass
+C   concentrations for each mode over the time interval DT.
+
+C  KEY SUBROUTINES CALLED:
+C     GETPAR, ORGAER5, GETCOAGS, INTERCOAG_GH, INTRACOAG_GH,
+C     VOLINORG
+
+C  KEY FUNCTIONS CALLED:  ERF, ERFC, GETAF
+
+C  REVISION HISTORY:
+C     Coded in December 1999 by Dr. Francis S. Binkowski
+C      Modified from older versions used in CMAQ.
+
+C FSB 05/17/00  new version of RPMARES included
+
+C FSB 05/30/00  Fixed minor bug in awater.f
+
+C FSB Correction to extinction coefficient in getbext.
+
+C FSB 07/21/00 corrected units on ORGRATES and ORGBRATE_IN from
+C      ppm/min to ppm/sec in AEROPROC and AEROSTEP.
+
+C FSB 11/30/00 following changes from 07/28/00
+C     Fixed problem for new emissions file version
+C     Combined emissions for M3
+C     Used a fixed value of Dpmin for plotting
+C     Added variables OMEGA_AT & OMEGA_AC for partitioning
+C     Eliminated the restriction on relative humidity for nucleation.
+C     Added a branch in EQL for very low relative humidity (<1%).
+
+C FSB Following changes to RPMARES:
+C     Number of iterations reduced from 150 to 50.
+C     Iterations are used only if 0.5 < = RATIO.
+C     In calculating the molality of the bisulfate ion, a
+C     MAX(1.0e-10, MSO4 ) is used.
+
+C FSB 08/08/01 Changes to NEWPART to correct mass rate and to AEROSTEP
+C     to correct sulfate, include emissions, and trap problem in
+C     accumulation mode number calculation.
+
+C FSB 09/19/01 Version AE3, major changes
+C     Organics are done with Dr. Benedikt Schell's approach. (ORGAER3)
+C     Particle production uses Kulmala approach (NEWPART3)
+C     Condensational factors for sulfate and organics are calculated
+C      separately.
+C     Emissions are assumed to be input in vertical diffusion.
+C     Include files replaced by Fortran 90 Modules.
+C     The modules also contain subroutines.
+
+C FSB 10/24/01 Added the treatment of gaseous N2O5 -> aerosol HNO3
+
+C FSB 10/25/01 Changed the mass transfer calculation for Aitken to
+C     accumulation mode by coagulation as recommended by Dr. Benedikt
+C     Schell.
+
+C SJR 04/24/02 Replaced thermodynamic code RPMARES with ISORROPIA
+C     --Shawn J. Roselle
+
+C GLG 04/04/03 Modifications to allow for evaporation of semi-volatile
+C     organics from aerosol phase.  --Gerald L. Gipson
+
+C FSB 11/18/03 Corrections to sulfate condensation.  Previously,
+C     SCONDRATE was undefined when SO4RATE=0 and SCONDRATE was
+C     negative when SO4RATE < DMDT_so4.
+
+C PVB 01/08/04 Several changes in preparation for simulation of 2001
+C      calendar year --Dr. Prakash V. Bhave
+C    -Added interface to new subroutine, GETCOAGS, for calculating
+C      coagulation rates.  GETCOAGS is used instead of Gauss-Hermite
+C      quadrature for computational efficiency, by setting
+C      FASTCOAG_FLAG = .TRUE.  --PVB
+C    -Removed SOA from the definition of "DRY" aerosol.  Aerosol surface
+C      area is now transported without SOA.  See notes in GETPAR, AERO,
+C      and AERO_DEPV subroutines.  --SJR
+C    -Moved EQL3 call from AEROPROC to AEROSTEP, immediately following
+C      the ORGAER3 call.  This is a side effect of transporting aerosol
+C      surface area without SOA.  --SJR
+C    -New subroutine, HCOND3, to calculate condensation rates for
+C      2nd and 3rd moments.  Results are unchanged.  --FSB
+C    -Revised method of calculating SOA.  Partition SOA to the modes
+C      in proportion to the amounts of total organic mass (SOA plus
+C      primary) in each mode.  Modal geometric standard deviations are
+C      now preserved during SOA condensation and evaporation. --FSB
+C    -Combined the former subroutines AEROPROC and AEROSTEP into this
+C      subroutine; retained the name AEROPROC.  --PVB
+
+C PVB 09/21/04 added in-line documentation with input from FSB.
+C     Changed MWH2SO4 from 98.07354 to 98.0 g/mol for consistency with
+C     the mechanism files.
+
+C PVB 09/27/04 removed the IF(XM3.GT.0.0) mode-merging precondition
+C     because it caused significant erroneous mode crossover.  Fix
+C     suggested by Dr. Chris Nolte.
+
+C PVB 01/19/05 Added SO4RATE to the EQL3 call vector.  This is necessary
+C     to ensure that the gas and inorganic fine PM (i+j) concentrations
+C     are in thermodynamic equilibrium at the end of each time step.
+
+C PVB 05/02/05 Modified ERF statement function for negative arguments such
+C     that erf(-x) = -erf(x).  Previous version had erf(-x) = erf(x).
+
+C PVB 04/06/06 Added GAMMA_N2O5 to the AEROPROC and EQL3 call vectors,
+C     so it can be written to the aerosol diagnostic file.
+
+C SLN 09/07/07 Several changes in preparation for new SOA module
+C    -Removed Aitken-mode SOA species (CBLK(VORGAI),CBLK(VORGBI)) and
+C     all of the related variables (OMASS_I, OMASS_J, FRACI, FRACJ,
+C     OLD_M2_I, OLD_M3_I, NEW_M2_I, NEW_M3_I)
+C    -Replaced the other SOA species (CBLK(VORGAJ),CBLK(VORGBJ)) with
+C     precursor-specific SOA species (e.g., CBLK(VTOL1J)).
+C    -Replaced SOA_A and SOA_B with an array, SOA_ALL.  Replaced
+C     OLDSOA_A and OLDSOA_B with an array, OLDSOA.  Updated ORGAER3
+C     call vector accordingly.
+C    -Removed dependence of mode-merging criteria on SOA condensation
+C     because that logic was flawed.  Deleted all variables needed
+C     for that calculation (CHEMRATE_ORG, ORGRATE, ORGBRATE).
+
+C PVB 11/02/07 Moved heterogenous N2O5 chemistry from EQL3 to a new
+C     subroutine, HETCHEM.
+
+C PVB 11/29/07 Implementation of new SOA formation mechanisms
+C    -Replaced call to ORGAER3 with a call to ORGAER5
+C    -Moved CBLK updates of SV species, SOA species, M2, and M3 into
+C     ORGAER5 instead of updating those values in AEROPROC
+
+C JOY 04/08/08 White space, alignment, readability
+
+C JTK 04/17/08 Implemented coarse chemistry updates
+C     -replaced condensation calculations with call to VOLINORG
+C     -added code for coarse surface area and variable coarse std. dev.
+C     -modified modal dynamics equations because new particle formation
+C      and growth are now calculated in VOLINORG
+
+C JOY 12/07/08 Removed unused EQL3 code, add column and row arguments to
+C     VOLINORG for diagnostic logging
+
+C SH  12/17/09 Major restructuring of all aerosol codes
+C     -use new Fortran modules (e.g., AERO_DATA, SOA_DEFN); shortened call
+C      vector; replaced CBLK with aerospc structure; eliminated AERO_INFO
+
+C SH  03/10/11 Renamed met_data to aeromet_data
+
+C HS  03/10/11 Added call to POAAGE between ORGAER and HETCHEM
+
+C SR  03/25/11 Replaced I/O API include files with UTILIO_DEFN
+
+C BH  09/30/13 Removed Call to HETCHEM and GAMMA_N2O5 argument
+C              because of merging of gas and heterogeneous 
+C              chemistry
+
+C JB  02/07/14 Added Jai Xing's mass balance fix when there is excessive
+C              condensation or evaporation under cold conditions
+
+C BH  07/21/14 Removed call to POAAGE because reaction represented in
+C              chemical mechanism
+
+C GS/KF 09/23/14 Updated nucleation scheme with Vehkamaki et al. (2002)
+
+C HP/BM  4/16 Removed m3_wet_flag since wet/dry status is now
+C             tracked by AERO_DATA variable. Moments are always wet in AEROPROC
+C             Updated treatment of aerosol moments
+
+C  REFERENCES:
+C   1. Binkowski, F.S. and U. Shankar, The regional particulate matter
+C      model 1. Model description and preliminary results, J. Geophys.
+C      Res., Vol 100, No D12, 26101-26209, 1995.
+
+C   2. Binkowski, F.S. and S.J. Roselle, Models-3 Community
+C      Multiscale Air Quality (CMAQ) model aerosol component 1:
+C      Model Description.  J. Geophys. Res., Vol 108, No D6, 4183
+C      doi:10.1029/2001JD001409, 2003.
+
+C   3. Bhave, P.V., S.J. Roselle, F.S. Binkowski, C.G. Nolte, S. Yu,
+C      G.L. Gipson, and K.L. Schere, CMAQ aerosol module development:
+C      recent enhancements and future plans, Paper No. 6.8, CMAS Annual
+C      Conference, Chapel Hill, NC, 2004.
+C-----------------------------------------------------------------------
+      
+      USE AERO_DATA
+      USE PRECURSOR_DATA      ! gas phase aero precursor data
+      USE SOA_DEFN
+      USE AEROMET_DATA
+      USE UTILIO_DEFN
+
+      IMPLICIT NONE
+
+C *** arguments:
+      REAL,    INTENT( IN ) :: DT          ! synchronization time step, sec
+      INTEGER, INTENT( IN ) :: COL         ! Column of cell
+      INTEGER, INTENT( IN ) :: ROW         ! Row of cell
+      INTEGER, INTENT( IN ) :: LAYER       ! Layer of cell
+
+C *** Parameters
+      REAL, PARAMETER :: DIFFSULF = 9.36E-06  ! molecular diffusiviity for sulfuric acid
+      REAL, PARAMETER :: SQRT2 = 1.4142135623731
+      REAL, PARAMETER :: T0 = 288.15   ! [ K ]
+      REAL, PARAMETER :: TWOTHIRDS   =  2.0 / 3.0
+      REAL, PARAMETER :: ONE_OVER_TICE =  1.0 / 273.16
+
+C *** local variables
+      REAL         DIFFCORR   ! Correction to DIFFSULF & DIFFORG for pressure
+      REAL         DV_SO4     ! molecular diffusivity of H2SO4 vapor after correction for ambient conditions
+      REAL         SQRT_TEMP  ! square root of ambient temperature
+      REAL         XLM        ! atmospheric mean free path [m]
+      REAL         AMU        ! atmospheric dynamic viscosity [kg/m s]
+
+      REAL( 8 ) :: CGR( N_MODE-1 ) ! Aitken & Accum. modes
+
+      REAL( 8 ) :: LAMDA      ! mean free path [ m ]
+      REAL( 8 ) :: KNC        ! KNC = TWO3 * BOLTZMANN *  AIRTEMP / AMU
+
+C *** Free Molecular regime (depends upon modal density)
+      REAL( 8 ) :: KFMAT      ! = SQRT( 3.0*BOLTZMANN * AIRTEMP / PDENSAT )
+      REAL( 8 ) :: KFMAC      ! = SQRT( 3.0*BOLTZMANN * AIRTEMP / PDENSAC )
+      REAL( 8 ) :: KFMATAC    ! = SQRT( 6.0*BOLTZMANN * AIRTEMP / ( PDENSAT + PDENSAC ) )
+
+C *** Intermodal coagulation rates [ m**3/s ] ( 0th & 2nd moments )
+      REAL( 8 ) :: BATAC( 2 ) ! Aitken to accumulation
+      REAL( 8 ) :: BACAT( 2 ) ! accumulation from Aitken
+
+C *** Intramodal coagulation rates [ m**3/s ] ( 0th & 2nd moments )
+      REAL( 8 ) :: BATAT( 2 ) ! Aitken mode
+      REAL( 8 ) :: BACAC( 2 ) ! accumulation mode
+
+C *** Intermodal coagulation rate [ m**3/s ] ( 3rd moment )
+      REAL( 8 ) :: C3IJ       ! Aitken to accumulation
+      REAL( 8 ) :: C30ATAC    ! Aitken to accumulation
+      REAL( 8 ) :: DG_D ( N_MODE )
+      REAL( 8 ) :: SG_D ( N_MODE )
+      REAL( 8 ) :: XXL_D( N_MODE )
+
+C *** variables for advancing concentrations one time step
+      REAL( 8 ) :: A, B
+      REAL( 8 ) :: Y0, Y
+      REAL( 8 ) :: EXPDT
+      REAL( 8 ) :: LOSS, PROD, POL
+      REAL         TMASS
+      REAL         FACTRANS ! special factor to compute mass transfer
+      REAL         M20      ! for initial condidtions in time stepping
+
+C *** Variables for mode merging
+      REAL         GETAF
+      REAL         AAA, XNUM, XM2, XM3,XXM2, XXM3
+      REAL         FNUM, FM2, FM3, PHNUM, PHM2, PHM3
+      REAL         ERF, ERFC    ! Error and complementary error function
+
+C *** local variables
+      INTEGER      SPC        ! loop counter
+      INTEGER      N          ! loop counter
+
+      integer, save :: logdev 
+      logical, save :: firstime = .true.
+C-----------------------------------------------------------------------
+
+      if ( firstime ) then
+         firstime = .false.
+         logdev = init3()
+#ifdef nomm
+         write( logdev,* ) 'aero_subs: nomm'
+#endif
+      end if
+
+C *** square root of the ambient temperature for later use
+      SQRT_TEMP = SQRT( AIRTEMP )
+ 
+C *** Calculate mean free path [ m ]:
+C     6.6328E-8 is the sea level value given in Table I.2.8
+C     on page 10 of U.S. Standard Atmosphere 1962
+
+      XLM = 6.6328E-8 * STDATMPA * AIRTEMP  / ( T0 * AIRPRES )
+
+C *** Calculate dynamic viscosity [ kg m**-1 s**-1 ]:
+C     U.S. Standard Atmosphere 1962 page 14 expression
+C     for dynamic viscosity is:
+C     dynamic viscosity =  beta * T * sqrt(T) / ( T + S)
+C     where beta = 1.458e-6 [ kg sec^-1 K**-0.5 ], s = 110.4 [ K ].
+      AMU = 1.458E-6 * AIRTEMP * SQRT_TEMP / ( AIRTEMP + 110.4 )
+
+C *** Set minimums for coarse mode
+      MOMENT0_CONC( N_MODE ) = MAX( AEROMODE_MINNUM( N_MODE ),
+     &                              MOMENT0_CONC( N_MODE ) )
+
+C *** Secondary Organics
+C     Update the secondary organic aerosol (SOA) mass concentrations
+C     and the SVOC mass concentrations by equilibrium absorptive
+C     partitioning between the particle and vapor phases.  Assume all
+C     SOA resides in the accumulation mode.
+C
+C     Aerosol is wet when it enters orgaer
+      CALL ORGAER( DT, LAYER )
+
+C *** Secondary Inorganics
+C     The VOLINORG subroutine includes the treatment of new particle
+C     production and a fully dynamic treatment of inorganic gas-to-
+C     particle mass transfer.
+
+C *** Compute H2SO4 diffusivity, correct for temperature and pressure
+      DIFFCORR = ( STDATMPA / AIRPRES ) * ( ONE_OVER_TICE * AIRTEMP ) ** 1.75
+      DV_SO4 = DIFFSULF * DIFFCORR
+
+C *** Update size parameters (distribution is wet from ORGAER)
+      CALL GETPAR( FIXED_sg )
+
+      CALL VOLINORG( DT, COL, ROW, LAYER, DV_SO4, CGR )
+
+C *** Coagulation
+C     Calculate coagulation coefficients using a method dictated by
+C     the value of FASTCOAG_FLAG.  If TRUE, the computationally-
+C     efficient GETCOAGS routine is used.  If FALSE, the more intensive
+C     Gauss-Hermite numerical quadrature method is used.  See Section
+C     2.1 of Bhave et al. (2004) for further discussion.
+
+C *** set atmospheric mean free path in double precision
+      LAMDA    = XLM
+
+C *** calculate term used in Equation A6 of Binkowski & Shankar (1995)
+      KNC      = TWOTHIRDS * BOLTZMANN *  AIRTEMP / AMU
+
+C *** calculate terms used in Equation A5 of Binkowski & Shankar (1995)
+      KFMAT    = SQRT( 3.0 * BOLTZMANN * AIRTEMP / AEROMODE_DENS( 1 ) )
+      KFMAC    = SQRT( 3.0 * BOLTZMANN * AIRTEMP / AEROMODE_DENS( 2 ) )
+      KFMATAC  = SQRT( 6.0 * BOLTZMANN * AIRTEMP
+     &         / ( AEROMODE_DENS( 1 ) + AEROMODE_DENS( 2 ) ) )
+
+C *** transfer of number to accumulation mode from Aitken mode is zero
+      BACAT( 1 ) = 0.0
+
+      IF ( FASTCOAG_FLAG ) THEN ! Solve coagulation analytically
+
+C *** set geometric mean diameters, geometric standard deviations, and
+C     ln(GSD) in double precision
+         DO N = 1, N_MODE
+            DG_D( N ) = AEROMODE_DIAM( N )
+            SG_D( N ) = EXP( AEROMODE_LNSG( N ) )
+            XXL_D( N ) = AEROMODE_LNSG( N )
+         END DO
+
+C *** calculate intermodal and intramodal coagulation coefficients
+C     for zeroth and second moments, and intermodal coagulation
+C     coefficient for third moment
+         CALL GETCOAGS( LAMDA, KFMATAC, KFMAT, KFMAC, KNC,
+     &                  DG_D(1), DG_D(2), SG_D(1), SG_D(2),
+     &                  XXL_D(1),XXL_D(2),
+     &                  BATAT( 2 ), BATAT( 1 ), BACAC( 2 ), BACAC( 1 ),
+     &                  BATAC( 2 ), BACAT( 2 ), BATAC( 1 ), C3IJ )
+
+      ELSE                 ! Use Gauss-Hermite numerical quadrature
+
+C *** calculate Aitken-mode intramodal coagulation coefficients
+C     for zeroth and second moments
+         CALL INTRACOAG_GH( LAMDA, KFMAT, KNC, AEROMODE_DIAM( 1 ),
+     &                      AEROMODE_LNSG( 1 ), BATAT( 2 ), BATAT( 1 ) )
+
+C *** calculate accumulation-mode intramodal coagulation coefficients
+C     for zeroth and second moments
+         CALL INTRACOAG_GH( LAMDA, KFMAC, KNC, AEROMODE_DIAM( 2 ),
+     &                      AEROMODE_LNSG( 2 ), BACAC( 2 ), BACAC( 1 ) )
+
+C *** calculate intermodal coagulation coefficients for zeroth, second,
+C     and third moments
+         CALL INTERCOAG_GH( LAMDA, KFMATAC, KNC,
+     &                      AEROMODE_DIAM( 1 ), AEROMODE_DIAM( 2 ),
+     &                      AEROMODE_LNSG( 1 ), AEROMODE_LNSG( 2 ),
+     &                      BATAC( 2 ), BACAT( 2 ), BATAC( 1 ), C3IJ )
+
+      END IF   ! FASTCOAG_FLAG
+
+C *** calculate 3rd moment intermodal transfer rate by coagulation
+      C30ATAC = C3IJ * MOMENT0_CONC( 1 ) * MOMENT0_CONC( 2 )
+
+C *** TAKE ONE FORWARD TIME STEP - Solve Modal Dynamics Equations
+C     This code implements Section 1.4 of Binkowski and Roselle (2003)
+C     with two notable exceptions.  1) emissions are treated in
+C     CMAQ`s vertical diffusion routine, so they do not appear in the
+C     following equations. 2) new particle formation and condensational
+C     growth are now treated in the VOLINORG subroutine, so they do not
+C     appear in the following equations.
+ 
+C     M2 is updated before M0 because the intermodal transfer rate of
+C     M2 is a function of the number concentrations.  In contrast,
+C     production and loss rates of M0 are independent of M2.  Advancing
+C     M2 before M0 avoids operator splitting within the modal-dynamic-
+C     equation solution.  A similar rearrangement would be necessary
+C     for the M3 update, but the dependence of M3 on number
+C     concentrations already is accounted for in the C30ATAC term.
+
+C *** UPDATE SECOND MOMENT
+C     For each lognormal mode, solve equations of form:
+C        dM2/dt = P2 - L2*M2   ! if L2 > 0
+C     with solution
+C        M2(t) = P2/L2 + ( M2(t0) - P2/L2 ) * exp( -L2*dt )
+C     or
+C        dM2/dt = P2           ! if L2 = 0
+C     with solution
+C        M2(t) = M2(t0) + P2*dt
+
+C *** Aitken mode: initial value of M2
+      M20 = MOMENT2_CONC( 1 )
+
+C *** Loss of 2nd moment from Aitken mode is due to intermodal
+C     coagulation with accumulation mode and intramodal coagulation.
+C     Production term is removed, because new particle formation
+C     and condensational growth are accounted for in VOLINORG.
+      LOSS = (
+     &        ( BATAT( 2 ) * MOMENT0_CONC( 1 )
+     &        + BATAC( 2 ) * MOMENT0_CONC( 2 ) ) * MOMENT0_CONC( 1 )
+     &       ) / M20
+
+C *** Solve for M2_Aitken based on LOSS during this time step
+C     Note: LOSS is assumed to be non-negative.
+      IF ( LOSS .GT. 0.0 ) THEN
+         Y = M20 * EXP( -LOSS * DT )
+      ELSE
+         Y = M20
+      END IF ! test on loss
+
+C *** Transfer new value of M2_Aitken to the array
+      MOMENT2_CONC( 1 ) = MAX( REAL( AEROMODE_MINM2( 1 ) ), REAL( Y ) )
+
+C *** Accumulation mode: initial value of M2
+      M20 = MOMENT2_CONC( 2 )
+
+C *** Production of 2nd moment in accumulation mode is due to
+C     intermodal coagulation Aitken mode
+      PROD = BACAT( 2 ) * MOMENT0_CONC( 1 ) * MOMENT0_CONC( 2 )
+
+C *** Loss of 2nd moment from accumulation mode is due only to
+C     intramodal coagulation
+      LOSS = ( BACAC( 2 ) * MOMENT0_CONC( 2 ) * MOMENT0_CONC( 2 ) ) / M20
+
+C *** Solve for M2_accum based on PROD and LOSS during this time step
+C     Note: LOSS is assumed to be non-negative.
+      IF ( LOSS .GT. 0.0 ) THEN
+         POL = PROD / LOSS
+         Y = POL + ( M20 - POL ) * EXP( -LOSS * DT )
+      ELSE
+         Y = M20 + PROD * DT
+      END IF ! test on loss
+
+C *** Transfer new value of M2_accum to moment array
+      MOMENT2_CONC( 2 ) = MAX( REAL( AEROMODE_MINM2( 2 ) ), REAL( Y ) )
+
+C *** Coarse mode: no change because coagulation of coarse particles
+C     is neglected in current model version.
+
+C *** end of update for second moment
+
+C *** Update Zeroth Moment (i.e. number concentration)
+
+C *** Aitken mode: initial value of M0
+
+      Y0 = MOMENT0_CONC( 1 )
+
+C *** The rate of change for M0_Aitken is described in Equation 8a of
+C     Binkowski & Roselle (2003), with the c_i term equal to 0.
+
+      A = BATAT( 1 )                      ! intramodal coagulation
+      B = BATAC( 1 ) * moment0_conc( 2 )  ! intermodal coagulation
+
+      EXPDT = EXP( - B * DT )
+      IF ( EXPDT .LT. 1.0D0 ) THEN
+         Y = B * Y0 * EXPDT / ( B + A * Y0 * ( 1.0D0 - EXPDT ) )
+      ELSE
+         Y = Y0                 ! solution in the limit that B approaches zero
+      END IF
+
+C *** Transfer new value of M0_Aitken to the moment array
+      MOMENT0_CONC( 1 ) = MAX( AEROMODE_MINNUM( 1 ), REAL( Y ) )
+
+C *** Accumulation mode: initial value of M0
+      Y0 = MOMENT0_CONC( 2 )
+
+C *** The rate of change for M0_accum is described in Equation 8b of
+C     Binkowski & Roselle (2003), except the coefficient C is zero
+C     because emissions are treated outside the CMAQ aerosol module.
+C     The equation reduces to the form: dY/dt = -A * Y**2 , where
+      A = BACAC( 1 )                 ! intramodal coagulation
+
+C *** Solve for M0_accum using Smoluchowski`s solution
+      Y = Y0 / ( 1.0D0 + A * Y0 * DT )
+
+C *** Transfer new value of M0_accum to the moment array
+      MOMENT0_CONC( 2 ) = MAX( AEROMODE_MINNUM( 2 ), REAL( Y ) )
+
+C *** end of update for zeroth moment - note that the coarse mode number does
+C     not change because coarse-mode coagulation is neglected in the model
+
+C *** UPDATE MASS CONCENTRATIONS (for each species)
+C     The following procedure is described in Paragraphs 21-23
+C     of Binkowski & Roselle (2003), except the Ei,n and Ej,n terms
+C     are excluded here because emissions are treated outside the
+C     CMAQ aerosol module.
+
+C     Aitken mode mass concentration rates of change are of the form:
+C        dc/dt = P - L*c    ! Equation 9a of Binkowski & Roselle (2003)
+C     with solution
+C        c(t0 + dt) = P/L + ( c(t0) - P/L ) * exp(-L*dt)
+
+C     For all species, loss of Aitken mode mass is due to intermodal
+C     coagulation.
+C        LOSSn = PI/6 * RHOn * C30ATAC / MASSn
+C        RHOn  = MASSn / (M3 * PI/6)
+C     When above equations are combined, the PI/6 terms cancel yielding
+C        LOSSn = C30ATAC / M3
+C     where LOSSn is the loss rate of species n, RHOn is the mass of
+C     species n per unit of particle volume, C30ATAC is the 3rd moment
+C     loss rate due to intermodal coagulation, MASSn is the mass
+C     concentration of species n, and M3 is the 3rd moment
+C     concentration.
+
+      LOSS = C30ATAC / MOMENT3_CONC( 1 )
+
+C *** Set up extra variables to solve for Aitken mode mass concentrations
+      FACTRANS = REAL( LOSS,4 ) * DT
+      EXPDT = EXP( -FACTRANS )
+
+C *** Transfer mass from Aitken to accumulation mode, resulting from 
+C     intermodal coagulation.
+
+      DO SPC = 1, N_AEROSPC
+         IF ( AERO_MISSING(SPC,1) ) CYCLE
+ 
+         TMASS = AEROSPC_CONC( SPC,1 ) + AEROSPC_CONC( SPC,2 )
+         IF( SPC .EQ. APHGJ_IDX  )THEN 
+! assumes all production adsorb onto accumulation mode
+             TMASS = TMASS + PHG_RATE * DT
+         END IF
+
+         AEROSPC_CONC( SPC,1 ) = MAX( AEROSPC( SPC )%MIN_CONC( 1 ),
+     &                                REAL( AEROSPC_CONC( SPC,1 ) * EXPDT ) )
+         AEROSPC_CONC( SPC,2 ) = MAX( AEROSPC( SPC )%MIN_CONC( 2 ),
+     &                                TMASS - AEROSPC_CONC( SPC,1 ) )
+      END DO
+
+C *** end of update for species mass concentrations
+
+C *** Mode Merging
+C     This code implements Section 1.5 of Binkowski and Roselle (2003).
+C     If the Aitken mode mass is growing faster than accumulation mode
+C     mass and the Aitken mode number concentration exceeds the
+C     accumulation mode number concentration, then modes are merged by
+C     renaming.
+
+#ifdef nomm
+      if ( .false. ) then
+#else
+      IF ( CGR( 1 ) .GT. CGR( 2 ) .AND.
+     &     MOMENT0_CONC( 1 ) .GT. MOMENT0_CONC( 2 ) ) THEN
+#endif
+
+C *** Before mode merging, update the third moments, geometric mean
+C     diameters, geometric standard deviations, modal mass totals, and
+C     particle densities, based on the new concentrations of M2, M0, and
+C     speciated masses calculated above. This is still the wet
+C     distribution.
+         CALL GETPAR( FIXED_sg )
+
+C *** Calculate AAA = ln( Dij / DGATK ) / ( SQRT2 * XXLSGAT ), where Dij
+C     is the diameter at which the Aitken-mode and accumulation-mode
+C     number distributions intersect (i.e., overlap).  AAA is equivalent
+C     to the "Xnum" term described below Equation 10a by Binkowski and
+C     Roselle (2003).
+         AAA = GETAF( MOMENT0_CONC( 1 ), MOMENT0_CONC( 2 ),
+     &                AEROMODE_DIAM( 1 ), AEROMODE_DIAM( 2 ), 
+     &                AEROMODE_LNSG( 1 ), AEROMODE_LNSG( 2 ),
+     &                SQRT2 ) 
+
+C *** Ensure that Xnum is large enough so that no more than half of
+C     the Aitken mode mass is merged into the accumulation mode during
+C     any given time step.  This criterion is described in Paragraph 26
+C     of Binkowski and Roselle (2003).
+         XXM3 = 3.0 * AEROMODE_LNSG( 1 ) / SQRT2
+         XNUM = MAX( AAA, XXM3 )
+
+C *** Factors used in error function calls for M2 and M3 mode merging
+         XXM2 = TWOTHIRDS * XXM3
+         XM2  = XNUM - XXM2 ! set up for 2nd moment transfer
+         XM3  = XNUM - XXM3 ! set up for 3rd moment and mass transfers
+
+C *** Calculate the fractions of the number, 2nd, and 3rd moment
+C     distributions with diameter greater than the intersection diameter
+         FNUM  = 0.5 * ERFC( XNUM )            ! Eq 10a of B&R 2003
+         FM2   = 0.5 * ERFC( XM2 )             ! Eq 10b of B&R 2003
+         FM3   = 0.5 * ERFC( XM3 )             ! Eq 10b of B&R 2003
+
+C *** Calculate the fractions of the number, 2nd, and 3rd moment
+C     distributions with diameters less than the intersection diameter.
+         PHNUM = 0.5 * ( 1.0 + ERF( XNUM ) )  ! Eq 10c of B&R 2003
+         PHM2  = 0.5 * ( 1.0 + ERF( XM2 ) )   ! Eq 10d of B&R 2003
+         PHM3  = 0.5 * ( 1.0 + ERF( XM3 ) )   ! Eq 10d of B&R 2003
+
+C *** Update accumulation-mode moment concentrations using
+C     Equations 11a - 11c of Binkowski and Roselle (2003).
+         MOMENT0_CONC( 2 ) = MOMENT0_CONC( 2 ) + MOMENT0_CONC( 1 ) * FNUM
+         MOMENT2_CONC( 2 ) = MOMENT2_CONC( 2 ) + MOMENT2_CONC( 1 ) * FM2
+         MOMENT3_CONC( 2 ) = MOMENT3_CONC( 2 ) + MOMENT3_CONC( 1 ) * FM3
+
+C *** Update Aitken-mode moment concentrations using
+C     Equations 11d - 11f of Binkowski and Roselle (2003).
+         MOMENT0_CONC( 1 ) = MOMENT0_CONC( 1 ) * PHNUM
+         MOMENT2_CONC( 1 ) = MOMENT2_CONC( 1 ) * PHM2
+         MOMENT3_CONC( 1 ) = MOMENT3_CONC( 1 ) * PHM3
+ 
+C *** Rename masses of each species from Aitken mode to acumulation mode
+C     using Equation 11b of Binkowski and Roselle (2003). Do this for
+C     all species, even the aerosol water.
+         DO SPC = 1, N_AEROSPC
+            IF ( AERO_MISSING(SPC,1) ) CYCLE
+
+            AEROSPC_CONC( SPC,2 ) = AEROSPC_CONC( SPC,2 ) + AEROSPC_CONC( SPC,1 ) * FM3
+            AEROSPC_CONC( SPC,1 ) = AEROSPC_CONC( SPC,1 ) * PHM3
+         END DO
+
+      END IF ! end check on necessity for merging
+
+C *** end of update for mode merging
+
+C *** Update the third moments, geometric mean diameters, geometric
+C     standard deviations, modal mass totals, and particle densities,
+C     based on the final concentrations of M2, M0, and speciated masses
+C     after mode merging is complete. This should be done for the wet
+C     distribution.
+      CALL GETPAR( FIXED_sg )
+
+C *** Set minimum value for all concentrations in the CBLK array
+
+      DO N = 1, N_MODE
+         DO SPC = 1, N_AEROSPC
+            AEROSPC_CONC( SPC,N ) = MAX( AEROSPC_CONC( SPC,N ),
+     &                                   AEROSPC( SPC )%MIN_CONC( N ) )
+         END DO
+      END DO
+
+      RETURN
+      END SUBROUTINE AEROPROC
+
+
+C:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+      SUBROUTINE VOLINORG( DT, COL, ROW, LAYER, DV_SO4, CGR )
+
+C *** Calculates the partitioning of inorganic components (CL,NO3,NH4,SO4)
+C     between the aerosol and gas phase over the operator synchronization
+C     timestep (DT). Partitioning is calculated using the Hybrid approach,
+C     where dynamic mass transfer of species to/from the coarse mode is
+C     calculated using multiple sub-operator time steps (TSTEP) and the
+C     fine modes are equilibrated with the gas phase. The mass transfer
+C     calculations are made using the H+ flux-limiting approach of Pilinis
+C     et al. (2000). If 'OPTIONFLAG' is not set to 'Hybrid', the mass
+C     transfer calculations for the coarse mode are skipped, and the fine
+C     modes are equilibrated with the gas phase.
+
+C     Returns updated volatile inorganic species concentrations in the gas
+C     and particulate phase, and the aerosol modal parameters
+
+C *** Revision history: 4/07 - Moved HCOND3 and NEWPART3 calls from 
+C                              AEROPROC to this subroutine for 
+C                              mass transfer calculation  
+C     15 Jul 08 J.Young, P.Bhave: increased cutoff to hybrid from .01 to .05 ug/m**3
+C               J.Young: change 'OPTIONFLAG' to just a logical variable, 'Hybrid'
+
+C     10 Mar 11 S.Howard Renamed met_data to aeromet_data
+C     25 Mar 11 S.Roselle Replaced I/O API include files with UTILIO_DEFN
+C     26 Apr 11 G.Sarwar Replaced existing ISORROPIA with ISORROPIA 2.1
+C               Updated coarse-mode aerosol speciation and H+ calculation  
+C     12 Apr 16 H. Pye and B. Murphy: Update with consistent treatment for wet particles.
+C     15 Apr 16 J.Young: Use aerosol factors from AERO_DATA module named constants
+
+C *** References
+C 1. Pilinis C, Capaldo KP, Nenes A, Pandis SN (2000) MADM - A new
+C    multicomponent aerosol dynamics model. AEROSOL SCIENCE AND TECHNOLOGY.
+C    32(5):482-502
+C
+C 2. Capaldo KP, Pilinis C, Pandis SN (2000) A computationally efficient hybrid
+C    approach for dynamic gas/aerosol transfer in air quality models. ATMOSPHERIC
+C    ENVIRONMENT. 34(21):3617-3627
+C
+C 3. Fountoukis C, Nenes, A (2007) ISORROPIA II: a comnputationally efficient 
+C    thermodynamic equilibrium model for K+-Ca2+-Mg2+-NH4+-SO42--NO3--Cl-H2O 
+C    aerosols. ATMOSPHERIC CHEMISTRY AND PHYSICS. 7, 4639-4659
+
+      USE AERO_DATA
+      USE PRECURSOR_DATA
+      USE SOA_DEFN
+      USE AEROMET_DATA
+      USE UTILIO_DEFN
+
+      IMPLICIT NONE
+
+C *** Arguments:
+      REAL    DT              ! time step [sec]
+      INTEGER COL             ! grid column index
+      INTEGER ROW             ! grid row index
+      INTEGER LAYER           ! model layer index
+      REAL    DV_SO4          ! molecular diffusivity of H2SO4 vapor 
+                              ! after correction for ambient conditions
+      REAL( 8 ) :: CGR( N_MODE-1 ) ! 3rd moment SO4 growth rate [m^3/m^3-s]
+
+C *** Parameters: 
+      INTEGER, PARAMETER :: NINORG = 9      ! number of inorganic species
+      INTEGER, PARAMETER :: NVOLINORG = 3   ! number of volatile inorganic species
+
+      ! indices for inorganic species
+!     INTEGER, PARAMETER :: KNH4 = 1, KNO3 = 2, KCL = 3, KSO4 = 4, KNA = 5, KHP = 6, KMG = 7, KK = 8, KCA = 9
+      INTEGER, PARAMETER :: KNH4 = 1, KNO3 = 2, KCL = 3, KSO4 = 4, KNA = 5, KMG = 6, KK = 7, KCA = 8, KHP = 9
+
+      REAL( 8 ), PARAMETER :: D_TWOTHIRDS = 2.0D0 / 3.0D0
+
+      REAL, PARAMETER :: CUTOFF = 0.05  ! [ug/m**3]
+      REAL, PARAMETER :: ALPHSULF = 0.1 ! Accommodation coefficient for sulfuric acid
+                                        ! see Capaldo et al. (2000)
+
+C *** Local Variables:
+
+C *** Inputs to subroutine HCOND3
+
+      REAL, SAVE :: COFCBAR_SO4  ! Temperature-independent coefficients
+                                 ! for caculating molecular vel [m/s]
+                                 ! = sqrt((8*Rgas)/(pi*MW)) 
+      REAL         CBAR_SO4      ! molecular velocity of H2SO4                      
+
+      REAL( 8 ) :: AM0( N_MODE ) ! zeroth moments
+      REAL( 8 ) :: AM1( N_MODE ) ! first moments
+      REAL( 8 ) :: AM2( N_MODE ) ! second moments
+
+      REAL( 8 ) :: M2DRY_INIT( N_MODE )  ! Dry Second Moment Initial Array
+      REAL( 8 ) :: M3DRY_INIT( N_MODE )  ! Dry Third Moment Initial Array
+      REAL( 8 ) :: M2WET_INIT( N_MODE )  ! Wet Second Moment Initial Array
+      REAL( 8 ) :: M3WET_INIT( N_MODE )  ! Wet Third Moment Initial Array
+      REAL( 8 ) :: M2WET_FINAL( N_MODE ) ! Wet Second Moment Final Array
+      REAL( 8 ) :: M3WET_FINAL( N_MODE ) ! Wet Third Moment Final Array
+
+C *** Outputs from HCOND3: size-dependent term in the condensational-growth 
+C     expressions defined in Equations A13-A14 of [Binkowski & Shankar,1995]
+      REAL( 8 ) :: FCONC_SO4( N_MODE,2 )  ! All sizes 2nd and 3rd moments
+      REAL( 8 ) :: FCONC_OUT( 2 )         ! Output for HCOND3, 2nd and 3rd moments
+      REAL( 8 ) :: FCONCM1_SO4       ! reciprocals of total SO4 cond rates
+
+C *** Modal partition factors [ dimensionless ]
+C     defined in Equations A17-A18 of [Binkowski & Shankar,1995]
+      REAL( 8 ) :: OMEGA_AT_SO4  ! Aitken mode 2nd and 3rd moments
+      REAL( 8 ) :: OMEGA_AC_SO4  ! Accumulation mode 2nd and 3rd moments
+      REAL( 8 ) :: OMEGA( 2 )    ! partitioning coefficient for equilibrium PM mass
+      REAL( 8 ) :: PHI( NINORG,2 ) ! Mass Fraction of each component in each aerosol mode
+      REAL( 8 ) :: TOTAER( NINORG )! Total aerosol component across multiple modes 
+
+C *** Variables for new particle formation:
+      REAL XH2SO4            ! steady state H2SO4 concentration
+      REAL( 8 ) :: DMDT_SO4  ! particle mass production rate [ ug/m**3 s ]
+      REAL( 8 ) :: DNDT      ! particle number production rate [ # / m**3 s ]
+      REAL( 8 ) :: DM2DT     ! second moment production rate [ m**2 / m**3 s]
+      REAL( 8 ) :: SCONDRATE ! SO4 condensation rate [ ug/m**3 s ]
+
+C *** Mode-specific sulfate production rate [ ug/m**3 s ]
+      REAL( 8 ) :: CONDSO4( N_MODE )    ! sulfate condensation rate [ ug/m**3 s ]
+      REAL( 8 ) :: RATE                 ! CONDSO4 or cond+nucl rate
+
+C *** Size-dependent portion of mass-transfer rate equation
+      REAL( 8 ) :: GRFAC1( N_MODE )     ! 2nd moment [ m**2/m**3-s ] 
+      REAL( 8 ) :: GRFAC2( N_MODE )     ! 3rd moment [ m**3/m**3-s ] 
+      
+C *** ISORROPIA input variables
+      REAL( 8 ) :: WI( NINORG - 1 )     ! species array [ mol/m**3 ]
+      REAL( 8 ) :: RHI                  ! relative humidity [ fraction ]
+      REAL( 8 ) :: TEMPI                ! temperature   [ deg K]
+      REAL( 8 ) :: CNTRL( 2 )           ! ISOROPIA control parameters 
+
+C *** ISORROPIA output variables
+      REAL( 8 ) :: WT( NINORG - 1 )     ! species output array (unused)
+      REAL( 8 ) :: GAS( 3 )             ! gas-phase   "     " 
+      REAL( 8 ) :: AERLIQ( 15 )         ! liq aerosol "     " 
+      REAL( 8 ) :: AERSLD( 19 )         ! solid "     "     "  (unused)
+      REAL( 8 ) :: OTHER( 9 )           ! supplmentary output array (unused)
+      CHARACTER( 15 ) :: SCASI          ! subcase number output (unused)
+
+C *** Variables to account for mass conservation violations in ISRP3F
+!     LOGICAL TRUSTNH4                  ! false if ISOROPIA's partitioning
+                                        !  of NH4/NH3 is to be ignored
+      LOGICAL TRUSTCL                   ! false if ISOROPIA's partitioning       
+                                        !  of Cl/HCl is to be ignored
+
+C *** Initial (double-precision) concentrations [ug/m3]
+      REAL( 8 ) :: GNH3R8               ! gas-phase ammonia
+      REAL( 8 ) :: GNO3R8               ! gas-phase nitric acid
+      REAL( 8 ) :: GCLR8                ! gas-phase hydrochloric acid
+
+C *** Variables for volatile species mass transfer between gas and aerosol and
+C     mass partitioning between the modes 
+      LOGICAL HYBRID ! mass transfer option flag (mass transfer if .TRUE.)
+      REAL( 8 ) :: DELT                 ! time step DT [s]
+      REAL( 8 ) :: HPLUS( N_MODE )      ! scratch var for H+ [umol/m**3]
+
+      REAL( 8 ), SAVE :: H2SO4RATM1     ! Mol. wt. ratio of SO4/H2SO4
+
+      REAL( 8 ) :: DVOLINORG( NVOLINORG ) ! vol inorg spcs mass to be xferred [mol/m3]
+      REAL( 8 ) :: DVOLMAX                ! max value for DVOLINORG 
+      REAL( 8 ) :: CINORG( NINORG,N_MODE ) ! scratch array for inorg spcs [ug/m**3]
+      REAL( 8 ) :: SEACAT                 ! coarse sea-salt cations [ug/m**3]
+      REAL( 8 ) :: SOILwVOLS              ! windblown dust before removal of
+                                          ! SO4,NO3,CL,H2O [ug/m**3]
+      REAL( 8 ) :: PMCwVOLS               ! anthrop coarse material before removal
+                                          ! of SO4,NO3,CL,H2O [ug/m**3]
+      REAL( 8 ) :: INT_TIME               ! internal mass transfer time (s)
+      REAL( 8 ) :: TSTEP                  ! mass transfer time step [s]
+      REAL( 8 ) :: DRYM20, Y              ! scratch vars for 2nd moment [m**2/m**3]
+      REAL( 8 ) :: M3OTHR                 ! vars for 3rd moment calculation [m**3/m**3]
+      REAL( 8 ), SAVE :: DF( NVOLINORG )  ! scratch array for mole -> ug conversion
+      REAL( 8 ), SAVE :: DFH2OR8          ! mole -> ug conversion for H2O
+      REAL( 8 ) :: J( NVOLINORG )         ! condensation/evaporation flux [mol/m**3-s]
+      REAL( 8 ) :: CFINAL( NVOLINORG,N_MODE ) ! conc after mass xfer step [ug/m**3]
+      REAL( 8 ) :: H2O                    ! Scratch LWC variable for output
+      REAL( 8 ) :: H2O_NEW                ! Update of LWC after condensation 
+      REAL( 8 ) :: SO4                    ! modal SO4 after condensation or cond + nucl
+      REAL( 8 ) :: DDRYM3DT               ! rate of 3rd moment transfer - dry inorg spcs
+      REAL( 8 ) :: DDRYM2DT               ! rate of 2nd moment transfer -  "     "    "
+      REAL( 8 ) :: DRYM3, WETM3           ! scratch vars for 3rd moment calc [m**3/m**3]
+      REAL( 8 ) :: DRYM2, WETM2           ! scratch vars for 2nd moment calc [m**2/m**3]
+      REAL( 8 ) :: LOSS                   ! rate of loss of second moment [1/s] 
+      REAL( 8 ) :: EQLBHIJ                ! H+ concentration from isoropia for I plus J-modes [ug/m**3]
+
+      REAL( 8 ) :: TMP
+      INTEGER I, N                        ! loop and array indices
+      INTEGER IMODE                       ! mode loop index  
+      INTEGER ISTEP                       ! loop index, mass transfer time step loop
+      INTEGER ISP                         ! loop index, species loop
+      INTEGER, SAVE :: LOGDEV 
+      LOGICAL TrustIso                    ! For negative vap. press., TrustIso = F
+
+C *** Local Saved Variables 
+      LOGICAL, SAVE :: FIRSTIME = .TRUE.
+      LOGICAL, SAVE :: FIRSTWRITE = .TRUE.
+      REAL( 8 ), SAVE :: SO4FAC         !  F6DPIM9 / RHOSO4
+      REAL( 8 ), SAVE :: SOILFAC        !  F6DPIM9 / RHOSOIL
+      REAL( 8 ), SAVE :: ANTHFAC        !  F6DPIM9 / RHOANTH
+      REAL( 8 ), SAVE :: NH3RAT         ! Mol. wt ratios NH3/NH4
+      REAL( 8 ), SAVE :: HNO3RAT        ! Mol. wt ratios HNO3/NO3
+      REAL( 8 ), SAVE :: HCLRAT         ! Mol. wt ratios HCL/CL 
+      REAL( 8 ), SAVE :: MWH2SO4        ! molecular weight for H2SO4
+      REAL( 8 ), SAVE :: FAERH2SO4      ! 1e-6 / mw(h2so4)
+
+      REAL( 8 ), SAVE :: CFAC_ANA
+      REAL( 8 ), SAVE :: CFAC_ASO4
+      REAL( 8 ), SAVE :: CFAC_ANH4
+      REAL( 8 ), SAVE :: CFAC_ANO3
+      REAL( 8 ), SAVE :: CFAC_ACL
+      REAL( 8 ), SAVE :: CFAC_ACA
+      REAL( 8 ), SAVE :: CFAC_AK
+      REAL( 8 ), SAVE :: CFAC_AMG
+      REAL( 8 ), SAVE :: CFAC_ASEACAT
+      REAL( 8 ), SAVE :: CFAC_GNH3
+      REAL( 8 ), SAVE :: CFAC_GHNO3
+      REAL( 8 ), SAVE :: CFAC_GHCL
+
+      REAL( 8 ), SAVE :: M3FAC_ANA
+      REAL( 8 ), SAVE :: M3FAC_ASO4
+      REAL( 8 ), SAVE :: M3FAC_ANH4
+      REAL( 8 ), SAVE :: M3FAC_ANO3
+      REAL( 8 ), SAVE :: M3FAC_ACL
+      REAL( 8 ), SAVE :: M3FAC_H2O
+
+      logical, save :: write1 = .true.
+
+C-----------------------------------------------------------------------
+ 
+      IF ( FIRSTIME ) THEN
+      
+         FIRSTIME = .FALSE.
+         LOGDEV = INIT3()
+#ifdef noiso
+         write( logdev,* ) 'aero_subs, volinorg: noiso'
+#endif
+
+         CFAC_ANA  = 1.0D-6 / REAL( AEROSPC_MW( ANA_IDX ), 8 )
+         CFAC_ASO4 = 1.0D-6 / REAL( AEROSPC_MW( ASO4_IDX ), 8 )
+         CFAC_ANH4 = 1.0D-6 / REAL( AEROSPC_MW( ANH4_IDX ), 8 )
+         CFAC_ANO3 = 1.0D-6 / REAL( AEROSPC_MW( ANO3_IDX ), 8 )
+         CFAC_ACL  = 1.0D-6 / REAL( AEROSPC_MW( ACL_IDX ), 8 )
+         CFAC_ACA  = 1.0D-6 / REAL( AEROSPC_MW( ACA_IDX ), 8 )
+         CFAC_AK   = 1.0D-6 / REAL( AEROSPC_MW( AK_IDX ), 8 )
+         CFAC_AMG  = 1.0D-6 / REAL( AEROSPC_MW( AMG_IDX ), 8 )
+         CFAC_ASEACAT = 1.0D-6 / REAL( AEROSPC_MW( ASEACAT_IDX ), 8 )
+         CFAC_GNH3 = 1.0D-6 / PRECURSOR_MW( NH3_IDX )
+         CFAC_GHNO3= 1.0D-6 / PRECURSOR_MW( HNO3_IDX )
+         CFAC_GHCL = 1.0D-6 / PRECURSOR_MW( HCL_IDX )
+
+         M3FAC_ANA  = 1.0D-9 * F6DPI / REAL( AEROSPC( ANA_IDX )%DENSITY, 8 )
+         M3FAC_ASO4 = 1.0D-9 * F6DPI / REAL( AEROSPC( ASO4_IDX )%DENSITY, 8 )
+         M3FAC_ANH4 = 1.0D-9 * F6DPI / REAL( AEROSPC( ANH4_IDX )%DENSITY, 8 )
+         M3FAC_ANO3 = 1.0D-9 * F6DPI / REAL( AEROSPC( ANO3_IDX )%DENSITY, 8 )
+         M3FAC_ACL  = 1.0D-9 * F6DPI / REAL( AEROSPC( ACL_IDX )%DENSITY, 8 )
+         M3FAC_H2O  = 1.0D-9 * F6DPI / REAL( AEROSPC( AH2O_IDX )%DENSITY, 8 )
+
+         MWH2SO4 = PRECURSOR_MW( SULF_IDX ) ! molecular weight for H2SO4
+         FAERH2SO4 = 1.0E-6 / MWH2SO4
+
+         COFCBAR_SO4 = SQRT( 8.0 * RGASUNIV / ( PI * REAL( MWH2SO4,4 ) * 1.0E-3 ) )
+         H2SO4RATM1 = AEROSPC_MW( ASO4_IDX ) / MWH2SO4
+         SO4FAC  = 1.0D-9 * F6DPI / REAL( AEROSPC( ASO4_IDX )%DENSITY, 8 )
+         SOILFAC = 1.0D-9 * F6DPI / REAL( AEROSPC( ASOIL_IDX )%DENSITY, 8 )
+         ANTHFAC = 1.0D-9 * F6DPI / REAL( AEROSPC( ACORS_IDX )%DENSITY, 8 )
+
+         DF( KNH4 ) = 1.0D0 / CFAC_ANH4
+         DF( KNO3 ) = 1.0D0 / CFAC_ANO3
+         DF( KCL )  = 1.0D0 / CFAC_ACL
+         DFH2OR8    = 1.0D6 * MWWAT      ! aerospc_mw(AH2O_IDX) (18.0 != 18.0153)
+
+         ! Mol. wt ratios NH3/NH4, HNO3/NO3, HCL/CL
+         NH3RAT  = PRECURSOR_MW( NH3_IDX )  / REAL( AEROSPC_MW( ANH4_IDX ), 8 )
+         HNO3RAT = PRECURSOR_MW( HNO3_IDX ) / REAL( AEROSPC_MW( ANO3_IDX ), 8 )
+         HCLRAT  = PRECURSOR_MW( HCL_IDX )  / REAL( AEROSPC_MW( ACL_IDX ), 8 )
+      END IF
+
+C *** Determine if Hybrid
+      TMP = 0.0
+#ifdef noiso
+      hybrid = .false.
+#else
+      DO I = 1, N_AEROSPC
+         IF(  AEROSPC( I )%tracer )CYCLE
+         IF ( AEROSPC( I )%CHARGE .NE. 0 ) TMP = TMP + AEROSPC_CONC( I,N_MODE )
+      END DO
+      HYBRID = ( TMP .GE. CUTOFF ) .AND. ( AIRRH .GE. 0.18 )
+#endif
+
+      DELT  = REAL( DT, 8 )
+      TEMPI = AIRTEMP             ! assume const within synch timestep
+      RHI   = MIN( 0.95, AIRRH )  ! "        "     "      "     "
+
+C *** Calculate molecular velocities (temperature dependent) and
+C     H+ concentration
+
+      CBAR_SO4 = COFCBAR_SO4 * SQRT( AIRTEMP )
+
+      HPLUS = 0.0
+      DO I = 1, N_MODE
+         DO N = 1, N_AEROSPC
+            IF(  AEROSPC( N )%tracer )CYCLE
+            HPLUS( I ) = HPLUS( I )
+     &                 - AEROSPC( N )%CHARGE * AEROSPC_CONC( N,I ) / AEROSPC_MW( N )
+         END DO
+      END DO
+
+C *** Condensational Growth (Size-dependent terms)
+C     Calculate intermediate variables needed to determine the 2nd and
+C     3rd moment condensational-growth rates.  3rd moment terms are 
+C     needed for the calculation of new particle production.  See 
+C     Section 3.3 of Jiang & Roth (2003) for a detailed discussion.
+C    
+C *** Set moments using Equation 4 of Binkowski & Shankar
+C     (1995) or Equation 3 of Binkowski and Roselle (2003).
+C     N.B: these are for a "wet" size distribution
+
+      DO I = 1, N_MODE
+         AM0( I ) = MOMENT0_CONC( I ) 
+         AM1( I ) = MOMENT0_CONC( I ) * AEROMODE_DIAM( I )
+     &            * EXP( 0.5 * AEROMODE_LNSG( I ) * AEROMODE_LNSG( I ) )
+         AM2( I ) = MOMENT2_CONC( I )
+      END DO
+      
+C *** Calculate the size-dependent terms in the condensational-
+C     growth factor expressions for sulfate using 
+C     Equations A13-A14 of Binkowski & Shankar (1995). 
+       
+      DO I = 1, N_MODE
+         CALL HCOND3( AM0( I ), AM1( I ), AM2( I ),
+     &                DV_SO4, ALPHSULF, CBAR_SO4, FCONC_OUT )
+         FCONC_SO4( I, : ) = FCONC_OUT( : )
+      END DO 
+
+      IF ( .NOT. HYBRID ) THEN
+         FCONC_SO4( N_MODE,1 ) = 0.0D0
+         FCONC_SO4( N_MODE,2 ) = 0.0D0
+      END IF
+
+      DO I = 1, N_MODE
+         GRFAC1( I ) = FCONC_SO4( I,1 )
+         GRFAC2( I ) = FCONC_SO4( I,2 )
+      END DO
+
+C *** New Particle Production
+C     Calculate the new particle production rate due to binary
+C     nucleation of H2O and H2SO4.  These calculations are performed 
+C     only when the gas-phase production rate of H2SO4 (i.e., SO4RATE) 
+C     is non-zero.  The condensation rate of H2SO4 is calculated as the
+C     gas-phase production rate minus the new particle production rate.
+
+C *** Initialize Variables
+      DMDT_SO4  = 0.0D0
+      DNDT      = 0.0D0
+      DM2DT     = 0.0D0
+      SCONDRATE = 0.0D0
+
+C *** Produce new particles only during time steps when the gas-phase 
+C     production rate of H2SO4 is non-zero
+
+      IF ( SO4RATE .NE. 0.0D0 ) THEN
+
+C *** Adjust sulfuric acid vapor concentration to a value in
+C     equilibrium with the production of new particles and the
+C     condensation of sulfuric acid vapor on existing particles, based 
+C     on Equations A21 and A23 of Binkowski & Shankar (1995).
+         TMP = 0.0
+         DO I = 1, N_MODE
+            TMP = TMP + FCONC_SO4( I,2 )
+         END DO
+
+         XH2SO4 = SO4RATE / REAL( TMP,4 )
+         XH2SO4 = MAX( XH2SO4, CONMIN )
+         PRECURSOR_CONC( SULF_IDX ) = REAL( XH2SO4, 8 )
+
+C *** Calculate new particle production rate for 0th, 2nd, & 3rd moments
+         CALL NEWPART3 ( AIRRH, AIRTEMP, XH2SO4, SO4RATE,
+     &                   DNDT, DMDT_SO4, DM2DT )
+         
+C *** Calculate sulfate condensation rate as the gas-phase production 
+C     rate minus the new particle production rate, following Equation
+C     3.23 of Jiang & Roth (2003).
+         SCONDRATE = MAX( SO4RATE - DMDT_SO4, 0.0D0 )
+
+      END IF   ! SO4RATE .NE. 0
+
+C *** Sulfate Condensation (Size-resolved)
+C     Calculate rate at which condensing sulfate should be added to each
+C     mode.  The "omega" factors are defined in Equations 7a and 7b of
+C     Binkowski & Shankar (1995). The i-mode and j-mode factors are 
+C     calculated using Equation A17 of Binkowski & Shankar (1995). The 
+C     condensation rate for accumulation mode (fine-equilibrium scheme) or 
+C     coarse mode (hybrid and dynamic schemes) is computed by difference, 
+C     to avoid mass conservation violations arising from numerical error.
+      TMP = 0.0
+      DO I = 1, N_MODE
+         TMP = TMP + FCONC_SO4( I,2 )
+      END DO
+
+      FCONCM1_SO4  = 1.0D0 / TMP
+      OMEGA_AT_SO4 = FCONCM1_SO4 * FCONC_SO4( 1,2 )
+      OMEGA_AC_SO4 = FCONCM1_SO4 * FCONC_SO4( 2,2 )
+
+C *** Growth values for mode merge condition
+      CGR( 1 ) = SO4FAC * SCONDRATE * OMEGA_AT_SO4
+      CGR( 2 ) = SO4FAC * SCONDRATE * OMEGA_AC_SO4
+
+      CONDSO4( 1 ) = OMEGA_AT_SO4 * SCONDRATE      
+      
+      IF ( HYBRID ) THEN 
+         CONDSO4( 2 ) = OMEGA_AC_SO4 * SCONDRATE      
+         CONDSO4( 3 ) = SCONDRATE - ( CONDSO4( 1 ) + CONDSO4( 2 ) ) 
+      ELSE                                  ! fine equilibrium
+         CONDSO4( 2 ) = SCONDRATE - CONDSO4( 1 )
+         CONDSO4( 3 ) = 0.0D0               ! no coarse mode chemistry
+      END IF
+
+C *** For Hybrid approach, calculate dynamic mass trasfer for
+C     semi-volatile components of coarse mode (NO3, CL, NH4)  
+
+      IF ( HYBRID ) THEN 
+
+         CNTRL( 1 ) = 1.0D0 ! reverse problem
+         CNTRL( 2 ) = 1.0D0 ! aerosol in metastable state
+
+         INT_TIME = 0.0D0
+         TSTEP    = 90.0D0
+         ISTEP    = 1
+         IMODE    = 3
+         TrustIso = .TRUE.
+ 
+         DO WHILE ( INT_TIME .LT. DELT ) 
+
+            IF ( INT_TIME + TSTEP .GT. DELT ) TSTEP = DELT - INT_TIME 
+            INT_TIME = INT_TIME + TSTEP 
+            ISTEP = ISTEP + 1   
+
+C *** Calculate first moments using Equation 4 of Binkowski & Shankar
+C     (1995) or Equation 3 of Binkowski and Roselle (2003).
+C     N.B: these are for a "wet" size distribution
+            AM0( IMODE ) = MOMENT0_CONC( IMODE )
+            AM1( IMODE ) = MOMENT0_CONC( IMODE ) * AEROMODE_DIAM( IMODE )
+     &                  * EXP( 0.5 * AEROMODE_LNSG( IMODE ) * AEROMODE_LNSG( IMODE ) )
+            AM2( IMODE ) = MOMENT2_CONC( IMODE )
+
+C *** Calculate the size-dependent terms in the condensational-
+C     growth factor expressions for sulfate using 
+C     Equations A13-A14 of Binkowski & Shankar (1995). 
+            CALL HCOND3( AM0( IMODE ), AM1( IMODE ), AM2( IMODE ), DV_SO4, ALPHSULF, 
+     &                      CBAR_SO4, FCONC_OUT )  ! adapted from Eq A14
+            FCONC_SO4( IMODE, : ) = FCONC_OUT( : )
+
+            GRFAC1( IMODE ) = FCONC_SO4( IMODE,1 ) 
+            GRFAC2( IMODE ) = FCONC_SO4( IMODE,2 ) 
+
+C *** Set conc array to aerosol concentrations prior to mass transfer
+C     (The _RENORM and cation_FAC constants are set in the AERO_DATA module)
+
+            SEACAT    = REAL( AEROSPC_CONC( ASEACAT_IDX,IMODE ), 8 )          ! ASEACAT_IDX = 40
+            SOILwVOLS = REAL( AEROSPC_CONC( ASOIL_IDX,IMODE ), 8 ) / ASOIL_RENORM ! ASOIL_IDX = 38
+            PMCwVOLS  = REAL( AEROSPC_CONC( ACORS_IDX,IMODE ), 8 ) / ACORS_RENORM ! ACORS_IDX = 39
+
+            CINORG( KNH4,IMODE ) = REAL( AEROSPC_CONC( ANH4_IDX,IMODE ), 8 )  ! KNH4 = 1, ANH4_IDX = 4
+            CINORG( KNO3,IMODE ) = REAL( AEROSPC_CONC( ANO3_IDX,IMODE ), 8 )  ! KNO3 = 2, ANO3_IDX = 2
+            CINORG( KCL, IMODE ) = REAL( AEROSPC_CONC( ACL_IDX,IMODE ), 8 )   ! KCL = 3, ACL_IDX = 3
+            CINORG( KSO4,IMODE ) = REAL( AEROSPC_CONC( ASO4_IDX,IMODE ), 8 )  ! KSO4 = 4, ASO4_IDX = 1
+            CINORG( KNA, IMODE ) = ASCAT_NA_FAC * SEACAT                      ! KNA = 5
+     &                           + ASOIL_NA_FAC * SOILwVOLS
+     &                           + ACORS_NA_FAC * PMCwVOLS
+            CINORG( KMG, IMODE ) = ASCAT_MG_FAC * SEACAT                      ! KMG = 6
+     &                           + ASOIL_MG_FAC * SOILwVOLS
+     &                           + ACORS_MG_FAC * PMCwVOLS
+            CINORG( KK,  IMODE ) = ASCAT_K_FAC  * SEACAT                      ! KK = 7
+     &                           + ASOIL_K_FAC  * SOILwVOLS
+     &                           + ACORS_K_FAC  * PMCwVOLS
+            CINORG( KCA, IMODE ) = ASCAT_CA_FAC * SEACAT                      ! KCA = 8
+     &                           + ASOIL_CA_FAC * SOILwVOLS
+     &                           + ACORS_CA_FAC * PMCwVOLS
+            CINORG( KHP, IMODE ) = REAL( HPLUS( IMODE ), 8 )                  ! KHP = 9
+
+            M3OTHR = SOILFAC * AEROSPC_CONC( ASOIL_IDX,IMODE )
+     &             + ANTHFAC * AEROSPC_CONC( ACORS_IDX,IMODE )
+            WETM3  = MOMENT3_CONC( IMODE )
+            WETM2  = MOMENT2_CONC( IMODE )
+            DRYM3  = WETM3 - REAL( H2OFAC * AEROSPC_CONC( AH2O_IDX, IMODE ), 8 )  ! Assume no SOA in coarse mode
+            DRYM20 = WETM2 * ( DRYM3 / WETM3 ) ** D_TWOTHIRDS
+
+C *** Initial vapor-phase concentrations [ug/m3]
+            GNO3R8 = PRECURSOR_CONC( HNO3_IDX )
+            GNH3R8 = PRECURSOR_CONC( NH3_IDX )
+            GCLR8  = PRECURSOR_CONC( HCL_IDX )
+
+C *** Compute sulfate production rate [ug/m3 s] for coarse mode
+
+            RATE = CONDSO4( IMODE )
+            SO4  = CINORG( KSO4,IMODE ) + RATE * TSTEP * H2SO4RATM1
+
+            IF ( TrustIso ) THEN
+
+C *** Double Precision vars for ISORROPIA [mole/m3]
+C              Compute equilibrium vapor pressures [mol/m3] of NH3, HNO3, and HCL
+C              at the gas/particle interface of coarse mode aerosol.
+C                 GAS(1) = NH3, GAS(2) = HNO3, GAS(3) = HCl
+               WI( 1 ) = CINORG( KNA, IMODE ) * CFAC_ANA
+               WI( 2 ) =                  SO4 * CFAC_ASO4
+               WI( 3 ) = CINORG( KNH4,IMODE ) * CFAC_ANH4
+               WI( 4 ) = CINORG( KNO3,IMODE ) * CFAC_ANO3
+               WI( 5 ) = CINORG( KCL, IMODE ) * CFAC_ACL
+               WI( 6 ) = CINORG( KCA, IMODE ) * CFAC_ACA
+               WI( 7 ) = CINORG( KK,  IMODE ) * CFAC_AK
+               WI( 8 ) = CINORG( KMG, IMODE ) * CFAC_AMG
+C              Also obtain the aqueous H+ concentration, AERLIQ(1) [mol/m3]
+
+#ifdef verbose_aero
+         if ( write1 ) then
+         write( logdev,'(a, 8e13.3)' ) "VOLINORG,WI's C:",
+     &                                  wi( 1 ), wi( 2 ), wi( 3 ), wi( 4 ),
+     &                                  wi( 5 ), wi( 6 ), wi( 7 ), wi( 8 )
+         write( logdev,* ) "VOLINORG,RH,T:", rhi, tempi
+         end if
+#endif
+
+               CALL ISOROPIA( WI, RHI, TEMPI, CNTRL, WT, GAS, AERLIQ,  
+     &                        AERSLD, SCASI, OTHER )
+
+               IF ( GAS( 1 ) .LT. 0.0D0 .OR. GAS( 2 ) .LT. 0.0D0 .OR.
+     &              GAS( 3 ) .LT. 0.0D0 ) THEN
+                  IF ( FIRSTWRITE ) THEN
+                     FIRSTWRITE = .FALSE.
+                     WRITE( LOGDEV,2023 )
+                  END IF
+                  WRITE( LOGDEV,2029 ) COL, ROW, LAYER, GAS( 1 ), GAS( 2 ), GAS( 3 )
+                  TrustIso = .FALSE.
+               END IF
+
+            END IF   ! TrustIso
+
+C *** Change in volatile inorganic PM concentration to achieve
+C     equilibrium, calculated as initial-gas-phase concentration minus 
+C     equilibrium gas-phase concentration.  DVOLINORG is positive for
+C     condensation and negative for evaporation.
+
+#ifdef verbose_aero
+         if ( write1 ) then
+         write( logdev,'(a, 3e13.3)' ) "GASes:", gas( 1 ), gas( 2 ), gas( 3 )
+
+         dvolinorg( knh4 ) = gnh3r8 * CFAC_GNH3  - gas( 1 )  ! [mol/m**3]
+         dvolinorg( kno3 ) = gno3r8 * CFAC_GHNO3 - gas( 2 )  ! [mol/m**3]
+         dvolinorg( kcl )  = gclr8  * CFAC_GHCL  - gas( 3 )  ! [mol/m**3]
+           
+         write( logdev,'(a, 3e13.3)' ) "DVOLINORG_coarse:",
+     &      dvolinorg( knh4 ) / ( gnh3r8 * CFAC_GNH3 ),
+     &      dvolinorg( kno3 ) / ( gno3r8 * CFAC_GHNO3),
+     &      dvolinorg( kcl )  / ( gclr8  * CFAC_GHCL )
+         end if
+#endif
+
+C *** Calculate condensation/evaporation flux for this time step and update 
+C     volatile species concentrations.  Final aerosol conc set to be no less
+C     than the minimum aerosol conc.
+            IF ( TrustIso ) THEN
+               CALL COMPUTE_FLUX( NVOLINORG, GNH3R8, GNO3R8, GCLR8, KNH4,
+     &                            KNO3, KCL, GAS( 1:3 ), GRFAC2( IMODE ),
+     &                            AERLIQ( 1 ), RATE, J )
+            ELSE
+               J( : ) = 0.0D0
+            END IF 
+
+            IF ( J( KNH4 ) * TSTEP * DF( KNH4 ) * NH3RAT .GT. GNH3R8 ) THEN
+               WRITE( LOGDEV,* ) 'Condensed amt. exceeds NH3 conc: aero_subs.f'
+               J( KNH4 ) = GNH3R8 / ( TSTEP * DF( KNH4 ) * NH3RAT )
+            END IF
+            IF ( J( KNO3 ) * TSTEP * DF( KNO3 ) * HNO3RAT .GT. GNO3R8 ) THEN
+               WRITE( LOGDEV,* ) 'Condensed amt. exceeds HNO3 conc: aero_subs.f'
+               J( KNO3 ) = GNO3R8 / ( TSTEP * DF( KNO3 ) * HNO3RAT )
+            END IF
+            IF ( J( KCL ) * TSTEP * DF(KCL) * HCLRAT .GT. GCLR8 ) THEN
+               WRITE( LOGDEV,* ) 'Condensed amt. exceeds HCl conc: aero_subs.f'
+               J( KCL ) = GCLR8 / ( TSTEP * DF( KCL ) * HCLRAT )
+            END IF
+
+C *** Integrate mass transfer equation, convert flux from molar to mass
+
+            DO ISP = 1, NVOLINORG
+               CFINAL( ISP,IMODE ) = MAX( 0.0D0,
+     &                                    CINORG( ISP,IMODE )
+     &                                    + J( ISP ) * TSTEP * DF( ISP ) )
+            END DO               
+
+C *** Calculate updated H+ concentration 
+
+            HPLUS( IMODE ) = 0.0
+     &                     - AEROSPC( ASO4_IDX )%CHARGE * SO4                  / AEROSPC_MW( ASO4_IDX )
+     &                     - AEROSPC( ANO3_IDX )%CHARGE * CFINAL( KNO3,IMODE ) / AEROSPC_MW( ANO3_IDX )
+     &                     - AEROSPC( ACL_IDX )%CHARGE  * CFINAL( KCL, IMODE ) / AEROSPC_MW( ACL_IDX )
+     &                     - AEROSPC( ANH4_IDX )%CHARGE * CFINAL( KNH4,IMODE ) / AEROSPC_MW( ANH4_IDX )
+!    &                     - AEROSPC( ANA_IDX )%CHARGE  * CINORG( KNA, IMODE ) / AEROSPC_MW( ANA_IDX )
+     &                     - AEROSPC( ASEACAT_IDX )%CHARGE  * CINORG( KNA, IMODE ) / AEROSPC_MW( ASEACAT_IDX )
+     &                     - AEROSPC( AMG_IDX )%CHARGE  * CINORG( KMG, IMODE ) / AEROSPC_MW( AMG_IDX )
+     &                     - AEROSPC( AK_IDX )%CHARGE   * CINORG( KK,  IMODE ) / AEROSPC_MW( AK_IDX )
+     &                     - AEROSPC( ACA_IDX )%CHARGE  * CINORG( KCA, IMODE ) / AEROSPC_MW( ACA_IDX )
+
+C *** Equilibrate aerosol LWC with CFINAL by calling CALC_H2O
+            WI( 1 ) = CINORG( KNA, IMODE ) * CFAC_ASEACAT
+            WI( 2 ) =                  SO4 * CFAC_ASO4
+            WI( 3 ) = CFINAL( KNH4,IMODE ) * CFAC_ANH4
+            WI( 4 ) = CFINAL( KNO3,IMODE ) * CFAC_ANO3
+            WI( 5 ) = CFINAL( KCL, IMODE ) * CFAC_ACL
+            WI( 6 ) = CINORG( KCA, IMODE ) * CFAC_ACA
+            WI( 7 ) = CINORG( KK,  IMODE ) * CFAC_AK
+            WI( 8 ) = CINORG( KMG, IMODE ) * CFAC_AMG
+
+            CALL CALC_H2O( WI, RHI, TEMPI, H2O_NEW ) 
+
+            H2O = H2O_NEW * DFH2OR8 
+
+C *** Update all Local Aerosol Mass and Vapor Concentrations 
+            !Aerosol
+            AEROSPC_CONC( ANH4_IDX,IMODE ) = REAL( CFINAL( KNH4,IMODE ),4 )
+            AEROSPC_CONC( ANO3_IDX,IMODE ) = REAL( CFINAL( KNO3,IMODE ),4 )
+            AEROSPC_CONC( ACL_IDX,IMODE )  = REAL( CFINAL( KCL, IMODE ),4 )
+            AEROSPC_CONC( ASO4_IDX,IMODE ) = REAL( SO4,4 )
+            AEROSPC_CONC( AH2O_IDX,IMODE ) = REAL( H2O,4 )
+
+            !Gas
+            PRECURSOR_CONC( NH3_IDX ) = GNH3R8 + ( CINORG( KNH4,IMODE )
+     &                                 -CFINAL( KNH4,IMODE ) ) * NH3RAT 
+            PRECURSOR_CONC( HNO3_IDX )= GNO3R8 + ( CINORG( KNO3,IMODE )
+     &                                 -CFINAL( KNO3,IMODE) ) * HNO3RAT  
+            PRECURSOR_CONC( HCL_IDX ) = GCLR8 + ( CINORG( KCL,IMODE )
+     &                                 -CFINAL( KCL,IMODE) ) * HCLRAT 
+ 
+C *** Compute net change in 3rd moment due to dry inorganic mass transfer
+
+            DDRYM3DT = ( ( CFINAL( KNH4,IMODE ) - CINORG( KNH4,IMODE ) ) * M3FAC_ANH4
+     &                 + ( CFINAL( KNO3,IMODE ) - CINORG( KNO3,IMODE ) ) * M3FAC_ANO3
+     &                 + ( CFINAL( KCL, IMODE ) - CINORG( KCL,IMODE ) )  * M3FAC_ACL
+     &                 + ( SO4                  - CINORG( KSO4,IMODE ) ) * M3FAC_ASO4 ) / TSTEP
+
+C *** Compute net change in 2nd moment due to dry inorganic mass transfer
+C     (including nucleation) using equation A7 of Binkowski & Shankar (1995)
+            DDRYM2DT = D_TWOTHIRDS * GRFAC1( IMODE ) / GRFAC2( IMODE ) * DDRYM3DT   
+
+C *** Update dry 2nd moment for condensation/evaporation based on whether
+C     net change in dry 2nd moment is production or loss
+            IF ( DDRYM2DT .LT. 0.0D0 ) THEN
+               LOSS = DDRYM2DT / DRYM20
+               Y = DRYM20 * EXP( LOSS * TSTEP )
+            ELSE
+               Y = DRYM20 + DDRYM2DT * TSTEP
+            END IF
+
+C *** Add water (no SOA) 2nd moment while preserving standard deviation
+
+            !Calculate 3rd Moment
+            DRYM3 = ( M3FAC_ASO4 ) * SO4
+     &            + M3FAC_ANH4 * CFINAL( KNH4,IMODE )
+     &            + M3FAC_ANO3 * CFINAL( KNO3,IMODE )
+     &            + M3FAC_ACL  * CFINAL( KCL,IMODE )
+     &            + M3FAC_ANA  * SEACAT
+     &            + M3OTHR                   
+            WETM3 = DRYM3 + H2O * M3FAC_H2O
+
+            !Calculate 2nd moment
+            DRYM2 = MAX( REAL( AEROMODE_MINM2( IMODE ), 8 ), Y )
+            WETM2 = DRYM2 * ( WETM3 / DRYM3 ) ** D_TWOTHIRDS
+
+            MOMENT2_CONC( IMODE ) = REAL( WETM2,4 )
+
+C *** Update the third moments, geometric mean diameters, geometric 
+C     standard deviations, modal mass totals, and modal particle 
+C     densities. It is a waste of time updating the aitken and
+C     accumulation modes but the coarse mode does need to be updated
+C     each sub-time step. This should be for the wet distribution
+               
+            CALL GETPAR( FIXED_sg )
+
+         END DO   ! end mass transfer time step loop
+         
+      END IF   ! for 'Hybrid' method
+
+      write1 = .false.
+C *** End of Coarse Mode dynamic mass transfer calculations
+
+C *** Fine Aerosol Modes: Call ISORROPIA in forward mode to calculate gas-particle equilibrium
+      !Get Precursors Vapor concentrations [ug m-3]
+      GNH3R8 = PRECURSOR_CONC( NH3_IDX )   
+      GNO3R8 = PRECURSOR_CONC( HNO3_IDX )  
+      GCLR8  = PRECURSOR_CONC( HCL_IDX )
+
+C *** Diagnose all total gas+particle concentrations to passed to
+C     ISORROPIA. Convert everything to [mol m-3].
+      WI( 1 ) = SUM( AEROSPC_CONC( ANA_IDX,1:2 ))   * CFAC_ANA
+      !Compute sulfate from total sulfate production rate [ug/m3-s] for fine 
+      !modes; add in H2SO4 nucleated in model timestep
+      WI( 2 ) = ( SUM( AEROSPC_CONC( ASO4_IDX,1:2 ) ) 
+     &           +( DMDT_SO4 + SUM( CONDSO4( 1:2 ) ) ) * DELT * H2SO4RATM1 ) * CFAC_ASO4
+      WI( 3 ) = PRECURSOR_CONC( NH3_IDX )  * CFAC_GNH3
+     &         +SUM( AEROSPC_CONC( ANH4_IDX,1:2 ) ) * CFAC_ANH4 
+      WI( 4 ) = PRECURSOR_CONC( HNO3_IDX ) * CFAC_GHNO3
+     &         +SUM( AEROSPC_CONC( ANO3_IDX,1:2 ) ) * CFAC_ANO3 
+      WI( 5 ) = PRECURSOR_CONC( HCL_IDX )  * CFAC_GHCL 
+     &         +SUM( AEROSPC_CONC( ACL_IDX,1:2 ) )  * CFAC_ACL 
+      WI( 6 ) = SUM( AEROSPC_CONC( ACA_IDX,1:2 ) )  * CFAC_ACA 
+      WI( 7 ) = SUM( AEROSPC_CONC( AK_IDX,1:2 ) )   * CFAC_AK 
+      WI( 8 ) = SUM( AEROSPC_CONC( AMG_IDX,1:2 ) )  * CFAC_AMG 
+
+      CNTRL( 1 ) = 0.0D0   ! Forward Problem
+      CNTRL( 2 ) = 1.0D0   ! Aerosol in Metastable State
+
+C *** Set flags to account for mass conservation violations in ISRP3F
+      TRUSTCL  = .TRUE.
+      IF ( (WI( 1 ) + WI( 5 )) .LT. 1.0D-20 .or. WI( 5 ) .LT. 1.0D-10 ) THEN
+         TRUSTCL = .FALSE.
+      END IF
+         
+#ifndef noiso
+      CALL ISOROPIA( WI, RHI, TEMPI, CNTRL, WT, GAS, AERLIQ,
+     &               AERSLD, SCASI, OTHER )
+
+C *** Save H+ concentration information in microgram/m3 for consistency
+      EQLBHIJ = AERLIQ(1) * 1.0D6 * AEROSPC_MW( ah3op_idx)
+
+#else
+      gas( 1 ) = real( precursor_conc( nh3_idx ),  8 ) * CFAC_GNH3
+      gas( 2 ) = real( precursor_conc( hno3_idx ), 8 ) * CFAC_GHNO3
+      gas( 3 ) = real( precursor_conc( hcl_idx ),  8 ) * CFAC_GHCL
+
+      EQLBHIJ =  HPLUS( 1 ) + HPLUS( 2 )  ! use charge balance if lacking isoropia info 
+
+#endif
+
+C *** Change in volatile inorganic PM concentration to achieve
+C     equilibrium, calculated as initial-gas-phase concentration minus 
+C     equilibrium gas-phase concentration.  DVOLINORG is positive for
+C     condensation and negative for evaporation.
+      DVOLINORG( KNH4 ) = GNH3R8 * CFAC_GNH3  - GAS( 1 )   ! mol m-3
+      DVOLINORG( KNO3 ) = GNO3R8 * CFAC_GHNO3 - GAS( 2 )   ! mol m-3
+      DVOLINORG( KCL )  = GCLR8  * CFAC_GHCL  - GAS( 3 )   ! mol m-3
+
+      IF ( DVOLINORG( KNH4 ) .LT. 0.0D0 ) THEN
+         DVOLMAX = -SUM(REAL( AEROSPC_CONC( ANH4_IDX,1:2 ), 8 ) ) * CFAC_ANH4 + EVAPMIND
+         DVOLINORG( KNH4 ) = MAX( DVOLINORG( KNH4 ), DVOLMAX )
+      END IF
+
+      IF ( DVOLINORG( KNO3 ) .LT. 0.0D0 ) THEN
+         DVOLMAX = -SUM(REAL( AEROSPC_CONC( ANO3_IDX,1:2 ), 8 ) ) * CFAC_ANO3 + EVAPMIND
+         DVOLINORG( KNO3 ) = MAX( DVOLINORG( KNO3 ), DVOLMAX)
+      END IF
+
+      IF ( .not.TRUSTCL ) THEN  
+         DVOLINORG( KCL ) = 0.0D0
+      ELSEIF ( DVOLINORG( KCL ) .LT. 0.0D0 ) THEN
+         DVOLMAX = -SUM(REAL( AEROSPC_CONC( ACL_IDX,1:2 ), 8 ) ) * CFAC_ACL + EVAPMIND
+         DVOLINORG( KCL ) = MAX( DVOLINORG( KCL ), DVOLMAX )
+      END IF
+
+C *** Apply modal partitioning of equilibrium aerosol mass
+      ! Calculate Distribution of Mass Transfer Among Modes
+      OMEGA( 1 ) = GRFAC2( 1 ) / ( GRFAC2( 1 ) + GRFAC2( 2 ) )
+      OMEGA( 2 ) = 1.0D0 - OMEGA( 1 )
+
+      ! Save Initial Concentrations
+      DO IMODE = 1, 2  
+         CINORG( KSO4,IMODE ) = AEROSPC_CONC( ASO4_IDX, IMODE )
+         CINORG( KNH4,IMODE ) = AEROSPC_CONC( ANH4_IDX, IMODE )
+         CINORG( KNO3,IMODE ) = AEROSPC_CONC( ANO3_IDX, IMODE )
+         CINORG( KNA, IMODE ) = AEROSPC_CONC( ANA_IDX,  IMODE )
+         CINORG( KCL, IMODE ) = AEROSPC_CONC( ACL_IDX,  IMODE )
+         CINORG( KCA, IMODE ) = AEROSPC_CONC( ACA_IDX,  IMODE )
+         CINORG( KK,  IMODE ) = AEROSPC_CONC( AK_IDX,   IMODE )
+         CINORG( KMG, IMODE ) = AEROSPC_CONC( AMG_IDX,  IMODE )
+      END DO
+
+      ! Calculate Initial Distribution of Mass Composition Among Modes
+      DO ISP = 1, NVOLINORG
+         TOTAER( ISP ) = MAX( SUM( CINORG( ISP,1:2 ) ), CONMIND )
+         DO IMODE = 1, 2
+            PHI( ISP, IMODE ) = CINORG( ISP,IMODE ) / TOTAER( ISP )
+         ENDDO
+      ENDDO
+
+      ! Initialize Final Concentrations
+      CFINAL = 0.0
+
+      ! Calculate Final Concentrations
+      DO ISP = 1, NVOLINORG
+         IF ( DVOLINORG( ISP ) .LT. 0.0 ) THEN
+            ! Evaporate Mass Using Condensed-Phase Fraction in each Mode
+            CFINAL( ISP,1:2 ) = CFINAL( ISP,1:2 ) + CINORG( ISP,1:2 )
+     &                        + PHI( ISP,1:2 ) * DVOLINORG( ISP ) * DF( ISP )
+         ELSE
+            ! Condense Mass Using Condensation Sink Factors
+            CFINAL( ISP,1:2 ) = CFINAL( ISP,1:2 ) + CINORG( ISP,1:2 )
+     &                        + OMEGA( 1:2 ) * DVOLINORG( ISP ) * DF( ISP )
+         END IF
+      END DO
+
+C *** Apply Final Concentrations to Moment Variables in Aerosol Scheme
+      ! Store Initial Wet Moments
+      M3WET_INIT( : ) = MOMENT3_CONC( : )
+      M2WET_INIT( : ) = MOMENT2_CONC( : )
+
+      ! Calculate and Store Initial Dry Moments and set wet_moments_flag to false/dry
+      ! There has not yet been an update to AEROSPC_CONC so this will
+      ! calculate the old 3rd moment.
+      call calcmoments( .false. )
+      M3DRY_INIT( : ) = MOMENT3_CONC( : )
+      M2DRY_INIT( : ) = MOMENT2_CONC( : )
+
+      DO IMODE = 1, 2  ! modal partitioning of equilibrium aerosol mass
+
+         IF ( IMODE .EQ. 1 ) THEN
+            ! Update Number Concentration with NPF
+            MOMENT0_CONC( IMODE ) = REAL( AM0(IMODE) + DNDT * DELT, 4 )
+            ! Add NPF to total condensation rate
+            RATE = DMDT_SO4 + CONDSO4( IMODE )
+            SO4 = CINORG( KSO4,IMODE ) + RATE * DELT * H2SO4RATM1 
+         ELSE
+            ! Ignore NPF. The small particles are not in these modes
+            SO4 = CINORG( KSO4,IMODE ) + CONDSO4( IMODE ) * DELT * H2SO4RATM1
+         END IF
+
+C *** Double precision vars for CALC_H2O
+         WI( 1 ) = CINORG( KNA, IMODE ) * CFAC_ANA
+         WI( 2 ) =                  SO4 * CFAC_ASO4
+         WI( 3 ) = CFINAL( KNH4,IMODE ) * CFAC_ANH4
+         WI( 4 ) = CFINAL( KNO3,IMODE ) * CFAC_ANO3
+         WI( 5 ) = CFINAL( KCL, IMODE ) * CFAC_ACL
+         WI( 6 ) = CINORG( KCA, IMODE ) * CFAC_ACA
+         WI( 7 ) = CINORG( KK,  IMODE ) * CFAC_AK
+         WI( 8 ) = CINORG( KMG, IMODE ) * CFAC_AMG
+
+         CALL CALC_H2O( WI, RHI, TEMPI, H2O_NEW ) 
+         
+         ! Update All Aerosol Concentrations
+         AEROSPC_CONC( AH2O_IDX, IMODE ) = REAL( H2O_NEW * DFH2OR8, 4 )
+         AEROSPC_CONC( ANH4_IDX, IMODE ) = REAL( CFINAL( KNH4,IMODE ),4 )
+         AEROSPC_CONC( ANO3_IDX, IMODE ) = REAL( CFINAL( KNO3,IMODE ),4 )
+         AEROSPC_CONC( ACL_IDX, IMODE )  = REAL( CFINAL( KCL ,IMODE ),4 )
+         AEROSPC_CONC( ASO4_IDX, IMODE ) = REAL( SO4,4 )
+
+C *** Compute net change in 3rd moment due to dry inorganic mass transfer
+C     (includes nucleated sulfate mass). This is for projecting the
+C     change to the second moment due to dry inorganic condensation
+         
+         DDRYM3DT = ( ( CFINAL( KNH4,IMODE ) - CINORG( KNH4,IMODE ) ) * M3FAC_ANH4
+     &              + ( CFINAL( KNO3,IMODE ) - CINORG( KNO3,IMODE ) ) * M3FAC_ANO3
+     &              + ( CFINAL( KCL, IMODE ) - CINORG( KCL,IMODE ) )  * M3FAC_ACL
+     &              + ( SO4                  - CINORG( KSO4,IMODE ) ) * M3FAC_ASO4 ) 
+     &              / DELT 
+
+C *** Compute net change in 2nd moment due to dry inorganic mass transfer
+C     (including nucleation) using equation A7 of Binkowski & Shankar (1995)
+         DDRYM2DT = D_TWOTHIRDS * GRFAC1( IMODE ) / GRFAC2( IMODE ) * DDRYM3DT
+
+C *** Update dry 2nd moment for condensation/evaporation based on whether
+C     net change in dry 2nd moment is production or loss
+         IF ( DDRYM2DT .LT. 0.0D0 ) THEN
+            LOSS = DDRYM2DT / M2DRY_INIT( IMODE )
+            Y = M2DRY_INIT( IMODE ) * EXP( LOSS * DELT )
+         ELSE
+            Y = M2DRY_INIT( IMODE ) + DDRYM2DT * DELT
+         END IF
+         moment2_conc( IMODE ) = REAL( MAX( REAL( AEROMODE_MINM2( IMODE ), 8 ), Y ),4 )
+
+      END DO
+
+C *** Add water and SOA to 2nd moment while preserving standard deviation
+      call calcmoments( .true. )
+      M3WET_FINAL = moment3_conc
+      M2WET_FINAL = moment2_conc
+
+C *** Assign H+ Concentration to each Mode
+      HPLUS( 1:2 ) = 0.0
+      DO I = 1, N_AEROSPC
+         IF(  AEROSPC( I )%tracer )CYCLE
+         HPLUS( 1:2 ) = HPLUS( 1:2 )
+     &                  - AEROSPC( I )%CHARGE * AEROSPC_CONC( I,1:2 ) / AEROSPC_MW( I )
+      END DO
+
+      H2O = AEROSPC_CONC( AH2O_IDX, 1 ) + AEROSPC_CONC( AH2O_IDX, 2 )
+      IF(  H2O .GT. CONMIN )THEN
+          H2O = 1.0 / H2O
+          AEROSPC_CONC( AH3OP_IDX, 1:2 ) = REAL( EQLBHIJ * H2O, 4 ) * AEROSPC_CONC( AH2O_IDX, 1:2 ) 
+      ELSE
+          AEROSPC_CONC( AH3OP_IDX, 1:2 ) = CONMIN
+      END IF
+      AEROSPC_CONC( AH3OP_IDX, 3 ) = REAL( HPLUS( 3 ),4 ) * AEROSPC_MW( ah3op_idx ) ! Coarse mode H+ concentration in ug/m3
+
+C *** Update the third moments, geometric mean diameters, geometric 
+C     standard deviations, modal mass totals, and modal particle 
+C     densities. Note that moment2_conc needs to be up to date when this
+C     routine is called. Moment3_conc does not need to be up to date
+C     because it will be recalculated inside GETPAR as the sum of 
+C     aerospc_conc variables. This should be for the wet distribution.
+      CALL GETPAR( FIXED_sg )
+
+C *** Update gas-phase concentrations from Aitken and Accumulation Mode Partitioning
+      PRECURSOR_CONC( NH3_IDX )  = GNH3R8 + sum( CINORG( KNH4,1:2 )
+     &                            -CFINAL( KNH4,1:2 ) ) * NH3RAT 
+      PRECURSOR_CONC( HNO3_IDX ) = GNO3R8 + sum( CINORG( KNO3,1:2 )
+     &                            -CFINAL( KNO3,1:2) ) * HNO3RAT  
+      PRECURSOR_CONC( HCL_IDX )  = GCLR8 + sum( CINORG( KCL,1:2 )
+     &                            -CFINAL( KCL,1:2) ) * HCLRAT 
+         
+2023  FORMAT( 1X, 'VOLINORG returning negative gas concentrations from ISOROPIA:'
+     &       /10X, 'GAS(1) = NH3, GAS(2) = HNO3, GAS(3) = HCl' )
+2029  FORMAT( 1X, '[see VOLINORG msg]'
+     &        1X, 'at (C,R,L): ', 3I4, 1X, 'GAS Conc:', 3( 1PE11.3 ) )
+
+      RETURN
+      END SUBROUTINE VOLINORG
+
+C:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+      SUBROUTINE HCOND3( AM0, AM1, AM2, DV, ALPHA, CBAR, F )
+
+C  calculates the size-dependent term in the condensational-growth rate
+C  expression for the 2nd and 3rd moments of a lognormal aerosol mode
+C  using the harmonic mean method.  This code follows Section A2 of
+C  Binkowski & Shankar (1995).
+ 
+C  Key Subroutines/Functions called:  none
+ 
+C  Revision History:
+C     coded November 7, 2003 by Dr. Francis S. Binkowski
+C     Revised November 20, 2003 by F. Binkowski to have am1 and
+C     am2 as inputs
+ 
+C  Reference:
+C   1. Binkowski, F.S. and U. Shankar, The regional particulate matter
+C      model 1. Model description and preliminary results, J. Geophys.
+C      Res., Vol 100, No D12, 26101-26209, 1995.
+
+      IMPLICIT NONE
+
+C *** Includes:
+
+      INCLUDE SUBST_CONST     ! physical and mathematical constants
+
+C *** Arguments:
+
+      REAL( 8 ), INTENT( IN ) :: AM0   ! zeroth moment of mode  [ #/m**3 ]
+      REAL( 8 ), INTENT( IN ) :: AM1   ! first moment of mode   [ m/m**3 ]
+      REAL( 8 ), INTENT( IN ) :: AM2   ! second moment of mode  [ m**2/m**3 ]
+      REAL,      INTENT( IN ) :: Dv    ! molecular diffusivity of the
+                                       ! condensing vapor  [ m**2/s ]
+      REAL,      INTENT( IN ) :: ALPHA ! accommodation coefficient
+      REAL,      INTENT( IN ) :: CBAR  ! kinetic velocity of condensing vapor [ m/s ]
+
+      REAL( 8 ), INTENT( OUT ) :: F( 2 ) ! size-dependent term in condensational-growth
+                                         ! rate: F(1) = 2nd moment [ m**2/m**3 s ]
+                                         !       F(2) = 3rd moment [ m**3/m**3 s ]
+
+C *** Local Variables:
+
+      REAL( 8 ) :: GNC2 ! integrals used to calculate F(1) [m^2 / m^3 s]
+      REAL( 8 ) :: GFM2 !
+
+      REAL( 8 ) :: GNC3 ! integrals used to calculate F(2) [m^3 / m^3 s]
+      REAL( 8 ) :: GFM3 !
+
+      REAL( 8 ), PARAMETER :: TWOPI = 2.0D0 * PI
+      REAL( 8 ), PARAMETER :: PI4 = 0.25D0 * PI
+
+C-----------------------------------------------------------------------
+
+C *** Implement equation A15 of Binkowski & Shankar (1995) for the
+C     2nd and 3rd moments of a lognormal mode of arbitrary size.
+
+      GNC2 = TWOPI * DV * AM0          ! 2nd moment, near-continuum
+      GNC3 = TWOPI * DV * AM1          ! 3rd moment, near-continuum
+      GFM2 = PI4 * ALPHA * CBAR * AM1  ! 2nd moment, free-molecular
+      GFM3 = PI4 * ALPHA * CBAR * AM2  ! 3rd moment, free-molecular
+
+C *** Implement equation A13 of Binkowski & Shankar (1995) for a
+C     lognormal mode of arbitrary size.  These are the size-dependent
+C     terms in the condensational-growth rate expression, given in
+C     equation 7a of B&S (1995).
+
+      F( 1 ) = GNC2 * GFM2 / ( GNC2 + GFM2 )  ! 2nd moment
+      F( 2 ) = GNC3 * GFM3 / ( GNC3 + GFM3 )  ! 3rd moment
+
+      RETURN
+      END SUBROUTINE HCOND3
+
+C:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+      SUBROUTINE NEWPART3 ( RH, T, XH2SO4, SO4RATE, DNDT, DMDT_so4, DM2DT )
+
+      USE AERO_DATA
+      USE AEROMET_DATA   ! Includes CONST.EXT
+      USE PRECURSOR_DATA, ONLY: PRECURSOR_MW, SULF_IDX
+      USE UTILIO_DEFN
+      
+      IMPLICIT NONE
+
+C   REVISION HISTORY:
+C     Replacement of Kulmala et al., 1998 nucleation scheme with scheme 
+C     of Vehkamaki et al. (2002) by G. Sarwar and K. Fahey - 03/2014
+
+C.. References:
+C     Vehkamaki, H., Kulmala, M, Napari, I., Lehtinen, K.E.J., Timmreck, C.,
+C     Noppel, M., and A. Laaksonen. (2002) An improved parameterization for 
+C     sulfuric acid-water nucleation rates for tropospheric and stratospheric
+C     conditions.  JGR, v107(D22).    
+   
+C..Inputs: 
+      REAL, INTENT(IN ) :: RH              ! fractional relative humidity      
+      REAL, INTENT(IN)  :: T               ! Ambient temperature [ K ]
+      REAL, INTENT(IN)  :: XH2SO4          ! sulfuric acid concentration [ ug/m**3 ]
+      REAL, INTENT(IN)  :: SO4RATE         ! gas-phase H2SO4 production rate [ ug/m**3 s ]
+
+C.. Outputs:
+      REAL( 8 ), INTENT( OUT ) :: DNDT     ! particle number production rate [ m^-3/s ]
+      REAL( 8 ), INTENT( OUT ) :: DMDT_so4 ! SO4 mass production rate [ ug/m**3 s ]
+      REAL( 8 ), INTENT( OUT ) :: DM2DT    ! second moment production rate [ m**2/m**3 s ]
+
+C.. Parameters
+      CHARACTER( 16 ), PARAMETER :: PNAME = 'NEWPART'                 
+
+C.. Particle size parameters:
+      REAL, PARAMETER :: d20 = 2.0E-07                ! diameter of a new particle [cm]
+      REAL, PARAMETER :: d20sq = d20 * d20            ! new-particle diameter squared [cm**2]
+      REAL, PARAMETER :: m2_20 = 1.0E-4 * d20sq       ! new-particle diameter squared [m**2]
+      REAL, PARAMETER :: v20 = PI * d20 * d20sq /6.0  ! volume of a new particle [cm**3]
+      
+      REAL( 8 )       :: sulfmass                     ! mass of a new particle [ug]
+      REAL( 8 )       :: sulfmass1                    ! inverse of sulfmass [ug**-1]
+
+C.. Set constants and local variables for Vehkamaki et al. (2002) scheme
+      REAL, PARAMETER :: C1 = 0.740997
+      REAL, PARAMETER :: C2 = -0.00266379
+      REAL, PARAMETER :: C3 = -0.00349998
+      REAL, PARAMETER :: C4 = 0.0000504022
+      REAL, PARAMETER :: C5 = 0.00201048
+      REAL, PARAMETER :: C6 = -0.000183289
+      REAL, PARAMETER :: C7 = 0.00157407
+      REAL, PARAMETER :: C8 = -0.0000179059
+      REAL, PARAMETER :: C9 = 0.000184403
+      REAL, PARAMETER :: C10 = -1.50345E-6
+
+      REAL :: XSTAR           ! mole fraction of sulfuric acid in the critical cluster
+      REAL :: NA              ! total gas phase concentration of H2SO4  [ #/cm**3 ]
+      REAL :: TEMP            ! ambient temperature
+      REAL :: LNRH, LNNA      ! LN(RH), LN(Na)
+      REAL :: LNRH2, LNNA2    ! LN(RH)**2, LN(Na)**2
+      REAL :: LNRH3, LNNA3    ! LN(RH)**3, LN(Na)**3  
+      REAL :: TEMP2, TEMP3    ! TEMP**2, TEMP**3
+      REAL( 8 ) :: XFAC       ! exponential term for the nucleation rate  
+      REAL( 8 ) :: Jnuc       ! nucleation rate [ #/cm**3 s ]
+      
+      REAL :: A, B, C, D, E, F, G, H, I, J
+
+      REAL :: MW_H2SO4        ! MW of H2SO4 in [ g / mole ]        
+      REAL :: DENSITY_H2SO4   ! DENSITY of H2SO4 in [ kg / m**3 ]
+
+      REAL, PARAMETER :: SCALEFAC = 1.0E-06           ! for [ 1 / m**3 ] ->  [ 1 / cm**3 ]
+      REAL, PARAMETER :: MUG2G = 1.0E-6               ! [ ug  ] -> [ g ]                 
+
+C.. Initialize variables
+      DNDT     = 0.0D0
+      DMDT_so4 = 0.0D0
+      DM2DT    = 0.0D0
+
+C.. Calculate molecular weight of H2SO4 [ g / mole ] 
+      MW_H2SO4 = REAL( PRECURSOR_MW( SULF_IDX ),4 )
+         
+C.. Calculate density of sulfuric acid [ kg / m**3 ] 
+      DENSITY_H2SO4 = AEROSPC( ASO4_IDX )%DENSITY           
+
+C.. Calculate mass of a new particle [ug]
+      sulfmass = 1.0D+3 * DENSITY_H2SO4 * v20
+
+C.. Calculate inverse of sulfmass [ug**-1]      
+      sulfmass1 = 1.0D0 / sulfmass   
+     
+C.. Calculate sulfuric acid concentration in molecules/cm3 
+      NA = XH2SO4 * MUG2G * AVO * SCALEFAC / MW_H2SO4     
+
+C.. The parameterization is valid at sulfuric acid concentrations of 1.0E4 - 1.0E11 molecules cm-3
+      NA  = MAX (NA, 1.0E4)
+      NA  = MIN (1.0E11, NA)
+
+C.. The parameterization is valid at temperatures of 190.00-305.15 K
+      TEMP = MAX (T, 190.00)
+      TEMP = MIN (305.15, TEMP)
+
+C.. The parameterization is valid at RH of 0.0001-1.0
+C   aero_driver.f limits RH to 0.005-0.99; thus no additional constraint is needed
+
+C.. Define convenient constants
+      TEMP2 = TEMP * TEMP
+      TEMP3 = TEMP * TEMP2
+      
+      LNRH = LOG( RH )  
+      LNNA = LOG( NA )
+      LNRH2 = LNRH * LNRH
+      LNRH3 = LNRH * LNRH2
+      LNNA2 = LNNA * LNNA
+      LNNA3 = LNNA * LNNA2
+
+C.. Calculate mole fraction of sulfuric acid in the critical cluster
+      XSTAR = C1 + C2 * TEMP + C3 * LNNA + C4 * TEMP * LNNA + 
+     &      C5 * LNRH + C6 * TEMP * LNRH +
+     &      C7 * LNRH2 + C8 * TEMP * LNRH2 + C9 * LNRH3 + 
+     &      C10 * TEMP * LNRH3
+
+C.. Calculate coefficients needed for the nucleation rate [Eq-12 - Vehkamaki et al., 2002]           
+      A = 0.14309 + 2.21956 * TEMP - 0.0273911 * TEMP2 + 
+     &      0.0000722811 * TEMP3 + 5.91822 / XSTAR
+     
+      B = 0.117489 + 0.462532 * TEMP - 0.0118059 * TEMP2 + 
+     &      0.0000404196 * TEMP3 + 15.7963 / XSTAR
+     
+      C = -0.215554 - 0.0810269 * TEMP + 0.00143581 * TEMP2 - 
+     &      4.7758E-6 * TEMP3 - 2.91297 / XSTAR
+     
+      D = -3.58856 + 0.049508 * TEMP - 0.00021382 * TEMP2 + 
+     &      3.10801E-7 * TEMP3 - 0.0293333 / XSTAR
+     
+      E = 1.14598 - 0.600796 * TEMP + 0.00864245 * TEMP2 - 
+     &      0.0000228947 * TEMP3 - 8.44985 / XSTAR
+     
+      F = 2.15855 + 0.0808121 * TEMP - 0.000407382 * TEMP2 - 
+     &      4.01957E-7 * TEMP3 + 0.721326 / XSTAR
+
+      G = 1.6241 - 0.0160106 * TEMP + 0.0000377124 * TEMP2 + 
+     &      3.21794E-8 * TEMP3 - 0.0113255 / XSTAR
+      
+      H = 9.71682 - 0.115048 * TEMP + 0.000157098 * TEMP2 + 
+     &      4.00914E-7 * TEMP3 + 0.71186 / XSTAR
+     
+      I = -1.05611 + 0.00903378 * TEMP - 0.0000198417 * TEMP2 +
+     &      2.46048E-8 * TEMP3 - 0.0579087 / XSTAR
+
+      J = -0.148712 + 0.00283508 * TEMP - 9.24619E-6 * TEMP2 + 
+     &      5.00427E-9 * TEMP3 - 0.0127081 / XSTAR
+
+C.. Calculate the exponential term for the nucleation rate [Eq-12 - Vehkamaki et al., 2002] 
+      XFAC = A + B * LNRH + C * LNRH2 + D * LNRH3 + 
+     &      E * LNNA + F * LNRH * LNNA + G * LNRH2 * LNNA +     
+     &      H * LNNA2 + I * LNRH * LNNA2 + J * LNNA3
+
+C.. Calculate particle nucleation rate: unit [ 1 / cm**3 s] [Eq-12 - Vehkamaki et al., 2002] 
+      Jnuc = EXP(XFAC)  
+      
+C.. The parameterization is valid for nucleation rates of 1.0E-7-1.0E10 [ 1 / cm**3 s]
+      Jnuc = MAX (Jnuc, 1.0D-7)
+      Jnuc = MIN (1.0D10, Jnuc)
+
+C.. Convert the unit of particle nucleation rate into [ 1 / m**3 s] by multiplying it by 1.0E6  
+       DNDT = Jnuc * 1.0E06  ! (1/(m**3 s))
+
+C.. Calculate mass production rate [ ug / (m**3 s) ] analogous to
+C   Equation 6a of Binkowski & Roselle (2003). Set the upper limit
+C   of the mass production rate as the gas-phase production rate of
+C   H2SO4, and adjust the number production rate accordingly.
+      DMDT_so4 = sulfmass * DNDT 
+
+      IF ( DMDT_so4 .GT. SO4RATE ) THEN
+         DMDT_so4 = SO4RATE
+         DNDT = DMDT_SO4 * sulfmass1
+      END IF
+
+C.. Calculate the production rate of 2nd moment [ m**2 / (m**3 s) ]
+C   This is similar to Equation 6c of Binkowski & Roselle (2003),
+C   except the factor of PI is removed and the assumed particle
+C   diameter is different.
+      DM2DT = DNDT * m2_20
+
+      RETURN    
+      END SUBROUTINE NEWPART3 
+
+C:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+      SUBROUTINE Compute_Flux ( nvolinorg, GNH3R8, GNO3R8, GCLR8, KNH4,
+     &                          KNO3, KCL, Ceq, CondRate, Hplus, rate, J )
+ 
+C Description
+C   Determines the evaporative/condensational flux of volatile
+C   inorganic species to aerosol modes. In cases where the resulting H+
+C   flux is greater than a specified limit, the Pilinis et al. (2000)
+C   AS&T approach is used to modify species vapor pressures such that
+C   cond./evap. produces an H+ flux equal to the limit (which is
+C   proportional to the current mode concentration of H+).
+C   Routine called by VOLINORG.
+ 
+C Arguments
+C   Inputs
+C     nvolinorg: Number of Volatile inorganic species
+C     GNH3R8   : NH3(g) concentration (ug/m3)
+C     GNO3R8   : HNO3(g) concentration (ug/m3)
+C     GCLR8    : HCl(g) concentration (ug/m3)
+C     KNH4     : Index to NH4 species
+C     KNO3     : Index to NO3 species
+C     KCL      : Index to NO3 species 
+C     Ceq      : vapor concentration (mol/m3)
+C     CondRate : effective condensation rate (I) of 3rd moment to mode
+C              : [treat units as (1/s)]
+C     Hplus    : aerosol hydrogen ion concentration (mol/m3) for mode
+C     rate     : H2SO4(g) condensation rate (ug/m3/s) for mode
+ 
+C   Output
+C     Ceq      : modified vapor concentration (mol/m3)
+C     J        : molar cond./evap. flux of volatile inorganics (mol/m3-s)
+ 
+C-----------------------------------------------------------------------
+
+      USE AERO_DATA
+      USE PRECURSOR_DATA
+      USE AEROMET_DATA
+
+      IMPLICIT NONE
+
+C     Arguments:
+      INTEGER      nvolinorg
+      REAL( 8 ) :: GNH3R8, GNO3R8, GCLR8 ! gas concentrations [ug/m3]
+      INTEGER      KNH4, KNO3, KCL       ! Indices to species
+      REAL( 8 ) :: Ceq( nvolinorg )      ! vapor concentrations [mol/m3]
+      REAL( 8 ) :: CondRate              ! effective condensation rate (I) for 3rd moment
+      REAL( 8 ) :: Hplus                 ! hydrogen ion concentration for mode [mol/m3]
+      REAL( 8 ) :: rate
+      REAL( 8 ) :: J( nvolinorg )        ! molar cond./evap. flux [mol/m3-s]
+
+C     Local Variables:
+      REAL( 8 ),  PARAMETER :: Afact = 1.0D-01  ! factor for H+ limiter
+      REAL( 8 ),  PARAMETER :: small = 1.0D-25
+      REAL( 8 ) :: Cinf( nvolinorg ) ! gas concentration in mol/m3
+      REAL( 8 ) :: Qk              ! factor for modifying vapor press. based on H+ limit
+      REAL( 8 ) :: Hflux           ! flux of H+ to mode from cond/evap
+      REAL( 8 ) :: Hlim            ! maximum allowable H+ flux to mode
+      REAL( 8 ) :: aa, bb, cc      ! terms in quadratic equation
+      REAL( 8 ) :: JH2SO4          ! molar flux of H2SO4(g) [mol/m3/s]
+      REAL( 8 ) :: CH2SO4          ! effective H2SO4(g) concentration [mol/m3]
+      INTEGER      isp             ! inorganic species index
+
+C-----------------------------------------------------------------------
+
+C     Convert gas concentration from ug/m3 to mol/m3
+      Cinf( KNH4 ) = GNH3R8 * 1.0D-6 / PRECURSOR_MW( NH3_IDX )
+      Cinf( KNO3 ) = GNO3R8 * 1.0D-6 / PRECURSOR_MW( HNO3_IDX )
+      Cinf( KCL )  = GCLR8  * 1.0D-6 / PRECURSOR_MW( HCL_IDX )
+
+C     Calculate cond/evap fluxes (no H+ limiting)
+      DO isp = 1, nvolinorg
+         J( isp ) = CondRate * ( Cinf( isp ) - Ceq( isp ) )
+      END DO
+
+C     Convert rate to mol/m3/s and get effective Cinf for H2SO4(g)
+      JH2SO4  = rate * 1.0D-6 / PRECURSOR_MW( SULPRD_IDX )
+      CH2SO4  = JH2SO4 / CondRate
+
+C     Limit H+ flux (Pilinis et al., 2000, AS&T). Note: J is flux
+C     to entire mode, not one particle
+      Hlim  = Afact * Hplus
+      Hflux = 2.0D0 * JH2SO4 + J( KNO3 ) + J( KCL ) - J( KNH4 )
+
+C     If Hflux is too large, limit the flux by modifying species
+C     vapor pressures with Qk factor (Pilinis et al., 2000, AS&T).
+      IF ( ABS( Hflux ) .GT. Hlim ) THEN
+         Hlim = SIGN( Hlim, Hflux )
+
+C        Solve quadratic for Qk: aa*Qk^2 + bb*Qk + cc = 0
+         aa = Ceq( KCL ) + Ceq( KNO3 )
+
+         bb = Hlim / CondRate
+     &      + Cinf( KNH4) - Cinf( KNO3 ) - Cinf( KCL ) - 2.0D0 * CH2SO4
+         cc = -Ceq( KNH4 )
+
+         Qk = 0.0D0 ! initialize Qk
+
+         IF ( aa .LT. small .AND. 0.0D0 .LT. bb ) THEN ! bb*Qk + cc = 0
+            Qk = -cc / bb
+         ELSE IF (aa .LT. small .AND. bb .LE. 0.0D0 ) THEN
+            Qk = 0.0D0
+         ELSE IF (-cc .LT. small .AND. bb .LT. 0.0D0 ) THEN  ! aa*Qk^2 + bb*Qk = 0
+            Qk = -bb / aa
+         ELSE IF (-cc .LT. small .AND. 0.0D0 .LE. bb ) THEN
+            Qk = 0.0D0
+         ELSE
+            Qk = ( -bb + SQRT ( bb**2 - 4.0D0 * aa * cc ) ) / ( 2.0D0 * aa )
+            IF ( bb ** 2 - 4.0D0 * aa * cc .LT. 0.0D0 ) THEN
+               PRINT *, 'Compute_Flux, sqrt<0'
+               Qk = 0.0D0
+            END IF
+         END IF
+
+C     Modify vapor pressures and get new fluxes
+         IF ( Qk .GT. small ) THEN
+            Ceq( KNH4 ) = Ceq( KNH4 ) / Qk
+            Ceq( KNO3 ) = Ceq( KNO3 ) * Qk
+            Ceq( KCl )  = Ceq( KCl )  * Qk
+            DO isp = 1, nvolinorg
+               J( isp ) = CondRate * ( Cinf( isp ) - Ceq( isp ) )
+            END DO
+         END IF
+
+      END IF   ! |Hflux| > Hlim
+
+      END SUBROUTINE Compute_Flux
+
+C:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+      SUBROUTINE CALC_H2O ( WI, RH, T, H2O_NEW )
+
+C Description
+C   Calculate the water content of aerosol at the new time step.  Water
+C   calculations use the ZSR mixing rule with salts determined by the
+C   ISORROPIA approach.
+C   Routine called by VOLINORG.
+ 
+C Arguments
+C   Input
+C     WI      : Concentration of components [mol/m^3] at new step
+C     RH      : Relative humidity [0-1]
+C     T       : Temperature [K]
+ 
+C   Output
+C     H2O_NEW : Water [mol/m^3] content at new time step
+ 
+C-----------------------------------------------------------------------
+
+      IMPLICIT NONE
+
+C Parameters:
+      INTEGER, PARAMETER :: NCMP = 8, NPAIR = 23
+      REAL( 8 ),  PARAMETER :: SMALL = 1.0D-20
+      REAL( 8 ),  PARAMETER :: Mw = 0.018D0   ! molar mass H2O (kg/mol)
+
+C Arguments:
+      REAL( 8 ), INTENT( IN )  :: WI( NCMP )
+      REAL( 8 ), INTENT( IN )  :: RH, T
+      REAL( 8 ), INTENT( OUT ) :: H2O_NEW
+
+C Local Variables:
+      CHARACTER( 3 ) :: SC ! subcase for composition
+      REAL( 8 ) :: FSO4, FNH4, FNA, FNO3, FCL ! "free" ion amounts
+      REAL( 8 ) :: FCA, FK, FMG            
+      REAL( 8 ) :: CASO4         ! amount of calcium sulfate, does not participate in ZSR calc
+      REAL( 8 ) :: WATER         ! kg of water for new time step 
+      REAL( 8 ) :: X, Y
+      REAL( 8 ) :: CONC( NCMP )    ! concentration (mol/m^3)
+      REAL( 8 ) :: CONCR( NPAIR )  ! concentration (mol/m^3) ion "pairs" 
+      REAL( 8 ) :: M0I( NPAIR )    ! single-solute molalities
+      INTEGER :: J
+
+#ifdef verbose_aero
+!     logical, save :: firstime = .true.
+!     integer, save :: logdev
+!     integer, external :: setup_logdev
+#endif
+
+C-----------------------------------------------------------------------
+
+#ifdef verbose_aero
+!     if ( firstime ) then
+!        firstime = .false.
+!        logdev = setup_logdev()
+!     end if
+#endif
+
+C     Return if small concentration
+      IF ( WI( 1 ) + WI( 2 ) + WI( 3 ) + WI( 4 )
+     &   + WI( 5 ) + WI( 6 ) + WI( 7 ) + WI( 8 ) .LE. SMALL) THEN
+         H2O_NEW = SMALL
+         RETURN
+      END IF
+
+C     Set component array (mol/m^3) for determining salts
+      CONC = WI   ! array assignment
+
+C     Get the sub-case to use in determining salts
+      CALL GETSC ( CONC, RH, T, SC )
+
+#ifdef verbose_aero
+!     write( logdev,* ) 'CALC_H2O -SC: ', sc
+#endif
+
+C     Initialize ion "pairs" (i.e., salts) used in ZSR
+      CONCR( : ) = 0.0D0
+
+C     Depending on case, determine moles of salts in solution (i.e., CONCR)
+C     for ZSR calculation below
+
+      IF ( SC .EQ. 'S2' ) THEN    ! sulfate poor (NH4-SO4 system), old K2
+         CONCR( 4 )= MIN ( CONC( 2 ), 0.5D0 * CONC( 3 ) )  ! (NH4)2SO4
+
+      ELSE IF ( SC .EQ. 'B4' ) THEN  ! sulfate rich (no acid), old L4, O4
+         X = 2.0D0 * CONC( 2 ) - CONC( 3 )     ! 2SO4 - NH4
+         Y = CONC( 3 ) - CONC( 2 )            ! NH4 - SO4
+         IF ( X .LE. Y ) THEN
+            CONCR( 13 ) = X      ! (NH4)3H(SO4)2 is MIN (X,Y)
+            CONCR(  4 ) = Y - X  ! (NH4)2SO4
+         ELSE
+            CONCR( 13 ) = Y      ! (NH4)3H(SO4)2 is MIN (X,Y)
+            CONCR(  9 ) = X - Y  ! NH4HSO4
+         END IF
+
+      ELSE IF ( SC .EQ. 'C2' ) THEN  ! sulfate rich (free acid), old M2, P2
+         CONCR( 9 ) = CONC( 3 )                      ! NH4HSO4
+         CONCR( 7 ) = MAX( CONC( 2 ) - CONC( 3 ), 0.0D0 )   ! H2SO4
+
+      ELSE IF ( SC .EQ. 'N3' ) THEN    ! sulfate poor (NH4-SO4-NO3 system)
+         CONCR( 4 ) = MIN ( CONC( 2 ), 0.5D0 * CONC( 3 ) )           ! (NH4)2SO4
+         FNH4       = MAX ( CONC( 3 ) - 2.0D0 * CONCR( 4 ), 0.0D0 )  ! available NH4
+         CONCR( 5 ) = MAX ( MIN ( FNH4, CONC( 4 ) ), 0.0D0 )         ! NH4NO3=MIN(NH4,NO3)
+
+      ELSE IF ( SC .EQ. 'Q5' ) THEN    ! sulfate poor, sodium poor (NH4-SO4-NO3-Cl-Na)
+         CONCR( 2 ) = 0.5D0 * CONC( 1 )                              ! Na2SO4
+         FSO4       = MAX ( CONC( 2 ) - CONCR( 2 ), 0.0D0 )          ! available SO4
+         CONCR( 4 ) = MAX ( MIN ( FSO4, 0.5D0 * CONC( 3 ) ), SMALL ) ! NH42S4=MIN(NH4,S4)
+         FNH4       = MAX ( CONC( 3 ) - 2.0D0 * CONCR( 4 ), 0.0D0 )  ! available NH4
+         CONCR( 5 ) = MIN ( FNH4, CONC( 4 ) )                        ! NH4NO3=MIN(NH4,NO3)
+         FNH4       = MAX ( FNH4 - CONCR( 5 ), 0.0D0 )               ! avaialable NH4
+         CONCR( 6 ) = MIN ( FNH4, CONC( 5 ) )                        ! NH4Cl=MIN(NH4,Cl)
+
+      ELSE IF ( SC .EQ. 'R6' ) THEN   ! sulfate poor, sodium rich (NH4-SO4-NO3-Cl-Na)
+         CONCR( 2 ) = CONC( 2 )                            ! Na2SO4
+         FNA        = MAX ( CONC( 1 ) - 2.0D0 * CONCR( 2 ), 0.0D0 )
+
+         CONCR( 3 ) = MIN ( FNA, CONC( 4 ) )               ! NaNO3
+         FNO3       = MAX ( CONC( 4 ) - CONCR( 3 ), 0.0D0 )
+         FNA        = MAX ( FNA - CONCR( 3 ), 0.0D0 )
+
+         CONCR( 1 ) = MIN ( FNA, CONC( 5 ) )               ! NaCl
+         FCL        = MAX ( CONC( 5 ) - CONCR( 1 ), 0.0D0 )
+         FNA        = MAX ( FNA - CONCR( 1 ), 0.0D0 )
+
+         CONCR( 5 ) = MIN ( FNO3, CONC( 3 ) )              ! NH4NO3
+         FNO3       = MAX ( FNO3 - CONCR( 5 ), 0.0D0 )
+         FNH4       = MAX ( CONC( 3 ) - CONCR( 5 ), 0.0D0 )
+
+         CONCR( 6 ) = MIN (FCL, FNH4 )                     ! NH4Cl
+
+      ELSE IF ( SC .EQ. 'I6' ) THEN   ! sulfate rich (no acid) (NH4-SO4-NO3-Cl-Na)
+         CONCR(  2 ) = 0.5D0 * CONC( 1 )                          ! Na2SO4
+         FSO4        = MAX ( CONC( 2 ) - CONCR( 2 ), 0.0D0 )
+         CONCR( 13 ) = MIN ( CONC( 3 ) / 3.0D0, FSO4 / 2.0D0 )    ! (NH4)3H(SO4)2
+         FSO4        = MAX ( FSO4 - 2.0D0 * CONCR( 13 ), 0.0D0 )
+         FNH4        = MAX ( CONC( 3 ) - 3.0D0 * CONCR( 13 ), 0.0D0 )
+
+         IF ( FSO4 .LE. SMALL ) THEN    ! reduce (NH4)3H(SO4)2, add (NH4)2SO4
+            CONCR( 13 ) = MAX ( CONCR( 13 ) - FNH4, 0.0D0 )   ! (NH4)3H(SO4)2
+            CONCR(  4 ) = 2.0D0 * FNH4                  ! (NH4)2SO4
+         ELSE IF ( FNH4 .LE. SMALL ) THEN ! reduce (NH4)3H(SO4)2, add NH4HSO4
+            CONCR(  9 ) = 3.0D0 * MIN ( FSO4, CONCR( 13 ) ) ! NH4HSO4
+            CONCR( 13 ) = MAX ( CONCR( 13 ) - FSO4, 0.0D0 )
+            IF ( CONCR( 2 ) .GT. SMALL ) THEN ! reduce Na2SO4, add NaHSO4
+               FSO4        = MAX ( FSO4 - CONCR( 9 ) / 3.0D0, 0.0D0 )
+               CONCR( 12 ) = 2.0D0 * FSO4                ! NaHSO4
+               CONCR(  2 ) = MAX ( CONCR( 2 ) - FSO4, 0.0D0 )  ! Na2SO4
+             END IF
+         END IF
+
+      ELSE IF ( SC .EQ. 'J3' ) THEN   ! sulfate rich (free acid) (NH4-SO4-NO3-Cl-Na)
+         CONCR(  9 ) = CONC( 3 )                             ! NH4HSO4
+         CONCR( 12 ) = CONC( 1 )                             ! NAHSO4
+         CONCR(  7 ) = MAX ( CONC( 2 ) - CONC( 3 ) - CONC( 1 ), 0.0D0 ) ! H2SO4
+
+      ! Crustal cases
+      ELSE IF ( SC .EQ. 'V7' ) THEN  ! sulfate poor, sodium+crustal poor
+         CASO4     = MIN ( CONC( 6 ), CONC( 2 ) )            ! CCASO4
+         FSO4      = MAX ( CONC( 2 ) - CASO4, 0.0D0 )
+         FCA       = MAX ( CONC( 6 ) - CASO4, 0.0D0 )
+
+         CONCR( 17 ) = MIN ( 0.5D0 * CONC( 7 ), FSO4 )       ! CK2SO4
+         FK          = MAX ( CONC( 7 ) - 2.D0 * CONCR( 17 ), 0.0D0 )
+         FSO4        = MAX ( FSO4 - CONCR( 17 ), 0.0D0 )
+
+         CONCR( 2 )  = MIN ( 0.5D0 * CONC( 1 ), FSO4 )       ! CNA2SO4
+         FNA         = MAX ( CONC( 1 ) - 2.0D0 * CONCR( 2 ), 0.0D0 )
+         FSO4        = MAX ( FSO4 - CONCR( 2 ), 0.0D0 )
+
+         CONCR( 21 ) = MIN ( CONC( 8 ), FSO4 )               ! CMGSO4
+         FMG         = MAX ( CONC( 8 ) - CONCR( 21 ), 0.0D0 )
+         FSO4        = MAX ( FSO4 - CONCR( 21 ), 0.0D0 )
+
+         CONCR( 4 )  = MAX ( MIN ( FSO4 , 0.5D0 * CONC( 3 ) ) , SMALL ) ! CNH42S4
+         FNH4        = MAX ( CONC( 3 ) - 2.0D0 * CONCR( 4 ), 0.0D0 )
+
+         CONCR( 5 )  = MIN ( FNH4, CONC( 4 ) )               ! CNH4NO3
+         FNH4        = MAX ( FNH4 - CONCR( 5 ), 0.0D0 )
+
+         CONCR( 6 )  = MIN ( FNH4, CONC( 5 ) )               ! CNH4CL
+
+      ELSE IF ( SC .EQ. 'U8' ) THEN  ! sulfate poor, crustal+sodium rich, crustal poor
+         CASO4       = MIN ( CONC( 6 ), CONC( 2 ) )          ! CCASO4
+         FSO4        = MAX ( CONC( 2 ) - CASO4, 0.0D0 )
+         FCA         = MAX ( CONC( 6 ) - CASO4, 0.0D0 )
+
+         CONCR( 17 ) = MIN ( 0.5D0 * CONC( 7 ), FSO4 )       ! CK2SO4
+         FK          = MAX ( CONC( 7 ) - 2.0D0 * CONCR( 17 ), 0.0D0 )
+         FSO4        = MAX ( FSO4 - CONCR( 17 ), 0.0D0 )
+
+         CONCR( 21 ) = MIN ( CONC( 8 ), FSO4 )               ! CMGSO4
+         FMG         = MAX ( CONC( 8 ) - CONCR( 21 ), 0.0D0 )
+         FSO4        = MAX ( FSO4 - CONCR( 21 ), 0.0D0 )
+
+         CONCR( 2 )  = MAX ( FSO4, 0.0D0 )                   ! CNA2SO4
+         FNA         = MAX ( CONC( 1 ) - 2.0D0 * CONCR( 2 ), 0.0D0 )
+
+         CONCR( 3 )  = MIN ( FNA, CONC( 4 ) )                ! NaNO3
+         FNO3        = MAX ( CONC( 4 ) - CONCR( 3 ), 0.0D0 )
+         FNA         = MAX ( FNA - CONCR( 3 ), 0.0D0 )
+
+         CONCR( 1 )  = MIN ( FNA, CONC( 5 ) )                ! NaCl
+         FCL         = MAX ( CONC( 5 ) - CONCR( 1 ), 0.0D0 )
+         FNA         = MAX ( FNA - CONCR( 1 ), 0.0D0 )
+
+         CONCR( 5 )  = MIN ( FNO3, CONC( 3 ) )               ! NH4NO3
+         FNO3        = MAX ( FNO3 - CONCR( 5 ), 0.0D0 )
+         FNH4        = MAX ( CONC( 3 ) - CONCR( 5 ), 0.0D0 )
+
+         CONCR( 6 )  = MIN ( FCL, FNH4 )                     ! NH4Cl
+         FCL         = MAX ( FCL - CONCR( 6 ), 0.0D0 )
+         FNH4        = MAX ( FNH4 - CONCR( 6 ), 0.0D0 )
+
+      ELSE IF ( SC .EQ. 'W13' ) THEN  ! sulfate poor, crustal+sodium rich
+         CASO4       = MIN ( CONC( 2 ), CONC( 6 ) )          ! CASO4
+         FCA         = MAX ( CONC( 6 ) - CASO4, 0.0D0 )
+         FSO4        = MAX ( CONC( 2 ) - CASO4, 0.0D0 )
+
+         CONCR( 17 ) = MIN ( FSO4, 0.5D0 * CONC( 7 ) )       ! K2SO4
+         FK          = MAX ( CONC( 7 ) - 2.0D0 * CONCR( 17 ), 0.0D0 )
+         FSO4        = MAX ( FSO4 - CONCR( 17 ), 0.0D0 )
+
+         CONCR( 21 ) = FSO4                                  ! MGSO4
+         FMG         = MAX ( CONC( 8 ) - CONCR( 21 ), 0.0D0 )
+
+         CONCR( 1 )  = MIN ( CONC( 1 ), CONC( 5 ) )          ! NACL
+         FNA         = MAX ( CONC( 1 ) - CONCR( 1 ), 0.0D0 )
+         FCL         = MAX ( CONC( 5 ) - CONCR( 1 ), 0.0D0 )
+
+         CONCR( 16 ) = MIN ( FCA, 0.5D0 * FCL )              ! CACL2
+         FCA         = MAX ( FCA - CONCR( 16 ), 0.0D0 )
+         FCL         = MAX ( CONC( 5 ) - 2.0D0 * CONCR( 16 ), 0.0D0 )
+
+         CONCR( 15 ) = MIN ( FCA, 0.5D0 * CONC( 4 ) )        ! CA(NO3)2
+         FCA         = MAX ( FCA - CONCR( 15 ), 0.0D0 )
+         FNO3        = MAX ( CONC( 4 ) - 2.0D0 * CONCR( 15 ), 0.0D0 )
+
+         CONCR( 23 ) = MIN ( FMG, 0.5D0 * FCL )              ! MGCL2
+         FMG         = MAX ( FMG - CONCR( 23 ), 0.0D0 )
+         FCL         = MAX ( FCL - 2.0D0 * CONCR( 23 ), 0.0D0 )
+
+         CONCR( 22 ) = MIN ( FMG, 0.5D0 * FNO3 )             ! MG(NO3)2
+         FMG         = MAX ( FMG - CONCR( 22 ), 0.0D0 )
+         FNO3        = MAX ( FNO3 - 2.0D0 * CONCR( 22 ), 0.0D0 )
+
+         CONCR( 3 )  = MIN ( FNA, FNO3 )                     ! NANO3
+         FNA         = MAX ( FNA - CONCR( 3 ), 0.0D0 )
+         FNO3        = MAX ( FNO3 - CONCR( 3 ), 0.0D0 )
+
+         CONCR( 20 ) = MIN ( FK, FCL )                       ! KCL
+         FK          = MAX ( FK - CONCR( 20 ), 0.0D0 )
+         FCL         = MAX ( FCL - CONCR( 20 ), 0.0D0 )
+
+         CONCR( 19 ) = MIN ( FK, FNO3 )                      ! KNO3
+         FK          = MAX ( FK - CONCR( 19 ), 0.0D0 )
+         FNO3        = MAX ( FNO3 - CONCR( 19 ), 0.0D0 )
+
+      ELSE IF ( SC .EQ. 'L9' ) THEN  ! sulfate rich, no free acid
+         CASO4       = MIN ( CONC( 6 ), CONC( 2 ) )          ! CCASO4
+         FSO4        = MAX ( CONC( 2 ) - CASO4, 0.0D0 )
+         FCA         = MAX ( CONC( 6 ) - CASO4, 0.0D0 )
+
+         CONCR( 17 ) = MIN ( 0.5D0 * CONC( 7 ), FSO4 )       ! CK2SO4
+         FK          = MAX ( CONC( 7 ) - 2.0D0 * CONCR( 17 ), 0.0D0 )
+         FSO4        = MAX ( FSO4 - CONCR( 17 ), 0.0D0 )
+
+         CONCR( 2 )  = MIN ( 0.5D0 * CONC( 1 ), FSO4 )       ! CNA2SO4
+         FNA         = MAX ( CONC( 1 ) - 2.0D0 * CONCR( 2 ), 0.0D0 )
+         FSO4        = MAX ( FSO4 - CONCR( 2 ), 0.0D0 )
+
+         CONCR( 21 ) = MIN ( CONC( 8 ), FSO4 )               ! CMGSO4
+         FMG         = MAX ( CONC( 8 ) - CONCR( 21 ), 0.0D0 )
+         FSO4        = MAX ( FSO4 - CONCR( 21 ), 0.0D0 )
+
+         CONCR( 13 ) = MIN ( CONC( 3 ) / 3.0D0, FSO4 / 2.0D0 ) ! CLC
+         FSO4        = MAX ( FSO4 - 2.0D0 * CONCR( 13 ), 0.0D0 )
+         FNH4        = MAX ( CONC( 3 )- 3.0D0 * CONCR( 13 ),  0.0D0 )
+
+         IF ( FSO4 .LE. SMALL ) THEN                           ! convert (NH4)3H(SO4)2 to (NH4)2SO4
+            CONCR( 13 ) = MAX( CONCR( 13 ) - FNH4, 0.0D0 )
+            CONCR(  4 ) = 2.0D0 * FNH4                         ! CNH42S4 
+
+         ELSE IF ( FNH4 .LE. SMALL ) THEN                      ! convert (NH4)3H(SO4)2 to NH4HSO4
+            CONCR(  9 ) = 3.0D0 * MIN( FSO4, CONCR( 13 ) )     ! CNH4HS4
+            CONCR( 13 ) = MAX( CONCR( 13 ) - FSO4, 0.0D0 )     ! CLC, (NH4)3H(SO4)2
+            IF ( CONCR( 2 ) .GT. SMALL ) THEN                  ! convert Na2SO4 to NaHSO4
+               FSO4        = MAX( FSO4 - CONCR( 9 ) / 3.0D0, 0.0D0 )
+               CONCR( 12 ) = 2.0D0 * FSO4                      ! CNAHSO4
+               CONCR(  2 ) = MAX( CONCR( 2 ) - FSO4, 0.0D0 )   ! CNA2SO4
+            END IF
+            IF ( CONCR( 17 ) .GT. SMALL ) THEN                 ! convert K2SO4 to KHSO4
+               FSO4        = MAX( FSO4 - CONCR( 9 ) / 3.0D0, 0.0D0 )
+               CONCR( 18 ) = 2.0D0 * FSO4                      ! CKHSO4
+               CONCR( 17 ) = MAX( CONCR( 17 ) - FSO4, 0.0D0 )  ! CK2SO4
+            END IF
+         END IF
+         
+      ELSE IF ( SC .EQ. 'K4' ) THEN ! sulfate super rich, free acid
+         CONCR(  9 ) = CONC( 3 )                               ! NH4HSO4 = NH3
+         CONCR( 12 ) = CONC( 1 )                               ! NaHSO4  = Na
+         CONCR( 18 ) = CONC( 7 )                               ! KHSO4   = K
+         CONCR( 21 ) = CONC( 8 )                               ! MgSO4   = Mg
+         CONCR(  7 ) = MAX( CONC( 2 ) - CONC( 3 ) - CONC( 1 )
+     &                    - CONC( 6 ) - CONC( 7 ) - CONC( 8 ), 0.0D0 ) ! H2SO4 = SO4 - NH4 - Na - Ca - K - Mg
+
+      ELSE
+         PRINT*, 'aero_subs.f: case not supported ',
+     &          '(metastable reverse only)'
+!        STOP
+      END IF
+
+C     Get single-solute molalities for ZSR calculation
+      CALL GETM0I ( RH, M0I )
+
+C     Calculate H2O with ZSR and determine delta water
+      WATER = 0.0D0
+      DO J = 1, NPAIR
+         WATER = WATER + CONCR( J ) / M0I( J )
+      END DO
+
+      WATER = MAX ( WATER, SMALL )
+      H2O_NEW = WATER / Mw
+
+      END SUBROUTINE CALC_H2O  
+
+C:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+      SUBROUTINE GETM0I ( RHIN, M0I )
+
+!!!!!!!!!!!!!!! We want to get rid of this dependency !!!!!!!!!!!!!!!!
+
+C Description
+C   Determines single-solute molalities for the 13 possible salts at
+C   the ambient RH.  These molalities are used in the ZSR calculation
+C   in CALC_H2O. Note that the molalities were determined at the beginning
+C   of the time step, and so they are available in the IONS common block
+C   of isrpia.inc.
+C   Routine called by CALC_H2O.
+
+C Revision History
+C   ??? ???? Prakash Bhave(?), Jim Kelly(?): initial revision
+C   Apr 2011 Havala Pye: Removed use of IONS common block since it requires
+C                        ISORROPIA to be called to setup the initial array values.
+C                        Now uses single-solute molalities from ZSR common block
+C                        in isrpia.inc that is defined in BLKISO in isocom.f
+C                        BE VERY CAREFUL ABOUT IMPLICIT VARIABLES HERE!
+ 
+C Arguments
+C   Output
+C     M0I : Single-solute molalities (mol/kg-H2O) for 13 salts
+ 
+C-----------------------------------------------------------------------
+
+!     implicit none
+
+      INCLUDE 'isrpia.inc'
+
+C Arguments
+      REAL( 8 ), INTENT( IN )  :: RHIN
+      REAL( 8 ), INTENT( OUT ) :: M0I( NPAIR )
+
+      INTEGER IZ
+
+C Location in pure molality array (function of RH)
+      IZ = MIN( INT( RHIN * REAL( NZSR, 8 ) + 0.5D0 ), NZSR )
+      IZ = MAX( IZ, 1 )
+
+C Default value
+      M0I = 1.0D+5   ! array assignment
+
+C Actual values (10,11 not provided)
+      M0I( 01 ) = AWSC( IZ )   ! NACl
+      M0I( 02 ) = AWSS( IZ )   ! (NA)2SO4
+      M0I( 03 ) = AWSN( IZ )   ! NANO3
+      M0I( 04 ) = AWAS( IZ )   ! (NH4)2SO4
+      M0I( 05 ) = AWAN( IZ )   ! NH4NO3
+      M0I( 06 ) = AWAC( IZ )   ! NH4CL
+      M0I( 07 ) = AWSA( IZ )   ! 2H-SO4
+      M0I( 08 ) = AWSA( IZ )   ! H-HSO4
+      M0I( 09 ) = AWAB( IZ )   ! NH4HSO4
+
+
+      M0I( 12 ) = AWSB( IZ )   ! NAHSO4
+      M0I( 13 ) = AWLC( IZ )   ! (NH4)3H(SO4)2
+
+      M0I( 15 ) = AWCN( IZ )   ! CA(NO3)2
+      M0I( 16 ) = AWCC( IZ )   ! CACl2
+      M0I( 17 ) = AWPS( IZ )   ! K2SO4
+      M0I( 18 ) = AWPB( IZ )   ! KHSO4
+      M0I( 19 ) = AWPN( IZ )   ! KNO3
+      M0I( 20 ) = AWPC( IZ )   ! KCl
+      M0I( 21 ) = AWMS( IZ )   ! MGSO4
+      M0I( 22 ) = AWMN( IZ )   ! MG(NO3)2
+      M0I( 23 ) = AWMC( IZ )   ! MGCL2
+    
+      END SUBROUTINE GETM0I               
+
+C:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+      SUBROUTINE GETSC ( CONC, RH, T, SC )
+ 
+C Description
+C   Determines the sub-case to use for water uptake calculations.
+C   Follows the procedure of ISORROPIA.
+C   Routine called by CALC_H2O.
+ 
+C ArgumentS
+C   Inputs
+C     CONC : Concentration [mol/m^3] of aerosol components. This routine
+C            sets minimum CONC to 1.0D-20
+C     RH   : Relative humidity
+C     T    : Temperature (K)
+     
+C   Output
+C     SC   : Sub-case for aerosol composition
+ 
+C-----------------------------------------------------------------------
+
+      IMPLICIT NONE
+
+      INTEGER, PARAMETER :: NCMP = 8    ! was NCMP  = 5    ! number of aerosol components
+      REAL( 8 ), PARAMETER :: SMALL = 1.0D-20
+
+C Arguments:
+!     REAL( 8 ), INTENT( IN )    :: CONC(  NCMP )
+      REAL( 8 ), INTENT( INOUT ) :: CONC(  NCMP )
+      REAL( 8 ), INTENT( IN )    :: RH, T
+      CHARACTER( 3 ), INTENT( OUT ) :: SC
+            
+C Local Variables:
+      REAL( 8 ) :: T0, TCF                     ! DRH(T) factor
+      REAL( 8 ) :: S4RAT, S4RATW, NaRAT, SRI   ! sulfate & sodium ratios
+      REAL( 8 ) :: CRAT                        ! crustals ratio
+      REAL( 8 ) :: FSO4                        ! "free" sulfate
+      REAL( 8 ) :: DNACL, DNH4CL, DNANO3, DNH4NO3, DNH42S4 ! DRH values
+
+      REAL( 8 ) :: GETASR    ! ISORROPIA function for sulfate ratio
+
+      LOGICAL :: SCP1R, SCP2R, SCP3R, SCP4R ! concentration regime
+
+C-----------------------------------------------------------------------
+
+      SCP1R = .FALSE.
+      SCP2R = .FALSE.
+      SCP3R = .FALSE.
+      SCP4R = .FALSE.
+
+C     See if any components are negligible (see isocom.for)
+      IF ( CONC( 1 ) + CONC( 4 ) + CONC( 5 ) + 
+     &     CONC( 6 ) + CONC( 7 ) + CONC( 8 ) .LE. SMALL ) THEN       ! Ca,K,Mg,Na,Cl,NO3=0
+         SCP1R = .TRUE.                                    
+      ELSE IF ( CONC( 1 ) +        CONC( 5 ) +
+     &          CONC( 6 ) + CONC( 7 ) + CONC( 8 ) .LE. SMALL ) THEN  ! Ca,K,Mg,Na,Cl=0
+         SCP2R = .TRUE.                                     
+      ELSE IF ( CONC( 6 ) + CONC( 7 ) + CONC( 8 ) .LE. SMALL ) THEN  ! Ca,K,Mg=0
+         SCP3R = .TRUE.                                     
+      ELSE                                                           ! all species
+         SCP4R = .TRUE.
+      END IF
+
+      CONC( : ) = MAX ( CONC( : ), SMALL )
+
+C     Deliquescence RH calculations
+      DNH42S4 = 0.7997D0
+      DNH4NO3 = 0.6183D0
+      IF ( INT( T ) .NE. 298 ) THEN
+         T0      = 298.15D0
+         TCF     = 1.0D0 / T - 1.0D0 / T0
+         DNH4NO3 = DNH4NO3 * EXP( 852.0D0 * TCF )
+         DNH42S4 = DNH42S4 * EXP(  80.0D0 * TCF )
+         DNH4NO3 = MIN ( DNH4NO3, DNH42S4 ) ! adjust for curves crossing T<271K
+      END IF
+
+C     Find sub-case "SC"
+      IF ( SCP1R ) THEN ! NH4-S04 system
+
+         IF ( RH .GE. DNH42S4 ) THEN
+            S4RATW = GETASR( CONC( 2 ), RH ) ! aerosol sulfate ratio
+         ELSE
+            S4RATW = 2.0D0                ! dry aerosol sulfate ratio
+         END IF
+         S4RAT  = CONC( 3 ) / CONC( 2 )     ! sulfate ratio (NH4/SO4)
+
+         IF ( S4RATW .LE. S4RAT ) THEN      ! sulfate poor
+            SC = 'S2'
+         ELSE IF ( 1.0D0 .LE. S4RAT .AND. S4RAT .LT. S4RATW ) THEN ! sulfate rich (no acid)
+            SC = 'B4'
+         ELSE IF ( S4RAT .LT. 1.0D0 ) THEN   ! sulfate rich (free acid)
+            SC = 'C2'
+         END IF
+
+      ELSE IF ( SCP2R ) THEN ! NH4-SO4-NO3 system
+
+         IF ( RH .GE. DNH4NO3 ) THEN
+            S4RATW = GETASR( CONC( 2 ), RH )
+         ELSE
+            S4RATW = 2.0D0               ! dry aerosol ratio
+         END IF
+         S4RAT = CONC( 3 ) / CONC( 2 )
+
+         IF ( S4RATW .LE. S4RAT ) THEN     ! sulfate poor
+            SC = 'N3'
+         ELSE IF ( 1.0D0 .LE. S4RAT .AND. S4RAT .LT. S4RATW ) THEN  ! sulfate rich (no acid)
+            SC = 'B4'
+         ELSE IF ( S4RAT .LT. 1.0D0 ) THEN    ! sulfate rich (free acid)
+            SC = 'C2'
+         END IF
+
+      ELSE IF ( SCP3R )  THEN ! NH4-SO4-NO3-Na-Cl system
+
+C        Adjust DRH of NH4NO3 for low temperature
+         DNACL  = 0.7528D0
+         DNANO3 = 0.7379D0
+         DNH4CL = 0.7710D0
+         IF ( INT( T ) .NE. 298 ) THEN
+            DNACL   = DNACL  * EXP(  25.0D0 * TCF )
+            DNANO3  = DNANO3 * EXP( 304.0D0 * TCF )
+            DNH4CL  = DNH4Cl * EXP( 239.0D0 * TCF )
+            DNH4NO3 = MIN ( DNH4NO3, DNH4CL, DNANO3, DNACL )
+         END IF
+
+         IF ( RH .GE. DNH4NO3 ) THEN
+            FSO4   = CONC( 2 ) - CONC( 1 ) / 2.0D0   ! sulfate unbound by Na+
+            FSO4   = MAX ( FSO4, SMALL )
+            SRI    = GETASR ( FSO4, RH )
+            S4RATW = ( CONC( 1 ) + FSO4 * SRI ) / CONC( 2 )
+            S4RATW = MIN ( S4RATW, 2.0D0 )
+         ELSE
+            S4RATW = 2.0D0                       ! ratio for dry aerosol
+         END IF
+         S4RAT = ( CONC( 1 ) + CONC( 3 ) ) / CONC( 2 )
+         NaRAT = CONC( 1 ) / CONC( 2 )
+
+         IF ( S4RATW .LE. S4RAT .AND. NaRAT .LT. 2.0D0 ) THEN ! sulfate poor, sodium poor
+            SC = 'Q5'
+         ELSE IF ( S4RAT .GE. S4RATW .AND. NaRAT .GE. 2.0D0 ) THEN ! SO4 poor, Na rich
+            SC = 'R6'
+         ELSE IF ( 1.0D0 .LE. S4RAT .AND. S4RAT .LT. S4RATW ) THEN ! SO4 rich, no acid
+            SC = 'I6'
+         ELSE IF ( S4RAT .LT. 1.0D0 ) THEN ! sulfate rich, free acid
+            SC = 'J3'
+         END IF
+
+      ELSE IF ( SCP4R ) THEN ! NH4-SO4-Na-Cl-Ca-K-Mg system
+
+         ! Do I need an RH if check here????
+         FSO4   = CONC( 2 ) - CONC( 1 ) / 2.0D0
+     &          - CONC( 6 ) - CONC( 7 ) / 2.0D0 - CONC( 8 )  ! sulfate unbound by sodium,calcium,pottasium,magnesium
+         FSO4   = MAX ( FSO4, SMALL )
+         SRI    = GETASR( FSO4, RH )                         ! sulfate ratio for NH4+
+         S4RATW = ( CONC( 1 ) + FSO4 * SRI + CONC( 6 )
+     &            + CONC( 7 ) + CONC( 8 ) ) / CONC( 2 )      ! limiting sulfate ratio
+         S4RATW = MIN ( S4RATW, 2.0D0 )
+         S4RAT = ( CONC( 1 ) + CONC( 3 ) + CONC( 6 ) + CONC( 7 ) + CONC( 8 ) ) / CONC( 2 ) ! sulfate ratio
+         NaRAT = ( CONC( 1 ) + CONC( 6 ) + CONC( 7 ) + CONC( 8 ) ) / CONC( 2 ) ! crustals+sodium ratio
+         CRAT  = ( CONC( 6 ) + CONC( 7 ) + CONC( 8 ) ) / CONC( 2 )             ! crustals ratio
+
+         IF ( S4RATW .LE. S4RAT .AND. NaRAT .LT. 2.0D0 ) THEN ! sulfate, sodium, crustal poor
+            SC = 'V7'
+         ELSE IF ( S4RAT .GE. S4RATW .AND. NaRAT .GE. 2.0D0 ) THEN
+            IF ( CRAT .LE. 2.0D0 ) THEN       ! sulfate poor, dust+sodium rich, dust poor
+               SC = 'U8'
+            ELSE                              ! sulfate poor, dust+sodium rich, dust rich
+               SC = 'W13'
+            END IF
+         ELSE IF ( 1.0D0 .LE. S4RAT .AND. S4RAT .LT. S4RATW ) THEN ! sulfate rich, no acid
+            SC = 'L9'
+         ELSE IF ( S4RAT .LT. 1.0D0 ) THEN     ! sulfate rich, free acid
+            SC = 'K4'
+         END IF
+      END IF
+
+      !print*,'SUBCASE identified in calc_h2o', SC
+
+      END SUBROUTINE GETSC
+
+C:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+      REAL FUNCTION GETAF( NI, NJ, DGNI, DGNJ, XLSGI, XLSGJ, SQRT2 )
+
+C  Returns the value of "Xnum" in Equations 10a and 10c
+C  of Binkowski and Roselle (2003), given the number concentrations,
+C  median diameters, and natural logs of the geometric standard
+C  deviations, in two lognormal modes.  The value returned by GETAF
+C  is used subsequently in the mode merging calculations:
+C       GETAF = ln( Dij / Dgi ) / ( SQRT2 * ln(Sgi) )
+C  where Dij is the diameter of intersection,
+C        Dgi is the median diameter of the smaller size mode, and
+C        Sgi is the geometric standard deviation of smaller mode.
+C  A quadratic equation is solved to obtain GETAF, following the
+C  method of Press et al.
+C 
+C  References:
+C   1. Binkowski, F.S. and S.J. Roselle, Models-3 Community
+C      Multiscale Air Quality (CMAQ) model aerosol component 1:
+C      Model Description.  J. Geophys. Res., Vol 108, No D6, 4183
+C      doi:10.1029/2001JD001409, 2003.
+C   2. Press, W.H., S.A. Teukolsky, W.T. Vetterling, and B.P.
+C      Flannery, Numerical Recipes in Fortran 77 - 2nd Edition.
+C      Cambridge University Press, 1992.
+
+      IMPLICIT NONE
+
+      REAL NI, NJ, DGNI, DGNJ, XLSGI, XLSGJ, SQRT2
+      REAL AA, BB, CC, DISC, QQ, ALFA, L, YJI
+
+C-----------------------------------------------------------------------
+
+C *** Store intermediate values used for the quadratic solution
+C     to reduce computational burden
+      ALFA = XLSGI / XLSGJ
+      YJI = LOG( DGNJ / DGNI ) / ( SQRT2 * XLSGI )
+      L = LOG( ALFA * NJ / NI)
+
+C *** Calculate quadratic equation coefficients & discriminant
+      AA = 1.0 - ALFA * ALFA
+      BB = 2.0 * YJI * ALFA * ALFA
+      CC = L - YJI * YJI * ALFA * ALFA
+      DISC = BB * BB - 4.0 * AA * CC
+
+C *** If roots are imaginary, return a negative GETAF value so that no
+C     mode merging takes place.
+      IF ( DISC .LT. 0.0 ) THEN
+         GETAF = - 5.0       ! error in intersection
+         RETURN
+      END IF
+
+C *** Equation 5.6.4 of Press et al.
+      QQ = -0.5 * ( BB + SIGN( 1.0, BB ) * SQRT( DISC ) )
+
+C *** Return solution of the quadratic equation that corresponds to a
+C     diameter of intersection lying between the median diameters of
+C     the 2 modes.
+      GETAF = CC / QQ       ! See Equation 5.6.5 of Press et al.
+
+      RETURN
+      END FUNCTION GETAF
+
+C:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+      SUBROUTINE AERO_INLET ( DGN, XXLSG, RHOP, fPM1, fPM25, fPM10 )
+
+C  Calculates the volume fraction of a given aerosol mode that would enter
+C  a sharp-cut inlet, using equations from Jiang et al (2006). The
+C  subroutine calculates transmission factors for PM1, PM2.5 and PM10,
+C  after first converting those cutoffs from Aerodynamic Diameter to
+C  Stokes Diameter (used internally within CMAQ).
+ 
+C  CMAQ aerosols are represented with Stokes Diameter. There are many
+C  alternate forms of diameter including the following:
+C       Volume Equivalent Diameter (D_ve) - the diameter of a sphere with the
+C          same volume as the particle.
+C       Stokes Diameter (D_st) - the diameter of a sphere with the same
+C          terminal velocity as the real particle. If the shape factor
+C          is 1, then the Stokes and Volume Equivalent Diameters are
+C          equal.
+C       Aerodynamic Diameter (D_ad) - the diameter of a sphere with unit
+C          density and the same terminal velocity as the real particle.
+C          If the density is 1, then the Aerodynamic Diameter and Stokes
+C          Diameter are equal.
+C       Vacuum Aerodynamic Diameter (D_va) - the diameter of a sphere with very
+C          high Knudsen number and thus a simplified relationship with
+C          Stokes diameter that is only dependent on density and shape
+C          factor, not Slip Correction. The very high Knudsen number
+C          could be because the particle is very small or because the
+C          system pressure is very low.
+C       Electrical Mobility Diameter (D_em) - the diameter of a sphere with the
+C          same migration velocity as the real particle. Requires a
+C          slip-correction and a shape factor correction when converting
+C          from volume equivalent diameter.
+ 
+C  Conversions:
+C       Parameters
+C         rho  - Density
+C         rho0 - Unit Density (1 g cm-3)
+C         Cc( ) - Cunningham Slip Correction of a particular diameter
+C         X   - Shape factor = (NonSpherical Drag Force)/(Spherical Drag Force)
+C       Aerodynamic -> Stokes
+C         D_st = D_ad * sqrt(rho0/rho) * sqrt( Cc(D_ad) / Cc(D_st) )
+C       Volume Equivalent -> Stokes
+C         D_st = D_ve * sqrt(1/X) * sqrt( Cc(D_ve) / Cc(D_st) )
+C       Electrical Mobility -> Volume Equivalent
+C         D_ve = D_em * [Cc(D_ve) / Cc(D_em)] * 1/X
+C             (If X = 1 (i.e. spherical), then D_st = D_ve = D_em )
+C       Vacuum Aerodynamic -> Volume Equivalent (DeCarlo et al., 2004)
+C         D_ve = D_va * rho0/rho * X
+C             (If X = 1 (i.e. spherical), then D_st = D_ve = D_va * rho0/rho )
+ 
+C  Key Subroutines called: none
+ 
+C  Key Functions called:  ERF
+ 
+C  Revision History:
+C    Coded Jul 2005 by Prakash Bhave
+C          Apr 2008 J.Kelly: corrected equation for Dst25 calculation
+C          Feb 2016 B.Murphy: modified to output PM1 and PM10 mode
+C                             fractions in addition to PM2.5
+ 
+C  References:
+C   1. Jiang, W., Smyth, S., Giroux, E., Roth, H., Yin, D., Differences
+C   between CMAQ fine mode particle and PM2.5 concentrations and their
+C   impact on model performance evaluation in the Lower Fraser Valley,
+C   Atmos. Environ., 40:4973-4985, 2006.
+C   2. Meng, Z., Seinfeld, J.H., On the source of the submicrometer
+C   droplet mode of urban and regional aerosols, Aerosol Sci. and
+C   Technology, 20:253-265, 1994.
+ 
+C-----------------------------------------------------------------------
+
+      IMPLICIT NONE
+
+      INCLUDE SUBST_CONST    ! for PI
+
+C    Input variables
+      REAL   DGN     ! geometric mean Stokes diameter by number [ m ]
+      REAL   XXLSG   ! natural log of geometric standard deviation
+      REAL   RHOP    ! average particle density [ kg/m**3 ]
+
+C    Output variable
+      REAL, INTENT( OUT ) :: fPM1   ! fraction of particulate volume transmitted through 1
+      REAL, INTENT( OUT ) :: fPM25  ! fraction of particulate volume transmitted through 2
+      REAL, INTENT( OUT ) :: fPM10  ! fraction of particulate volume transmitted through 10
+
+C    Internal variables
+      REAL, PARAMETER :: SQRT2 = 1.4142136  !  SQRT( 2 )
+      REAL, PARAMETER :: D_AD1  = 1.0  ! aerodynamic diameter cut point [ um ]
+      REAL, PARAMETER :: D_AD25 = 2.5  ! aerodynamic diameter cut point [ um ]
+      REAL, PARAMETER :: D_AD10 = 10.0 ! aerodynamic diameter cut point [ um ]
+      REAL, PARAMETER :: B = 0.21470 ! Cunningham slip-correction approx. param [ um ]
+                                     ! This factor works well applied to the entire particle size-range
+                                     ! The approximation is: Cc(Dp) = 1 + B/Dp
+      REAL D_ST1, D_ST25, D_ST10     ! Stokes diameter equivalent of DCA..
+      REAL DG                        ! DGN converted to [ um ]
+      REAL ERFARG                    ! argument of ERF, from Step#6 of Jiang et al. (2006)
+
+C *** Error function approximation, from Meng & Seinfeld (1994)
+      REAL ERF        ! Error function
+      REAL XX         ! dummy argument for ERF
+      ERF( XX )  = SIGN( 1.0, XX ) * SQRT( 1.0 - EXP( -4.0 * XX * XX / PI ) )
+
+C ----------------------- Begin solution -------------------------------
+
+C *** Calculate Transmission Fractions for Inlets with Aerodynamic
+C     Cutoffs
+      DG = DGN * 1.0E+06 ! [um] The units need to be equivalent with the B parameter
+
+      ! Convert size cut to equivalent Stokes diameter using
+      ! equation 2 of Jiang et al. (2006). Note: the equation in Step 5
+      ! of this paper has a typo (i.e., eq. 2 is correct).
+      D_ST1  = 0.5 * ( SQRT( B ** 2 + 4.0 * D_AD1 *
+     &                     ( D_AD1 + B ) * 1.0E+03 / RHOP ) - B )
+      D_ST25 = 0.5 * ( SQRT( B ** 2 + 4.0 * D_AD25 *
+     &                     ( D_AD25 + B ) * 1.0E+03 / RHOP ) - B )
+      D_ST10 = 0.5 * ( SQRT( B ** 2 + 4.0 * D_AD10 *
+     &                     ( D_AD10 + B ) * 1.0E+03 / RHOP ) - B )
+
+      ! Calculate mass fraction with Dca < SizeCut, using ERF approximation
+      ! from Meng & Seinfeld (1994) and modified form of Fk(X) equation
+      ! in Step#6 of Jiang et al. (2006).
+      ERFARG = ( LOG( D_ST1 ) - LOG( DG ) ) / ( SQRT2 * XXLSG ) - 3.0 * XXLSG / SQRT2
+      fPM1   = 0.5 * ( 1.0 + ERF( ERFARG ) )
+      ERFARG = ( LOG( D_ST25 ) - LOG( DG ) ) / ( SQRT2 * XXLSG ) - 3.0 * XXLSG / SQRT2
+      fPM25  = 0.5 * ( 1.0 + ERF( ERFARG ) )
+      ERFARG = ( LOG( D_ST10 ) - LOG( DG ) ) / ( SQRT2 * XXLSG ) - 3.0 * XXLSG / SQRT2
+      fPM10  = 0.5 * ( 1.0 + ERF( ERFARG ) )
+
+      END SUBROUTINE AERO_INLET
+
+C:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+      SUBROUTINE AERO_AMS ( M3_WET, M2_WET, M0, M_H2O, RHOP, RHO_H2O, fAMS )
+
+C  The subroutine calculates transmission factors applicable for
+C  comparison with AMS measurements using the curve suggested by Jimenez
+C  and coworkers  (http://cires1.colorado.edu/jimenez-group/wiki/index.php/
+C  FAQ_for_AMS_Data_Users#What_is_the_size_cut_of_AMS_measurements.3F).
+C  The AMS measures Vacuum Aerodynamic Diameter (D_va) because the pressure is
+C  so low in the instrument. This curve (also described in Ensberg et
+C  al., 2004)  includes the following (Note: before applying the curve,
+C  the bounds must be converted to Stokes Diameter):
+C     D_va < 0.04 um: 0% transmission (T)
+C     0.04 < D_va < 0.1 um:  T% = 1666.6 * (D_va - 0.04)   (1)
+C     0.1  < D_va < 0.55 um: T% = 100%                     (2)
+C     0.55 < D_va < 2.0 um:  T% = 100-68.965*(D_va-0.55)   (3)
+C     2.0 um < D_va: T = 0%
+ 
+C  CMAQ aerosols are represented with Stokes Diameter. There are many
+C  alternate froms of diameter including the following:
+C       Volume Equivalent Diameter (D_ve) - the diameter of a sphere with the
+C          same volume as the particle.
+C       Stokes Diameter (D_st) - the diameter of a sphere with the same
+C          terminal velocity as the real particle. If the shape factor
+C          is 1, then the Stokes and Volume Equivalent Diameters are
+C          equal.
+C       Vacuum Aerodynamic Diameter (D_va) - the diameter of a sphere with very
+C          high Knudsen number and thus a simplified relationship with
+C          Stokes diameter that is only dependent on density and shape
+C          factor, not Slip Correction. The very high Knudsen number
+C          could be because the particle is very small or because the
+C          system pressure is very low.
+ 
+C  Conversions:
+C       Parameters
+C         ro  - Density
+C         ro0 - Unit Density (1 g cm-3)
+C         Cc( ) - Cunningham Slip Correction of a particular diameter
+C         X   - Shape factor = (NonSpherical Drag Force)/(Spherical Drag Force)
+C       Vacuum Aerodynamic -> Volume Equivalent (DeCarlo et al., 2004)
+C         D_ve = D_va * ro0/ro * X
+C             (If X = 1 (i.e. spehrical), then D_st = D_ve = D_va * ro0/ro )
+ 
+C  Key Functions called:  ERF
+ 
+C  Revision History:
+C    Coded Feb 2016 B.Murphy: Created
+
+C  References:
+C   1. DeCarlo et al., Particle Morphology and Density Characterization
+C   by Combined Mobility and Aerodynamic Diameter Measurements. Part 1:
+C   Theory, Aerosol Sci. and Technology, 38:1185-1205, 2004
+C   2. Ensberg et al., Inorganic and black carbin aerosols in the Los
+C   Angeles Basin during CalNex, Journ. Geophys. Res., 2013.
+
+C-----------------------------------------------------------------------
+
+      USE AERO_DATA, ONLY : MIN_SIGMA_G, MAX_SIGMA_G
+      USE AEROMET_DATA, ONLY : F6PI, PI6
+
+      IMPLICIT NONE
+
+      INCLUDE SUBST_CONST    ! for PI
+
+C    Input variables
+      REAL, INTENT( IN ) :: M3_WET  ! Third Moment of Wet Distirbution (m3/m3)
+      REAL, INTENT( IN ) :: M2_WET  ! Second Moment of Wet Distribution (m2/m3)
+      REAL, INTENT( IN ) :: M0      ! Number of Particles in Distribution (N/m3)
+      REAL, INTENT( IN ) :: M_H2O   ! Mass Conc. of Water in Particles (ug/m3)
+      REAL, INTENT( IN ) :: RHOP    ! average particle density [ kg/m**3 ]
+      REAL, INTENT( IN ) :: RHO_H2O ! Water Density [ kg/m3 ]
+
+C    Output variable
+      REAL, INTENT(OUT) :: fAMS   ! fraction of particulate volume transmitted through AMS Inlet
+
+C    Internal variables
+      REAL, PARAMETER :: SQRT2 = 1.4142136    !  SQRT( 2 )
+      REAL, PARAMETER :: DGMIN = 1.0E-9       !  min(Dp) in [m]
+      REAL, PARAMETER :: ONETHIRD = 1.0 / 3.0
+      REAL, PARAMETER :: TWOTHIRDS = 2.0 * ONETHIRD
+
+      REAL DG                        ! DGN converted to [ um ]
+      REAL DGv                       ! Volume Median Diameter
+      REAL XXLSG                     ! ln(StndDev) for current mode
+      REAL M3_DRY, M2_DRY, M3SUBT, M_WET, M_DRY, DRY_DENS, DENSFAC
+      REAL XFSUM, LXFM2, L2SG, ES36
+      REAL DBlo_st, DBhi_st, LOG_HILO, LOG_LOHI, LOG_HI, LOG_LO
+      REAL SQRT2LSG, TERM1, TERM2, TERM3, TERM4, TERM5
+
+C *** Error function approximation, from Meng & Seinfeld (1994)
+      REAL ERF        ! Error function
+      REAL XX         ! dummy argument for ERF
+      ERF( XX )  = SIGN( 1.0, XX ) * SQRT( 1.0 - EXP( -4.0 * XX * XX / PI ) )
+
+C ----------------------- Begin solution -------------------------------
+
+C *** First Calculate Parameters of Dry Distributiuon since this is more
+C     applicable in general to AMS measurements.
+      M3SUBT = ( 1.0E-9 * F6PI / RHO_H2O ) * M_H2O        ! m3 m-3
+      M3_DRY = M3_WET - M3SUBT              ! m3 m-3
+      M2_DRY = M2_WET * ( M3_DRY / M3_WET ) ** TWOTHIRDS  ! m2 m-3
+
+      M_WET = M3_WET * 1.0E+9 * PI6 * RHOP ! ug m-3
+      M_DRY = M_WET - M_H2O                ! ug m-3
+
+      DRY_DENS = M_DRY / M3_DRY * F6PI * 1.0E-9   ! kg m-3
+
+      XFSUM = ONETHIRD * Log( M0 ) + TWOTHIRDS * Log( M3_DRY )
+      LXFM2 = Log( M2_DRY )
+      L2SG = XFSUM - LXFM2   ! ( ln(sigma) )^2
+
+      L2SG = Min( Max( L2SG, LOG( MIN_SIGMA_G ) ** 2 ), LOG( MAX_SIGMA_G ) ** 2 )
+      LXFM2 = XFSUM - L2SG
+      ES36 = Exp( 4.5 * L2SG )
+
+      DG = Max( DGMIN, ( M3_DRY / ( M0 * ES36 ) ) ** ONETHIRD ) * 1.0E+06 ![um] Units should correspond to D
+      XXLSG = Sqrt( L2SG )  ! ln(sigma)
+
+      DGv = EXP( LOG( DG ) + 3.0 * L2SG )
+
+C *** Calculate Transmission Fractions for AMS with Vacuum Aerodynamic
+C     Cutoffs. This approzimation is split into a piecewise function (see
+C     Appendix B in Ensberg et al., 2013).
+      fAMS = 0.0
+      DENSFAC = 1.0E+03 / DRY_DENS  ! Density Correction Factor
+                                    !   = rho0 / rho
+                                    !   = 1000.0 / rho
+      SQRT2LSG = SQRT2 * XXLSG
+
+      ! First Piece of Function [T(%) = 1666.6 * (Dva - 0.04) ]
+      DBlo_st = 0.040 * DENSFAC  ! Stokes Lower Bound of Piece [um]
+      DBhi_st = 0.100 * DENSFAC  ! Stokes Upper Bound of Piece [um]
+
+      LOG_HILO = LOG( 100.0/40.0 )
+      LOG_HI   = LOG( DBhi_st/DGv )
+      LOG_LO   = LOG( DBlo_st/DGv )
+
+      TERM1 = LOG( DGv/DBlo_st ) / LOG_HILO
+      TERM2 =  ERF( LOG_HI / SQRT2LSG )
+     &        -ERF( LOG_LO / SQRT2LSG )
+      TERM3 = XXLSG / ( LOG_HILO * (pi/2.0) ** 0.5 )
+      TERM4 = EXP( -1.0 * ( LOG_LO / SQRT2LSG ) ** 2 )
+      TERM5 = EXP( -1.0 * ( LOG_HI / SQRT2LSG ) ** 2 )
+
+      fAMS = ( TERM1*TERM2  +  TERM3*(TERM4-TERM5) )
+
+      ! Second Piece of Function [T(%) = 100]
+      DBlo_st = DBhi_st         ! Stokes Lower Bound [um]
+      DBhi_st = 0.55 * DENSFAC  ! Stokes Upper Bound [um]
+
+      TERM1 = ERF( LOG( DBhi_st/DGv ) / SQRT2LSG )
+      TERM2 = ERF( LOG( DBlo_st/DGv ) / SQRT2LSG )
+      fAMS = fAMS +  (TERM1 - TERM2)
+
+      ! Third Piece of Function [T(%) = 1.0 - 0.6805 * (Dva - 0.55) ]
+      DBlo_st = DBhi_st        ! Stokes Lower Bound [um]
+      DBhi_st = 2.0 * DENSFAC  ! Stokes Upper Bound [um]
+
+      LOG_LOHI = LOG( 550.0/2000.0 )
+      LOG_HI   = LOG( DBhi_st/DGv )
+      LOG_LO   = LOG( DBlo_st/DGv )
+
+      TERM1 = LOG( DGv/DBhi_st ) / LOG_LOHI
+      TERM2 =  ERF( LOG_HI / SQRT2LSG )
+     &        -ERF( LOG_LO / SQRT2LSG )
+      TERM3 = XXLSG / ( LOG_LOHI * (pi/2.0) ** 0.5 )
+      TERM4 = EXP( -1.0 * ( LOG_LO / SQRT2LSG ) ** 2 )
+      TERM5 = EXP( -1.0 * ( LOG_HI / SQRT2LSG ) ** 2 )
+
+      fAMS = fAMS + TERM1 * TERM2  +  TERM3 * (TERM4-TERM5)
+
+      ! Apply the Factor of 0.5 Consistent with Appendix B in Ensberg et
+      ! al., 2013. Omit the total mass quantity since these are fractions
+      ! we want.
+      fAMS = 0.5 * fAMS
+
+      END SUBROUTINE AERO_AMS
+
+C:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+      SUBROUTINE GETVISBY( DCV1, EXT1, DCV2, EXT2 )
+ 
+C *** This routine calculates the Pitchford & Malm visual index,
+C     deciview, using the Evans & Fournier extinction with 20 point
+C     Gauss_Hermite numerical quadrature to integrate the extincetion
+C     over the log normal size distribution.
+C     This new method reproduces the results of Willeke and Brockmann
+C     very very closely.
+C     The Heintzenberg and Baker (h&b) method used previously has been
+C     replaced.
+C *** This also routine calculates the Pitchford & Malm visual index,
+C     deciview, using reconstructed extinction values from the IMPROVE
+C     monitoring network
+ 
+C *** References:
+ 
+C     Evans, B.T.N.  and G.R. Fournier, Simple approximations to
+C     extinction efficiency valid over all size parameters,
+C     Applied Optics, 29, 4666 - 4670.
+ 
+C     Heintzenberg, j. and M. Baker, Applied Optics, vol. 15, no. 5,
+C     pp 1178-1181, 1976.
+C     correction in Applied Optics August 1976 does not affect this code.
+ 
+C     Sisler, J. Fax dated March 18, 1998 with IMPROVE information.
+ 
+C     Pitchford, M. and W. Malm, Atmos. Environ.,vol 28,no.5,
+C     pp 1049-1054, 1994.
+ 
+C     Willeke,K. & J. E. Brockmann, Atmos. Environ., vol.11,
+C     pp 995 - 999, 1977.
+ 
+Coding history:
+C    who           when     what
+C ------------------------------------------------------------------
+C   Peng Liu       05/2016  to get EXT2 and DCV2, use IMPROVE
+C                           reconstructed method, by calling subroutine
+C                           get_extinc (defined in module AOD_DEFN) in order to be consistent with
+C                           the updated algorithm to estimate the
+C                           aerosol extinction efficiency
+C   F.S. Binkowski 5/9/95   
+C             coded this version to use the h&b approximation
+C             and alfa and c obtained from fits to adt results
+C             b was fit from comparisons to willeke & brockmann.
+C   F.S. Binkowski 9/12/95  modified code to push j-loop inside.
+C   F.S. Binkowski 5/13/97  made models-3 version
+C   F.S. Binkowski 4/20/98  changed to Evans and Fournier approach
+C                           for extinction
+C   F.S. Binkowski 4/20/98  began code for reconstructed method
+C   F.S. Binkowski 4/24/98  merged codes for both methods
+C   F.S. Binkowski 5/20/98  corrected CONSTL
+C   F.S. Binkowski 3/9/99   Modified for variable XXLSGAT and XXLSGAC
+C   P.V. Bhave     1/30/08  Updated EXT2 to account for new SOA species
+C   J.T. Kelly     4/17/08  Modified for variable XXLSGCO
+C ////////
+C NOTE: This subroutine is dependent upon the variables defined in the
+C       IF( FIRSTIME ) section of aeroproc.f for implementation of
+C                      coarse mode contribution.
+C ///////
+
+      USE AERO_DATA
+      USE SOA_DEFN
+      USE AEROMET_DATA
+      USE AOD_DEFN
+
+      IMPLICIT NONE
+
+      REAL    DCV1   ! block deciview (Mie)
+      REAL    EXT1   ! block extinction [ km**-1 ] (Mie)
+
+      REAL    DCV2   ! block deciview (Reconstructed)
+      REAL    EXT2   ! block extinction [ km**-1 ]
+                                  ! (Reconstructed)
+
+C *** Paramters 
+
+      REAL, PARAMETER :: LAM = 0.55E-6  ! wavelenght of visible light [ m ]
+
+      REAL, PARAMETER :: CONSTL = 1.0E3 * PI6 / LAM    ! 1.0e3  to get km**-1
+
+      REAL, PARAMETER :: CONST3 = PI / LAM  ! Changed 3/9/99 FSB
+
+      REAL, PARAMETER :: SCALE = 1.0E-03  ! factor to rescale units from [ 1/Mm ] to [ 1/km ]
+
+      REAL, PARAMETER :: RAY = 0.01         ! standard value for Rayleigh extinction [ 1/km ]
+      REAL, PARAMETER :: RAY1 = 1.0 / RAY   ! the reciprocal of Rayleigh
+
+C *** internal variables:
+
+
+      REAL    WFRAC  ! water mass fraction
+      REAL    NR, NI ! real and imaginary parts of the refractive index
+      REAL    ALFV( n_mode )  ! Mie parameters for modal mass median diameters
+      REAL    BBEXT  ! dimensionless extinction coefficient
+      REAL    BEXT( n_mode ) ! Modal extinction coefficients [ 1/km ]
+
+
+      INTEGER N       ! loop counter
+
+C-----------------------------------------------------------------------
+
+C NOTE: In the following calculations, the contribution from the
+C        coarse mode is ignored.
+
+C *** calculate the  mass fraction of aerosol water
+
+      WFRAC = MIN( ( AEROSPC_CONC( AH2O_IDX,1 ) + AEROSPC_CONC( AH2O_IDX,2 ) )
+     &            / ( AEROMODE_MASS( 1 ) + AEROMODE_MASS( 2 ) ), 1.0 )
+
+C *** interpolate between "dry" state with m = 1.5 - 0.01i
+C     and pure water particle with  m = 1.33 - 0.0i as a function of
+C     wfrac
+
+      NR = 1.5 - 0.17 * WFRAC     ! real part of refractive index
+      NI = 0.01 * ( 1.0 - WFRAC ) ! imaginary part of refractive index
+
+C *** set up Mie parameters for Volume ( mass median diameter)
+      
+      DO N = 1, N_MODE
+        ALFV( N ) = CONST3 * AEROMODE_DIAM( N )
+     &            * EXP( 3.0 * AEROMODE_LNSG( N ) * AEROMODE_LNSG( N ) )
+      END DO
+
+C *** Call extinction routines
+
+      DO N = 1, N_MODE
+         CALL GETBEXT( NR, NI, ALFV( N ), AEROMODE_LNSG( N ), BBEXT )
+         BEXT( N ) = CONSTL * MOMENT3_CONC( N ) * BBEXT
+      END DO
+
+      BEXT( N_MODE ) = 0.0
+
+      EXT1  = BEXT( 1 ) + BEXT( 2 ) + RAY
+
+      DCV1  = 10.0 * LOG ( EXT1 * RAY1 )
+
+C     note if EXT1 < 0.01 then DCV1 is negative.
+C     this implies that visual range is greater than the Rayleigh limit.
+C     The definition of deciviews is based upon the Rayleigh limit
+C     being the maximum visual range
+C     thus, set a floor of 0.0 on DCV1.
+
+      DCV1  = MAX( 0.0, DCV1 )
+
+C *** begin  IMPROVE reconstructed method
+
+      EXT2 = 0.0
+      
+      CALL get_extinc( AIRRH, EXT2 )
+C EXT2 from get_extinc in [ 1/km ], no need to scale 
+C     EXT2 = SCALE * EXT2 + RAY
+      EXT2 = EXT2 + RAY
+
+      DCV2  = 10.0 * LOG ( EXT2  * RAY1 )
+
+C     note if EXT2 < RAY then DCV2 is negative.
+C     this implies that visual range is greater than the Rayleigh limit.
+C     The definition of deciviews is based upon the Rayleigh limit
+C     being the maximum visual range
+C     thus, set a floor of 0.0 on BLKDCV.
+
+      DCV2  = MAX( 0.0, DCV2 )
+
+      RETURN
+      END SUBROUTINE GETVISBY
+
+C:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+      subroutine getbext(nr, ni, alfv, xlnsig, bext)
+
+C     calculates the extinction coefficient normalized by wavelength
+C     and total particle volume concentration for a log normal
+C     particle distribution with the logarithm of the
+C     geometric standard deviation given by xlnsig.
+ 
+C *** does gauss-hermite quadrature of Qext / alfa
+C     over log normal distribution
+C     using 20 symmetric points
+ 
+      implicit none
+
+      INCLUDE SUBST_CONST     ! physical and mathematical constants
+
+      real nr, ni  ! indices of refraction
+      real alfv    ! Mie parameter for dgv
+      real xlnsig  ! log of geometric standard deviation
+      real bext    ! normalized extinction coefficient
+      real aa, aa1 ! see below for definition
+
+      real alfaip, alfaim   ! Mie parameters at abscissas
+
+      real xxqalf  ! function to calculate the extinction ceofficient
+      real qalfip, qalfim   ! extinction efficiencies at abscissas
+
+!     real, parameter :: pi      = 3.14159265
+!     real, parameter :: sqrtpi  = 1.77245385
+!     real, parameter :: sqrtpi1 = 1.0 / sqrtpi
+      real, parameter :: sqrt2   = 1.41421356
+!     real, parameter :: three_pi_two = 3.0 * pi / 2.0
+!     real, parameter :: const = three_pi_two * sqrtpi1
+
+      integer i
+      real const, sum, xi, wxi, xf
+
+      integer, parameter :: n = 10   ! one-half the number of abscissas
+      real ghxi( n ) ! Gauss-Hermite abscissas
+      real ghwi( n ) ! Gauss-Hermite weights
+
+C *** the following weights and abscissas are from abramowitz and
+C     stegun, page 924
+C *** tests show that 20 point is adquate.
+
+      data ghxi / 0.245341, 0.737474, 1.234076, 1.738538, 2.254974,
+     &            2.788806, 3.347855, 3.944764, 4.603682, 5.387481 /
+
+      data ghwi/ 4.622437e-1, 2.866755e-1, 1.090172e-1, 2.481052e-2,
+     &           3.243773e-3, 2.283386e-4, 7.802556e-6, 1.086069e-7,
+     &           4.399341e-10, 2.229394e-13 /
+
+      sum = 0.0
+
+      aa = 1.0 / ( sqrt2 * xlnsig )
+      aa1 = sqrt2 * xlnsig ! multiplication cheaper than another division
+
+      do i = 1, n
+
+         xi      = ghxi( i )
+         wxi     = ghwi( i)
+         xf      = exp( xi * aa1 )
+         alfaip  = alfv * xf
+         alfaim  = alfv / xf
+         qalfip  = xxqalf( alfaip, nr, ni )
+         qalfim  = xxqalf( alfaim, nr, ni )
+
+         sum = sum + wxi * ( qalfip + qalfim )
+
+      end do ! i
+
+C fsb      bext = const * aa * sum
+      const = 3.0 * sqrt( pi ) / 2.0
+      bext = const * sum ! corrected 07/21/2000 FSB; found by Rokjin Park
+
+      return
+      end subroutine getbext
+
+C:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+      real function xxqalf( alfa, nr, ni )
+ 
+C *** compute the extinction efficiency divided by the Mie parameter
+C     reference:
+C     Evans, B.T.N.  and G.R. Fournier, Simple approximations to
+C     extinction efficiency valid over all size parameters,
+C     Applied Optics, 29, 4666 - 4670.
+
+      implicit none
+
+      real alfa
+      real nr, ni  ! real and imaginary parts of index of refraction
+
+      real qextray
+      real qextadt
+      real qextef
+      real tt        !  edge effect factor
+      real mu, mum1  !  exponents in formula
+      real aa        !  first coefficient in mu
+      real gg        !  second coefficient in mu
+      real nrm1, sqrtni
+      real alfm23   ! functions of alfa (mie parameter)
+
+      real, parameter :: three5 = 3.0 / 5.0,
+     &                   three4 = 3.0 / 4.0,
+     &                   two3   = 2.0 / 3.0
+
+      nrm1   = nr - 1.0
+      sqrtni = sqrt (ni )
+
+      call adtqext( alfa, nr, ni, qextadt )
+      call pendrfx( alfa, nr, ni, qextray )
+
+      if ( alfa .gt. 0.5 ) then
+
+         alfm23 = 1.0 / alfa ** two3
+         tt = 2.0 - exp( -alfm23 )
+
+         aa = 0.5 + ( nrm1 - two3 * sqrtni - 0.5 * ni )
+     &      + ( nrm1 + two3 * ( sqrtni - 5.0  * ni )  ) ** 2
+
+         gg = three5 - three4 * sqrt ( nrm1) + 3.0 * nrm1 ** 4
+     &      + 25.0 * ni / ( 6.0 * ni + 5.0 * nrm1 )
+
+         mu     = aa + gg / alfa
+         mum1   = - 1.0 / mu
+
+         qextef = qextray
+     &          * ( 1.0 + (qextray /( qextadt * tt)) ** mu ) ** mum1
+
+      else
+
+         qextef = qextray   ! Use Rayleigh extinction for really small alfa's
+
+      end if ! check on alfa
+
+      xxqalf = qextef / alfa
+
+      return
+      end function xxqalf
+
+C:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+      subroutine adtqext( alfa, nr, ni, QEXT )
+ 
+C *** van de Hulst approximation for QEXT.
+C *** This approximation is known as Anomalous Diffraction Theory (ADT)
+ 
+C *** originally coded by Dr Francis  S. Binkowski,
+C     AMAB/MD/ESRL RTP,N.C. 27711 28 July 1977.
+C     corrected 7/19/90 by fsb.
+C     revised 1/8/98 by FSB
+ 
+C *** reference:
+C     van de Hulst- Light Scattering by Small Particles,
+C     Dover,1981 page 179. Original edition was Wiley, 1957.
+
+      implicit none
+
+      real alfa     ! Mie parameter
+      real nr, ni   ! real and imaginary parts of the index of refraction
+      real QEXT     ! extinction efficiency for a sphere
+      real z, tanb, b, cos2b, v1, v2, x, expmx, cs1, cs2
+      real twob, cosb
+      real nr1
+
+      nr1    = nr - 1.0
+      z      = 2.0 * alfa * nr1
+      tanb   = ni / nr1
+      b      = atan( tanb )
+      cosb   = cos( b )
+      twob   = 2.0 * b
+      cos2b  = cos( twob )
+      v1     = 5.0 * nr1
+      v2     = 4.08 / ( 1.0 + 3.0 * tanb )
+      x      = Min(z * tanb, 69.0)
+      expmx  = exp( -x )
+      cs1    = cosb / z
+      cs2    = cs1 * cs1
+      QEXT   = 2.0 - 4.0 * cs1 * expmx * sin( z - b )
+     &       + 4.0 * cs2 * ( cos2b - expmx * cos(z - twob ) )
+      return
+      end subroutine adtqext
+
+C:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+      subroutine pendrfx( alfa, nr, ni, QEXT )
+ 
+C *** calculates the Mie efficiencies for extinction, scattering and
+C     absorption using Penndorf`s approximations for small
+C     values of alfa.
+ 
+C  input:
+C       nr        the real part of the refractive index.
+C       ni        the imaginary part of the refractive index
+C       alfa      mie parameter
+ 
+C  output:
+C       QEXT      extinction efficiency
+ 
+C *** Reference:
+C       Penndorf, r., Scattering and extinction coefficients for small
+C       aerosols, J. Atmos. Sci., 19, p 193, 1962.
+C
+C *** Coded by Dr Francis  S.  Binkowski,
+C       AMAB/MD/ESRL RTP,N.C. 27711 28 July 1977.
+C       corrected 7/19/90 by FSB
+C       modified 30 september 1992 by FSB
+C       modified 1/6/98 by FSB
+
+      implicit none
+
+      real alfa, nr, ni
+      real QEXT
+      real alf2, alf3, alf4
+
+      real a1, a2, a3
+      real xnr, xni, xnr2, xni2, xnri, xnri2, xnrmi
+      real xri, xri2, xri36, xnx, xnx2
+      real z1, z12, z2, xc1
+
+      xnr   = nr
+      xni   = ni
+      xnr2  = xnr   * xnr
+      xni2  = xni   * xni
+      xnri  = xnr2  + xni2
+      xnri2 = xnri  * xnri
+      xnrmi = xnr2  - xni2
+      xri   = xnr   * xni
+      xri2  = xri   * xri
+      xri36 = 36.0  * xri2
+      xnx   = xnri2 + xnrmi - 2.0
+      xnx2  = xnx   * xnx
+
+      z1    = xnri2 + 4.0 * xnrmi + 4.0
+      z12   = z1    * z1
+      z2    = 4.0   * xnri2 + 12.0 * xnrmi + 9.0
+      xc1   = 8.0   / ( 3.0 * z12 )
+
+      alf2  = alfa  * alfa
+      alf3  = alfa  * alf2
+      alf4  = alfa  * alf3
+
+      a1    = 24.0  * xri / z1
+
+      a2    = 4.0   * xri / 15.0 + 20.0 * xri / ( 3.0 * z2 )
+     &      + 4.8   * xri * ( 7.0 * xnri2
+     &      + 4.0   * ( xnrmi - 5.0 ) ) / z12
+
+      a3    = xc1   * ( xnx2 - xri36 )
+
+      QEXT  = a1    * alfa + a2 * alf3 + a3 * alf4
+
+      return
+      end subroutine pendrfx
+

--- a/DOCS/Known_Issues/CMAQv5.2-i5/getpar.f
+++ b/DOCS/Known_Issues/CMAQv5.2-i5/getpar.f
@@ -1,0 +1,187 @@
+
+!------------------------------------------------------------------------!
+!  The Community Multiscale Air Quality (CMAQ) system software is in     !
+!  continuous development by various groups and is based on information  !
+!  from these groups: Federal Government employees, contractors working  !
+!  within a United States Government contract, and non-Federal sources   !
+!  including research institutions.  These groups give the Government    !
+!  permission to use, prepare derivative works of, and distribute copies !
+!  of their work in the CMAQ system to the public and to permit others   !
+!  to do so.  The United States Environmental Protection Agency          !
+!  therefore grants similar permission to use the CMAQ system software,  !
+!  but users are requested to provide copies of derivative works or      !
+!  products designed to operate in the CMAQ system to the United States  !
+!  Government without restrictions as to use by others.  Software        !
+!  that is used with the CMAQ system but distributed under the GNU       !
+!  General Public License or the GNU Lesser General Public License is    !
+!  subject to their copyright restrictions.                              !
+!------------------------------------------------------------------------!
+
+C RCS file, release, date & time of last delta, author, state, [and locker]
+C $Header: /project/yoj/arc/CCTM/src/aero/aero5/getpar.f,v 1.7 2012/01/19 13:13:27 yoj Exp $
+
+C:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+      Subroutine getpar( fixed_sg  )
+
+C  Calculates the 3rd moments (M3), masses, aerosol densities, and
+C  geometric mean diameters (Dg) of all 3 modes, and the natural logs of
+C  geometric standard deviations (Sg) of the Aitken and accumulation modes.
+
+C  The logical variable, WET_MOMENTS_FLAG, dictates whether the
+C  calculations in GETPAR are to assume that the aerosol is "wet" or
+C  "dry."  In the present context, a "wet" aerosol consists of all
+C  chemical components of the aerosol.  A "dry" aerosol excludes
+C  particle-bound water and also excludes semivol secondary organic aerosol.
+
+C  NOTE! 2nd moment concentrations (M2) are passed into GETPAR in the
+C  CBLK array and are modified within GETPAR only in the event that
+C  the Sg value of a given mode has gone outside of the acceptable
+C  range (1.05 to 2.50).  The GETPAR calculations implicitly assume
+C  that the input value of M2 is consistent with the input value of
+C  WET_MOMENTS_FLAG.  If, for example, the input M2 value was calculated
+C  for a "dry" aerosol and the WET_MOMENTS_FLAG is .TRUE., GETPAR would
+C  incorrectly adjust the M2 concentrations!
+C  
+C  Outputs: 
+C    moment3_conc  third moment, porportional to volume [ m3/m3 ]
+C    moment2_conc  second moment, prop. to surface area [ m2/m3 ] 
+C                     (adjusted if standard dev. hits limit)
+C    aeromode_dens [ kg/m3 ]
+C    aeromode_lnsg log of geometric standard deviation
+C    aeromode_diam geometric mean diameter [ m ]
+C    aeromode_mass mass concentration: [ ug / m**3 ]
+C
+C SH  03/10/11 Renamed met_data to aeromet_data
+C HP and BM 4/2016: Updated use of wet_moments_flag which is now
+C    available through AERO_DATA consistent with the moments it refers to
+C-----------------------------------------------------------------------
+
+      Use aero_data, only : wet_moments_flag, moment3_conc, moment2_conc, moment0_conc,
+     &                       aeromode_dens, aeromode_lnsg, aeromode_diam, aeromode_mass,
+     &                       min_diam_g, min_sigma_g, max_sigma_g, n_mode, n_aerospc,
+     &                       aerospc, aero_missing, aerospc_conc, aeromode
+      Use aeromet_data, only : f6pi   ! Includes CONST.EXT
+
+      Implicit None
+
+C Arguments:
+      Logical, Intent( In ) :: fixed_sg  ! If TRUE, then the second moment is modified 
+                                         ! during each call in order to preserve the 
+                                         ! standard deviaiton at the current value.
+                                         !
+                                         ! If FALSE, then the standard deviation is 
+                                         ! recalculated to be consistent with the current 
+                                         ! combination of the 0th, 2nd and 3rd moments.
+                                         ! During this calculation, standard deviaiton is 
+                                         ! limited by parameters in AERO_DATA (min_sigma_g 
+                                         ! and max_sigma_g)
+
+C Local Variables:
+      Real( 8 ) :: xxm0        ! temporary storage of moment 0 conc's
+      Real( 8 ) :: xxm2        ! temporary storage of moment 2 conc's
+      Real( 8 ) :: xxm3        ! temporary storage of moment 3 conc's
+      Real( 8 ) :: xfsum       ! (ln(M0)+2ln(M3))/3; used in Sg calcs
+      Real( 8 ) :: lxfm2       ! ln(M2); used in Sg calcs
+      Real( 8 ) :: l2sg        ! square of ln(Sg); used in diameter calcs
+      Real      :: es36        ! exp(4.5*l2sg); used in diameter calcs
+
+      Real( 8 ), Parameter :: one3d = 1.0D0 / 3.0D0
+      Real( 8 ), Parameter :: two3d = 2.0D0 / 3.0D0
+
+      Real,      Parameter :: one3  = 1.0 / 3.0
+      Real,      Parameter :: densmin = 1.0E03  ! minimum particle density [ kg/m**3 ]
+
+      Real( 8 ) :: minl2sg( n_mode )   ! min value of ln(sg)**2 for each mode
+      Real( 8 ) :: maxl2sg( n_mode )   ! max value of ln(sg)**2 for each mode
+
+      Real( 8 ) :: factor
+      Real( 8 ) :: species_mass
+      Real( 8 ) :: sumM3
+      Real( 8 ) :: sumMass
+      Integer   :: n, spc   ! loop counters
+
+      Real( 8 ), Save :: min_ln_sig_g_squ
+      Real( 8 ), Save :: max_ln_sig_g_squ
+      Logical,   Save :: FirsTime = .True.
+
+C-----------------------------------------------------------------------
+
+      If ( FirsTime ) Then
+          ! Set bounds for ln(Sg)**2
+          minl2sg = Real( Log( min_sigma_g ) ** 2, 8 )
+          maxl2sg = Real( Log( max_sigma_g ) ** 2, 8 )
+          FirsTime = .False.
+      End If
+
+
+
+C *** Calculate aerosol 3rd moment concentrations [ m**3 / m**3 ]
+
+      Do n = 1, n_mode
+         sumM3   = 0.0d0
+         sumMass = 0.0d0
+
+         Do spc = 1, n_aerospc
+            If ( aerospc( spc )%tracer .Or. aero_missing(spc,n) .Or. 
+     &         ( aerospc( spc )%no_M2Wet .AND. .Not. wet_moments_flag ) ) Cycle
+
+            factor       = Real( 1.0E-9 * f6pi / aerospc( spc )%density, 8 )
+            species_mass = Real( aerospc_conc( spc,n ), 8 )
+            sumM3        = sumM3   + factor * species_mass
+            sumMass      = sumMass + species_mass
+         End Do
+
+         moment3_conc( n )  = Max ( Real( sumM3 ), aeromode( n )%min_m3conc )
+         aeromode_mass( n ) = Real( sumMass )
+      End Do
+
+C *** Calculate modal average particle densities [ kg/m**3 ]
+      aeromode_dens = 1.0E-9 * f6pi * aeromode_mass / moment3_conc
+      Where( aeromode_dens .Lt. densmin )
+         aeromode_dens = densmin
+      End Where
+
+C *** Calculate geometric standard deviations as follows:
+c        ln^2(Sg) = 1/3*ln(M0) + 2/3*ln(M3) - ln(M2)
+c     NOTES:
+c      1. Equation 10-5a of [Binkowski:1999] and Equation 5a of
+c         Binkowski&Roselle(2003) contain typographical errors.
+c      2. If the square of the logarithm of the geometric standard
+c         deviation is out of an acceptable range, reset this value and
+c         adjust the second moments to be consistent with this value.
+c         In this manner, M2 is artificially increased when Sg exceeds
+c         the maximum limit.  M2 is artificially decreased when Sg falls
+c         below the minimum limit.
+
+      Do n = 1, n_mode
+         xxm0 = Real( moment0_conc( n ), 8 )
+         xxm3 = Real( moment3_conc( n ), 8 )
+         xfsum = one3d * Log( xxm0 ) + two3d * Log( xxm3 )
+
+         if ( fixed_sg ) then
+            l2sg  = Real( aeromode_lnsg( n ) ** 2, 8)
+
+         else
+            xxm2  = Real( moment2_conc( n ), 8 )
+
+            lxfm2 = Log( xxm2 )
+            l2sg  = xfsum - lxfm2
+
+            l2sg  = Max( l2sg, minl2sg( n ) )
+            l2sg  = Min( l2sg, maxl2sg( n ) )
+
+         end if
+
+         lxfm2 = xfsum - l2sg
+         moment2_conc( n )  = Real( Exp ( lxfm2 ) )
+         aeromode_lnsg( n ) = Real( Sqrt( l2sg ) )
+
+         ES36 = Real( Exp( 4.5d0 * l2sg ) )
+         aeromode_diam( n ) = Max( min_diam_g( n ), ( moment3_conc( n )
+     &                      / ( moment0_conc( n ) * es36 ) ) ** one3 )
+
+      End Do
+
+      Return
+      End Subroutine getpar
+

--- a/DOCS/Known_Issues/README.md
+++ b/DOCS/Known_Issues/README.md
@@ -62,4 +62,22 @@ When gridded inputs are used within CMAQ, the model checks to ensure that the pr
 CMAQ will exit claiming that the grids are inconsistent, when they are actually compatible.
 
 ### Solution  
-We have implemented a straight-forward solution that calculates the difference of the internal and input grid spacing in advstep.F. If the absolute value of this difference is greater than an assumed tolerance (i.e. 1.0E-5), then the code will error and exit as before. Replace CCTM/src/driver/yamo/advstep.F in repository with the version located under CMAQv5.2-i4.
+We have implemented a straight-forward solution that calculates the difference of the internal and input grid spacing in advstep.F. If the absolute value of this difference is greater than an assumed tolerance (i.e. 1.0E-5), then the code will error and exit as before. Replace CCTM/src/driver/yamo/advstep.F in repository with the version located under CMAQv5.2-i4.   
+
+## *CMAQv5.2-i5:* 
+Date: 2017-10-30   
+Contact: Ben Murphy (murphy.benjamin@epa.gov)  
+
+### Description  
+The subroutine getpar is needed to synchronize the aerosol properties like diameter and standard deviaiton with advected quantities such as number, surface area and mass. This routine also updates the current estimate of the aerosol bulk density. It should be called at the beginning of the aerosol module, but was erroneously skipped before calculation of organic aerosol partitioning.
+
+### Scope and Impact
+The impact on PM2.5 species is sporadic and difficult to predict. After employing the new code described below, tests within EPA have revealed differences generally less than 1 ug/m3 but could be as much as 6 ug/m3 in parts of the Southeast US in summer, 2011. The wet diameter of the accumulation mode can be quite high on the order of 100 nm and the standard deviation of that mode was affected by as much as 1.2, but generally less than 0.6.   
+It is also suspected, though unconfirmed, that this issue can be partly responsible for variable predictions of particle properties aloft when using different compilers.
+
+### Solution  
+Several modifications have been made to add consistency to the execution of getpar. Six source files in total should be replaced in the repository. We have implemented a call to getpar at the beginning of the orgaer routine. We have also generalized and renamed the input flag (LIMIT_SG --> FIXED_SG) to getpar and placed it in the AERO_DATA module for transparency. The following subroutines then need to be updated to be consistent with this update in the nature of FIXED_SG: AEROSOL_CHEMISTRY.F, aero_driver.F, aero_subs.F, and AERO_DATA.F. Finally, some of the logic in getpar.f was revised for clarity and transparency. Replace all of the files CCTM/src/aero/aero6 that have updated versions in CMAQv5.2-i5 with their new counterparts.
+
+
+
+


### PR DESCRIPTION
The subroutine getpar is needed to synchronize the aerosol properties like diameter and standard deviaiton with advected quantities such as number, surface area and mass. This routine also updates the current estimate of the aerosol bulk density. It should be called at the beginning of the aerosol module, but was erroneously skipped before calculation of organic aerosol partitioning.

The impact on PM2.5 species is sporadic and difficult to predict. After employing the new code described below, tests within EPA have revealed differences generally less than 1 ug/m3 but could be as much as 6 ug/m3 in parts of the Southeast US in summer, 2011. The wet diameter of the accumulation mode can be quite high on the order of 100 nm and the standard deviation of that mode was affected by as much as 1.2, but generally less than 0.6. It is also suspected, though unconfirmed, that this issue can be partly responsible for variable predictions of particle properties aloft when using different compilers.

Several modifications have been made to add consistency to the execution of getpar. Six source files in total should be replaced in the repository. We have implemented a call to getpar at the beginning of the orgaer routine. We have also generalized and renamed the input flag (LIMIT_SG --> FIXED_SG) to getpar and placed it in the AERO_DATA module for transparency. The following subroutines then need to be updated to be consistent with this update in the nature of FIXED_SG: AEROSOL_CHEMISTRY.F, aero_driver.F, aero_subs.F, and AERO_DATA.F. Finally, some of the logic in getpar.f was revised for clarity and transparency. Replace all of the files CCTM/src/aero/aero6 that have updated versions in CMAQv5.2-i5 with their new counterparts.