### PR TITLE
Add Release Notes and Minor Bug Fixes to v5.2.1

### DIFF
--- a/CCTM/docs/Release_Notes/Aerosol_ICBC_GetPar.md
+++ b/CCTM/docs/Release_Notes/Aerosol_ICBC_GetPar.md
@@ -4,9 +4,23 @@
 
 ## Brief Description
 
+ CMAQv5.2 employs a routine to check that the aerosol size distributions read in to the model from initial and boundary conditions is within reasonable bounds for the numerical approaches used in the aerosol module. Unfortunately, the approach in the release version of the code makes a number of small mistakes. First, it does not use the "dry" aerosol mass as it should, but instead uses the "wet" mass. Second, the restrictions on the aerosol diameter are too tight, especially at the upper bound. Third, the aerosols really should not be checked from the ICs on a restart day. It is more important for the size distribution to be continuous from day to day.
+ Because of these errors, number concentrations in all modes is artificially high at the beginning of every day. The discontinuity in number concentration, surface area, standard deviation and diameter can easily be seen. The mass is completely conserved and unaffected by these errors.
+The following updates have been introduced:
+
+- A mask has been used to select for only the dry components of the aerosol when summing the mass, LBCDRY( N_AE_TRANS )
+
+- The tolerances on the aerosol diameter, min_diam_g and max_diam_g, have been relaxed.
+
+- The "NEW_START" environment variable is now read and used by load_cgrid.F in order to distinguish between the initial day and subsequent days.
+
+ In addition, the subroutine getpar is needed to synchronize the aerosol properties like diameter and standard deviaiton with advected quantities such as number, surface area and mass. This routine also updates the current estimate of the aerosol bulk density. It should be called at the beginning of the aerosol module, but was erroneously skipped before calculation of organic aerosol partitioning. 
 
 ## Significance and Impact
 
+ The resolution of these initialization issues should result in more stable code that avoids numerical inconsistencies and spontaneous model hangs.
+ The impact on PM2.5 species of correctly calling getpar is sporadic and difficult to predict. Tests within EPA have revealed differences generally less than 1 ug/m3 but could be as much as 6 ug/m3 in parts of the Southeast US in summer, 2011. The wet diameter of the accumulation mode can be quite high on the order of 100 nm and the standard deviation of that mode was affected by as much as 1.2, but generally less than 0.6.
+ It is also suspected, though unconfirmed, that this issue can be partly responsible for variable predictions of particle properties aloft when using different compilers.
 
 ## Affected Files:
 

--- a/CCTM/docs/Release_Notes/Bioseason.md
+++ b/CCTM/docs/Release_Notes/Bioseason.md
@@ -4,9 +4,11 @@
 
 ## Brief Description
 
+The default CCTM run script was pointing to the wrong Bioseason file. This has been corrected.
 
 ## Significance and Impact
 
+A default run of CMAQ would not considered seasonality or summertime levels of emissions from biogenic sources. Now that seasonality has been restored.
 
 ## Affected Files:
 

--- a/CCTM/docs/Release_Notes/Compilation_Options_and_Debug.md
+++ b/CCTM/docs/Release_Notes/Compilation_Options_and_Debug.md
@@ -4,9 +4,18 @@
 
 ## Brief Description
 
+Bldmake has been modified to allow the CMAQ Makefile to take "DEBUG=TRUE" as a command line option and then choose the debug flags if it is invoked. This will help, for instance, when users want to work debug-activated builds into part of a larger automated testing protocol.
+
+This improvement also addresses the following issues the makefile:
+* should indicate ioapi version explicitly, and replace module with explict Linux2_*.
+* LINK_FLAGS should not have -openmp
+* remove "MPICH = -L$(LIB)/mpi/lib -lcurl"
+* remove MPICH in the "LIBRARY = " clause
+* an explicit path should be included in this line "-DSUBST_MPI=mpif.h"
 
 ## Significance and Impact
 
+No changes to results were observed with these model workflow and compilation changes.
 
 ## Affected Files:
 

--- a/CCTM/docs/Release_Notes/Emiss_Check_Zero_PT_Sources.md
+++ b/CCTM/docs/Release_Notes/Emiss_Check_Zero_PT_Sources.md
@@ -4,9 +4,13 @@
 
 ## Brief Description
 
+The EMIS_SPC_CHECK subroutine does not set NPTSPC, the number emission species from point sources, if a simulation does not use point source emissions as in ongoing hemispheric simulations. The uninitialized variable causes CCTM to stall for some versions of the intel compiler used.
+
+This pull request removes the problem by adding a line to initially set NPTSPC to zero.
 
 ## Significance and Impact
 
+CMAQ will now run even if no point emission files are used as input.
 
 ## Affected Files:
 

--- a/CCTM/docs/Release_Notes/Grid_Check_Tolerance.md
+++ b/CCTM/docs/Release_Notes/Grid_Check_Tolerance.md
@@ -4,15 +4,15 @@
 
 ## Brief Description
 
+When using some grid files, the size of the advection spacing don''t exactly match. For example 1333.33333.... meters can be rounded many different ways. The code was modified to use a tolerance to test for consistency.
 
 ## Significance and Impact
 
+CMAQ will now be more flexible in receiving grid spacings that are essentially equivalent but may have some small numerical precision differences.
 
 ## Affected Files:
 
 CCTM/src/driver/yamo/advstep.F  
-
-## References:    
 
 -----
 ## Internal Records:

--- a/CCTM/docs/Release_Notes/README.md
+++ b/CCTM/docs/Release_Notes/README.md
@@ -10,29 +10,32 @@ The Community Multiscale Air Quality (CMAQ) Model version 5.2.1 is a minor updat
 # Summary of CMAQv5.2.1 Updates  
 
 ## Transport  
-  * [Grid check tolerance during advection](Grid_Check_Tolerance.md) (Ben, Tanya)  
+  * [Grid check tolerance during advection](Grid_Check_Tolerance.md)   
   * [HDIFF hang with offline CMAQ](HDIFF_hang.md) (Jesse)  
   * [Remove SWAP routines](SWAP_routines.md) (David)  
-  * [Unique INTERPX offsets for METCRO2D](INTERPX.md) (Bill)  
+  * [Unique INTERPX offsets for METCRO2D](INTERPX.md)  
 
 ## Emissions and Air-Surface Exchange  
-  * [Turn on bioseason switch by default](Bioseason.md) ( Ben )  
+  * [Turn on bioseason switch by default](Bioseason.md)  
   * [Hay Land Use fix for BiDi](Hay_Land_Use.md) (Jesse)  
-  * [Allow Emissions Check to have no point sources](Emiss_Check_Zero_PT_Sources.md) ( Ben)  
+  * [Allow Emissions Check to have no point sources](Emiss_Check_Zero_PT_Sources.md)  
 
 ## Chemistry  
   * [Remove duplicative heterogeneous uptake of N2O5](Duplicate_N2O5.md) (Sarwar)  
-  * [Make generalized solvers work with intel version 17](Intel17_Solver_Compatibility.md) ( Bill)  
+  * [Make generalized solvers work with intel version 17](Intel17_Solver_Compatibility.md)   
 
 ## Aerosol Processes  
-  * [Fix Bugs in initialization including ICBC checking, getpar calls and getpar save variables](Aerosol_ICBC_GetPar.md) (Ben)  
+  * [Fix Bugs in initialization including ICBC checking, getpar calls and getpar save variables](Aerosol_ICBC_GetPar.md)   
  
+## WRF-CMAQ
+  * [Fix Bug in switch for turning convective scheme on and off](Two_Way_Convective_Scheme.md)  
+
 ## Compilation  
-  * [Compilation options, debugging flag, and include paths](Compilation_Options_and_Debug.md) (Ben)  
+  * [Compilation options, debugging flag, and include paths](Compilation_Options_and_Debug.md)   
 
 ## Post-Processing  
-  * [Improve combine's math](Combine_Math.md) (Bill)  
-  * [Add command for extracting specdef files to bldit_project.csh](SpecDefExtraction.md) ( Ben )  
+  * [Improve combine's math](Combine_Math.md)    
+  * [Add command for extracting specdef files to bldit_project.csh](SpecDefExtraction.md)   
 
 -----
 

--- a/CCTM/docs/Release_Notes/SpecDefExtraction.md
+++ b/CCTM/docs/Release_Notes/SpecDefExtraction.md
@@ -4,9 +4,11 @@
 
 ## Brief Description
 
+A few small but necessary changes to the SpecDef files involve correcting symbolic links in the combine subfolder, extracting specdef files for use with combine in the project space, and changing the location of log files.
 
 ## Significance and Impact
 
+No impacts were observed results. These changes all fit within the category of model workflow.
 
 ## Affected Files:
 
@@ -22,8 +24,6 @@ POST/combine/scripts/spec_def_files/SpecDef_saprc07tb_ae6i_aq.txt
 POST/combine/scripts/spec_def_files/linkem  
 bldit_project.csh  
 
-
-## References:    
 
 -----
 ## Internal Records:

--- a/CCTM/docs/Release_Notes/Two_Way_Convective_Scheme.md
+++ b/CCTM/docs/Release_Notes/Two_Way_Convective_Scheme.md
@@ -1,0 +1,29 @@
+# Two-way Coupled Meteorology Convective Scheme in WRF-CMAQ
+
+**Author/P.O.C.:**, [David Wong](mailto:wong.david-c@epa.gov), Computational Exposure Division, U.S. EPA
+
+## Brief Description
+
+The new twoway_aqprep.F will take into account whether WRF portion of the coupled model is running with or without cumulus convective scheme. This reflects in the content of variable rainc. This code change does not affect CMAQ offline mode and only in WRF-CMAQ twoway coupled model and make it similar to offline run.
+
+## Significance and Impact
+
+There were minor effects on ozone in the coupled model run (based on Dr. Christian Hogrefe evaluation)
+
+## Affected Files:
+
+CCTM/src/twoway/twoway_aqprep.F90
+
+## References:    
+
+-----
+## Internal Records:
+
+
+### Relevant Pull Requests:
+  [PR #275](https://github.com/USEPA/CMAQ_Dev/pull/275)  
+
+### Commit IDs:
+
+a85e17c7b8bd0a144a7919e8061f0a57a8cefec8
+

--- a/CCTM/scripts/bldit_cctm.csh
+++ b/CCTM/scripts/bldit_cctm.csh
@@ -40,7 +40,7 @@
  setenv REPOROOT $CCTM_SRC
 
 #> Working directory and Version IDs
- set VRSN  = v5.2.1                    #> model configuration ID
+ set VRSN  = v521                    #> model configuration ID
  set EXEC  = CCTM_${VRSN}.exe          #> executable name
  set CFG   = CCTM_${VRSN}.cfg          #> configuration file name
 

--- a/CCTM/scripts/run_cctm.csh
+++ b/CCTM/scripts/run_cctm.csh
@@ -24,7 +24,7 @@
  cd CCTM/scripts
 
 #> Set General Parameters for Configuring the Simulation
- set VRSN      = v5.2.1            #> Code Version
+ set VRSN      = v521            #> Code Version
  set PROC      = mpi               #> serial or mpi
  set MECH      = cb6r3_ae6_aq      #> Mechanism ID
  set EMIS      = 2013ef            #> Emission Inventory Details

--- a/CCTM/src/phot/inline/CLOUD_OPTICS.F
+++ b/CCTM/src/phot/inline/CLOUD_OPTICS.F
@@ -130,6 +130,11 @@
      
          real( 8 ), private            :: gauss_laguerre_total( 16 )
      
+         real( 8 ), parameter :: cloud_largest      = 9.0d+307 
+         real( 8 ), parameter :: cloud_smallest     = 9.0d-307
+         real( 8 ), parameter :: cloud_log_largest  =  709.090848126508d0
+         real( 8 ), parameter :: cloud_log_smallest = -709.090848126508d0
+         
          contains         
       
 !-----------------------------------------------------------------------
@@ -143,7 +148,7 @@
 
          integer          :: allocstat           ! memory allocation status
          integer          :: i
-         
+
          Character( 132 ) :: xmsg
          Character(  32 ) :: pname = 'init_cloud_optics'
          Logical, Save    :: initialized = .false.
@@ -755,7 +760,8 @@
             real( 8 ) :: n0
             real( 8 ) :: chi
             real( 8 ) :: comp
-            real( 8 ) :: psd   ! partical size distribution
+            real( 8 ) :: psd      ! partical size distribution
+            real( 8 ) :: argument
             real      :: factor
             real      :: dmin  ! value if q .le. limit
 
@@ -790,6 +796,7 @@
                   reff( 1:nlayers )  = min_dge
                   return
                end select
+               
             do lay = 1, nlayers
 !              lamda = (1.0e+3*pi*rho_hydro*n0/q(lay))**0.25
                if( q(lay) .le.  limit )then
@@ -801,7 +808,9 @@
                sum2 = 0.0D0
 !original method used thirty-two nodes
                do nk = 1, 32
-                  psd  = n0*dexp(lamda*xk(nk))
+                  argument = lamda*xk(nk)
+                  if( argument .lt. cloud_log_smallest ) cycle ! assume dexp( argument ) equals zero
+                  psd = n0*dexp( argument ) 
                   comp = newtotalw(nk) * psd
                   sum2 = sum2 + comp 
                   sum1 = sum1 + xk(nk)*comp
@@ -812,7 +821,11 @@
 !                 sum2 = sum2 + comp 
 !                 sum1 = sum1 + gauss_laguerre_node(nk)*comp
                end do
-               reff(lay) = factor * real( sum1/sum2, 4 )    ! microns
+               if( sum2 .lt. cloud_smallest )then
+                 reff(lay) = dmin
+               else
+                 reff(lay) = factor * real( sum1/sum2, 4 )    ! microns
+               end if
             end do
 
          end subroutine aggreg_size_effective

--- a/CCTM/src/twoway/twoway_aqprep.F90
+++ b/CCTM/src/twoway/twoway_aqprep.F90
@@ -90,6 +90,8 @@ SUBROUTINE aqprep (grid, config_flags, t_phy_wrf, p_phy_wrf, rho_wrf,     &
 !                 rather than the two-way model time step
 !           30 Aug 2016  (David Wong)
 !              -- fixed a bug in outputing MET_CRO_2D physical file
+!           11 Jan 2017  (David Wong)
+!              -- fixed a bug to handle simulation with convective scheme or not
 !===============================================================================
 
   USE module_domain                                ! WRF module
@@ -535,6 +537,12 @@ SUBROUTINE aqprep (grid, config_flags, t_phy_wrf, p_phy_wrf, rho_wrf,     &
      end if
 
      RUN_CMAQ_DRIVER = envyn ('RUN_CMAQ_DRIVER', ' ', def_false, stat)
+
+     if (config_flags%cu_physics == 0) then
+        convective_scheme = .false.
+     else
+        convective_scheme = .true.
+     end if
 
 !-------------------------------------------------------------------------------
 ! Fill time-independent arrays for GRIDCRO2D and GRIDDOT2D.
@@ -1580,7 +1588,13 @@ SUBROUTINE aqprep (grid, config_flags, t_phy_wrf, p_phy_wrf, rho_wrf,     &
   metcro2d_data_wrf (:,:,11) =  grid%gsw   (sc:ec, sr:er)   ! gsw
 
   metcro2d_data_wrf (:,:,13) =  (grid%rainnc(sc:ec, sr:er) - grid%prev_rainnc(sc:ec,sr:er)) * 0.1  ! RNA = SUM(RN), in cm
-  metcro2d_data_wrf (:,:,14) =  (grid%rainc (sc:ec, sr:er) - grid%prev_rainc(sc:ec,sr:er)) * 0.1   ! RCA = SUM(RC), in cm
+
+  if (convective_scheme) then
+     metcro2d_data_wrf (:,:,14) = (grid%rainc (sc:ec, sr:er) - grid%prev_rainc(sc:ec,sr:er)) * 0.1   ! RCA = SUM(RC), in cm
+  else
+     metcro2d_data_wrf (:,:,14) = -1.0
+  end if
+
   metcro2d_data_wrf (:,:,19) =  grid%snowc (sc:ec, sr:er)           ! snowcov
   metcro2d_data_wrf (:,:,21) =  grid%t2    (sc:ec, sr:er)           ! temp2
   metcro2d_data_wrf (:,:,22) =  grid%canwat(sc:ec, sr:er) * 0.001   ! wr (in meter)
@@ -1600,9 +1614,9 @@ SUBROUTINE aqprep (grid, config_flags, t_phy_wrf, p_phy_wrf, rho_wrf,     &
     metcro2d_data_wrf (:,:,13) = 0.0
   end where
 
-  where (metcro2d_data_wrf (:,:,14) .lt. 0.0)
-    metcro2d_data_wrf (:,:,14) = 0.0
-  end where
+! where (metcro2d_data_wrf (:,:,14) .lt. 0.0)
+!   metcro2d_data_wrf (:,:,14) = 0.0
+! end where
 
   !-----------------------------------------------------------------------------
   ! Assign surface pressure (PRSFC) from WRF array P8W (i.e., "p at w levels").
@@ -1688,7 +1702,9 @@ SUBROUTINE aqprep (grid, config_flags, t_phy_wrf, p_phy_wrf, rho_wrf,     &
                          wrf_cmaq_ce_send_index_l, wrf_cmaq_ce_recv_index_l, 5)
 
   temp_rainnc = temp_rainnc + metcro2d_data_cmaq(:,:,13)
-  temp_rainc  = temp_rainc  + metcro2d_data_cmaq(:,:,14)
+  if (convective_scheme) then
+     temp_rainc  = temp_rainc  + metcro2d_data_cmaq(:,:,14)
+  end if
 
   if (RUN_CMAQ_DRIVER) then
      if ( .not. buf_write3 (fname, allvar3, jdate, jtime, metcro2d_data_cmaq ) ) then

--- a/CCTM/src/twoway/twoway_data_module.F90
+++ b/CCTM/src/twoway/twoway_data_module.F90
@@ -3,6 +3,7 @@
 !
 ! Revised:  April 2007  Original version.  David Wong
 ! Revised:  April 7, 2016 David Wong: Added variable mminlu
+!           Jan 11, 2018 David Wong: Added variable convective_scheme
 !===============================================================================
 
   module twoway_data_module
@@ -54,5 +55,7 @@
 
     INTEGER, SAVE :: sc, ec, sr, er
     INTEGER, SAVE :: sc_d, ec_d, sr_d, er_d
+
+    LOGICAL :: convective_scheme
 
   end module twoway_data_module


### PR DESCRIPTION
This PR adds text for several Release Notes and implements bug fixes for the way the convective scheme is called as well a proposed fix for a floating point error in CLOUD_OPTICS. Unfortunately, the latter error persists, but should be resolved soon.