### PR TITLE
Correct link to AMET metadata files

### DIFF
--- a/POST/sitecmp/scripts/run_sitecmp_AQS_Daily.csh
+++ b/POST/sitecmp/scripts/run_sitecmp_AQS_Daily.csh
@@ -164,7 +164,7 @@
 #> The column headings for the optional variables need to be
 #> gmt_offset, state, county, and elevation (case insensitive)
 #> This file can be downloaded from
-#> https://github.com/USEPA/AMET/tree/1.4/obs/AQ/site_metadata_files
+#> https://github.com/USEPA/AMET/tree/master/obs/AQ/site_metadata_files
  setenv SITE_FILE AQS_full_site_list.csv
 #> On EPA system:
 #  setenv SITE_FILE /work/MOD3EVAL/aq_obs/routine/site_metadata_files/AQS_full_site_list.csv

--- a/POST/sitecmp/scripts/run_sitecmp_AQS_Hourly.csh
+++ b/POST/sitecmp/scripts/run_sitecmp_AQS_Hourly.csh
@@ -144,7 +144,7 @@
 #> The column headings for the optional variables need to be
 #> gmt_offset, state, county, and elevation (case insensitive)
 #> This file can be downloaded from
-#> https://github.com/USEPA/AMET/tree/1.4/obs/AQ/site_metadata_files
+#> https://github.com/USEPA/AMET/tree/master/obs/AQ/site_metadata_files
  setenv SITE_FILE AQS_full_site_list.csv
 #> On EPA system:
 #  setenv SITE_FILE /work/MOD3EVAL/aq_obs/routine/site_metadata_files/AQS_full_site_list.csv

--- a/POST/sitecmp/scripts/run_sitecmp_CSN.csh
+++ b/POST/sitecmp/scripts/run_sitecmp_CSN.csh
@@ -157,7 +157,7 @@
 #> The column headings for the optional variables need to be
 #> gmt_offset, state, county, and elevation (case insensitive)
 #> This file can be downloaded from
-#> https://github.com/USEPA/AMET/tree/1.4/obs/AQ/site_metadata_files
+#> https://github.com/USEPA/AMET/tree/master/obs/AQ/site_metadata_files
  setenv SITE_FILE AQS_full_site_list.csv
 #> On EPA system:
 #  setenv SITE_FILE /work/MOD3EVAL/aq_obs/routine/site_metadata_files/AQS_full_site_list.csv

--- a/POST/sitecmp/scripts/run_sitecmp_IMPROVE.csh
+++ b/POST/sitecmp/scripts/run_sitecmp_IMPROVE.csh
@@ -159,7 +159,7 @@
 #> The column headings for the optional variables need to be
 #> gmt_offset, state, county, and elevation (case insensitive)
 #> This file can be downloaded from
-#> https://github.com/USEPA/AMET/tree/1.4/obs/AQ/site_metadata_files
+#> https://github.com/USEPA/AMET/tree/master/obs/AQ/site_metadata_files
  setenv SITE_FILE IMPROVE_full_site_list.csv
 #> On EPA system:
 #  setenv SITE_FILE /work/MOD3EVAL/aq_obs/routine/site_metadata_files/IMPROVE_full_site_list.csv

--- a/POST/sitecmp/scripts/run_sitecmp_NADP.csh
+++ b/POST/sitecmp/scripts/run_sitecmp_NADP.csh
@@ -160,7 +160,7 @@
 #> The column headings for the optional variables need to be
 #> gmt_offset, state, county, and elevation (case insensitive)
 #> This file can be downloaded from
-#> https://github.com/USEPA/AMET/tree/1.4/obs/AQ/site_metadata_files
+#> https://github.com/USEPA/AMET/tree/master/obs/AQ/site_metadata_files
  setenv SITE_FILE NADP_full_site_list.csv
 #> On EPA system:
 #  setenv SITE_FILE /work/MOD3EVAL/aq_obs/routine/site_metadata_files/NADP_full_site_list.csv

--- a/POST/sitecmp/scripts/run_sitecmp_SEARCH_Hourly.csh
+++ b/POST/sitecmp/scripts/run_sitecmp_SEARCH_Hourly.csh
@@ -140,7 +140,7 @@
 #> The column headings for the optional variables need to be
 #> gmt_offset, state, county, and elevation (case insensitive)
 #> This file can be downloaded from
-#> https://github.com/USEPA/AMET/tree/1.4/obs/AQ/site_metadata_files
+#> https://github.com/USEPA/AMET/tree/master/obs/AQ/site_metadata_files
  setenv SITE_FILE SEARCH_full_site_list.csv
 #> On EPA system:
 #  setenv SITE_FILE /work/MOD3EVAL/aq_obs/routine/site_metadata_files/SEARCH_full_site_list.csv

--- a/POST/sitecmp_dailyo3/scripts/run_sitecmp_dailyo3_AQS.csh
+++ b/POST/sitecmp_dailyo3/scripts/run_sitecmp_dailyo3_AQS.csh
@@ -115,7 +115,7 @@
 #> The column headings for the optional variables need to be
 #> gmt_offset, state, county, and elevation (case insensitive)
 #> This file can be downloaded from
-#> https://github.com/USEPA/AMET/tree/1.4/obs/AQ/site_metadata_files
+#> https://github.com/USEPA/AMET/tree/master/obs/AQ/site_metadata_files
  setenv SITE_FILE AQS_full_site_list.csv
 #> On EPA system:
 #  setenv SITE_FILE /work/MOD3EVAL/aq_obs/routine/site_metadata_files/AQS_full_site_list.csv

--- a/POST/sitecmp_dailyo3/scripts/run_sitecmp_dailyo3_CASTNET.csh
+++ b/POST/sitecmp_dailyo3/scripts/run_sitecmp_dailyo3_CASTNET.csh
@@ -117,7 +117,7 @@
 #> The column headings for the optional variables need to be
 #> gmt_offset, state, county, and elevation (case insensitive)
 #> This file can be downloaded from
-#> https://github.com/USEPA/AMET/tree/1.4/obs/AQ/site_metadata_files
+#> https://github.com/USEPA/AMET/tree/master/obs/AQ/site_metadata_files
  setenv SITE_FILE CASTNET_full_site_list.csv
 #> On EPA system:
 #  setenv SITE_FILE /work/MOD3EVAL/aq_obs/routine/site_metadata_files/CASTNET_full_site_list.csv


### PR DESCRIPTION
Corrected link in comments of sitecmp and sitecmp_dailyo3 runs scripts that provides location of metadata files for each air quality network that are needed when setting the environment variable SITE_FILE.
