### PR TITLE
Resolve Bug for reading Emission Stream Families

### DIFF
--- a/CCTM/src/cio/centralized_io_module.F
+++ b/CCTM/src/cio/centralized_io_module.F
@@ -3958,7 +3958,7 @@ C   mminlu and num_land_cat are WRF global variables
          ! Capitalize All Family and Member Names
          DO IFAM = 1,NStreamFamilies
              CALL UPCASE( StreamFamilyName( IFAM ) )
-             DO INUM = 1,StreamFamilyNum( INUM )
+             DO INUM = 1,StreamFamilyNum( IFAM )
                  CALL UPCASE( StreamFamilyMembers( IFAM,INUM ) )
              END DO
          END DO


### PR DESCRIPTION
**Contact:**  
Ben Murphy (US EPA)

**Type of code change:**   
Bugfix

**Description of changes:**   
This bug resulted in errors processing matches for emission stream families since the capitalization function was not successfully executed on all stream family members.

**Summary of Impact:**  
No impact on chemical predictions unless a particular stream family defined by the user is not processed correctly.



