### PR TITLE
Bugfix Speed up emissions processing in PTMET subroutine

### DIFF
--- a/CCTM/src/emis/emis/PT3D_DEFN.F
+++ b/CCTM/src/emis/emis/PT3D_DEFN.F
@@ -658,13 +658,14 @@ C Based on the current time step, find whether or not a report should be written
 !            END DO
 !         END IF
 
-C Convert pt source met data to bi-linear interpolated data
-         CALL PTMET_CONVT( JDATE, JTIME )
-
 C Initialize Output Array
          !VDEMIS_PT = 0.0   ! array assignment
 
          N = IPSRM( ISRM )
+         
+
+C Convert pt source met data to bi-linear interpolated data
+         CALL PTMET_CONVT( JDATE, JTIME, N )
          PT_LAYS = 1       ! Initialize Point Layers at lowest possible value
 
          IF ( MY_NSRC( N ) .LE. 0 ) RETURN

--- a/CCTM/src/emis/emis/PTMET.F
+++ b/CCTM/src/emis/emis/PTMET.F
@@ -170,7 +170,7 @@ C Allocate per-layer arrays from 0:EMLAYS
 
 C-----------------------------------------------------------------------
 
-         SUBROUTINE PTMET_CONVT( JDATE, JTIME )
+         SUBROUTINE PTMET_CONVT( JDATE, JTIME, N )
 
          USE STK_PRMS, ONLY: MY_NSRC, SOURCE, MY_STKCOL, MY_STKROW
          USE STACK_GROUP_DATA_MODULE, ONLY: STKHT
@@ -181,8 +181,9 @@ C-----------------------------------------------------------------------
          IMPLICIT NONE
 
          INTEGER, INTENT( IN ) :: JDATE, JTIME
+         INTEGER, INTENT( IN ) :: N
 
-         INTEGER         :: L, N, MSRC, S
+         INTEGER         :: L, MSRC, S
          CHARACTER( 16 ) :: PNAME = 'PTMET_CONVT'   ! PROCEDURE NAME
 
          INTEGER :: MYC, MYR, STAT
@@ -255,7 +256,6 @@ C-----------------------------------------------------------------------
          CALL INTERPOLATE_VAR ('UWINDC', JDATE, JTIME, LOC_UWIND)
          CALL INTERPOLATE_VAR ('VWINDC', JDATE, JTIME, LOC_VWIND)
 #endif
-         DO N = 1, NPTGRPS
 
             MSRC = MY_NSRC( N )
 
@@ -309,8 +309,6 @@ C-----------------------------------------------------------------------
      &                        PTMET_DATA( N )%ZSTK,
      &                        PTMET_DATA( N )%DDZF )
             END IF ! MY_NSRC( N ) > 0
-
-         END DO   ! NPTGRPS
 
          END SUBROUTINE PTMET_CONVT
 


### PR DESCRIPTION
**Contact:**  
Ben Murphy (US EPA)

**Type of code change:**   
Bugfix

**Description of changes:**   
The PTMET subroutine is streamlined so that it is not run for every point source and every stream every time each stream is called.

**Issue:**  
Before CMAQv5.3, the PTMET subroutine looped over the every point source stream file to retrieve meteorological conditions for calculating plume height. When the DESID emissions module was added, the stream loop was conceptualized and implemented at a higher level, but PTMET still looped over every stream, effectively re-retrieving data more times than necessary. With this PR, the loop inside PTMET is removed and the stream number is passed into the subroutine instead.

**Summary of Impact:**  
Drastically reduces runtimes in areas where there happen  to be lots of point sources on a particular processor. No impact on results.

**Tests conducted:**  
This improvement was tested on the CONUS 2016 platform and on the EQUATES platform for 2015.


