### PR TITLE
WRF-CMAQ: Fix Typo in Tutorial and Update Runscript v5.3.3+

### DIFF
--- a/CCTM/scripts/run_cctm_Bench_2016_12SE1.WRFCMAQ.csh
+++ b/CCTM/scripts/run_cctm_Bench_2016_12SE1.WRFCMAQ.csh
@@ -990,10 +990,10 @@ End_Of_Namelist
 # ( /usr/bin/time -p mpirun -np $NPROCS $OUTDIR/$EXEC ) |& tee buff_${EXECUTION_ID}.txt
 # /usr/bin/time -p mpirun -np $NPROCS $OUTDIR/$EXEC
 
-  ls -al wrf.exe
+  ls -al ${OUTDIR}/wrf.exe
 
   date
-  time mpirun -np $NPROCS wrf.exe
+  time mpirun -np $NPROCS ${OUTDIR}/wrf.exe
   date
   
   #> Harvest Timing Output so that it may be reported below

--- a/DOCS/Users_Guide/Tutorials/CMAQ_UG_tutorial_WRF-CMAQ_Benchmark.md
+++ b/DOCS/Users_Guide/Tutorials/CMAQ_UG_tutorial_WRF-CMAQ_Benchmark.md
@@ -28,7 +28,7 @@ The suggested hardware requirements for running the CMAQ Southeast Benchmark cas
 In the directory where you would like to install WRF-CMAQ, create the directory issue the following command to clone the EPA GitHub repository for CMAQv5.3.3+:
 
 ```
-git clone -b v5.3.3+ https://github.com/USEPA/CMAQ.git CMAQ_REPO
+git clone -b 5.3.3+ https://github.com/USEPA/CMAQ.git CMAQ_REPO
 ```
 
 ## Check Out a new Branch in the CMAQ Repository 


### PR DESCRIPTION
**Contact:**  
[Fahim Sidi](sidi.fahim@epa.gov) (USEPA)

**Type of code change:**   
Documentation & Enhancement 

**Description of changes:**   
1. Update the WRF-CMAQ tutorial to point to the correct github hyperlink.
2. Update WRF-CMAQ runscript to explicitly point to the wrf.exe in the compiled directory. 

**Issue:**  
These changes were in response to Issue #174. 

**Summary of Impact:**  
N/A: No source code was modified. 

**Tests conducted:**  
WRF-CMAQ benchmark runscript was re-run to ensure it still worked. 

**Acknowledgements:**

Many thanks to the Github user @bismark99 for exercising the WRF-CMAQ tutorial and Benchmark runscript and identifying errors on his system.