### PR TITLE
BDSNP fix

### DIFF
--- a/CCTM/src/biog/megan3/megan_fx_mod.f90
+++ b/CCTM/src/biog/megan3/megan_fx_mod.f90
@@ -2037,7 +2037,6 @@ CONTAINS    !!-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
       INTEGER  JDAY
       INTEGER  GSJULIAN_START
       INTEGER  GSJULIAN_END
-      OPEN(UNIT = 10, FILE = 'growseason_error_outoputs.txt')
 !-----------------------------------------------------------------------------
 !   NOTE: The use of "julian Day" to describe the day of tHE year is
 !     technically incorrect. 

--- a/CCTM/src/vdiff/acm2_m3dry/vdiffacmx.F
+++ b/CCTM/src/vdiff/acm2_m3dry/vdiffacmx.F
@@ -59,7 +59,7 @@ C-----------------------------------------------------------------------
 !      USE LSM_MOD, ONLY: N_LUFRAC
       USE VDIFF_DIAG, NLPCR => NLPCR_MEAN
       USE HGRD_DEFN,only : COLSX_PE, ROWSX_PE
-      USE BDSNP_MOD, ONLY: GET_N_DEP
+      USE BDSNP_MOD, only: GET_N_DEP
 #ifdef isam
       USE SA_DEFN, ONLY: N_SPCTAG, ISAM, VNAM_SPCTAG, TRANSPORT_SPC,
      &                   SA_VDEMIS_DIFF, ITAG, NTAG_SA, NSPC_SA,
@@ -719,7 +719,7 @@ C --------- END of HET HONO RX ----------
 
 C Pass selected N species to the BDSNP Soil NO emissions scheme
 
-                  IF ( BDSNP_MEGAN ) THEN
+                  IF ( MGN_ONLN_DEP ) THEN
 
                     IF(SPECLOG) then
                       IF( V .eq. N_SPC_DEPV)  THEN

--- a/CCTM/src/vdiff/acm2_stage/vdiffacmx.F
+++ b/CCTM/src/vdiff/acm2_stage/vdiffacmx.F
@@ -667,7 +667,7 @@ C --------- END of HET HONO RX ----------
 
 C Pass selected N species to the BDSNP Soil NO emissions scheme
 
-                  IF ( BDSNP_MEGAN ) THEN
+                  IF ( MGN_ONLN_DEP ) THEN
 
                     IF(SPECLOG) then
                       IF( V .eq. N_SPC_DEPV)  THEN


### PR DESCRIPTION
**Contact:**  
Jeff Willison, USEPA (willson.jeff@epa.gov)

**Type of code change:**   
Bug fix

**Description of changes and impact:**   
Online nitrogen deposition (NDEP) is erroneously enabled when using BDSNP in the released version of CMAQ 5.4 . This calculation should be disabled unless setting a hidden research option (MGN_ONLN_DEP) to true. Climatological NDEP rates should be used instead of online deposition at this time. This PR corrects an IF statement that was meant to disable online nitrogen deposition. 

With online N deposition the BDSNP module in MEGAN accumulates an unreasonably large nitrogen deposition reservoir. The large nitrogen deposition reservoir leads to extreme soil NO emissions. 

Along with this bug fix I have included a minor change to prevent the creation of an unused text file. 



**Tests conducted:**  
These changes were tested and merged into the main branch of the development repository. The changes were also tested with the CMAQ/5.4+ branch. The resulting behavior is now as intended for BDSNP soil NO.



