### PR TITLE
Resolve time-stepping issue in ELMO when used within WRF-CMAQ and MPAS-CMAQ

### DIFF
--- a/CCTM/src/driver/ELMO_DATA.F
+++ b/CCTM/src/driver/ELMO_DATA.F
@@ -30,7 +30,7 @@ c:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
       Logical, Parameter, Private :: F = .false.
 
       LOGICAL, SAVE :: L_ELMO
-      INTEGER, SAVE :: ELMO_AVRG_STEP = 0
+      REAL,    SAVE :: ELMO_NSTEP = 0.
       INTEGER, SAVE :: NLAY_ELMO_INST
       INTEGER, SAVE :: NLAY_ELMO_AVRG
 

--- a/CCTM/src/driver/ELMO_PROC.F
+++ b/CCTM/src/driver/ELMO_PROC.F
@@ -3053,7 +3053,7 @@
       END SUBROUTINE LOAD_ELMO
 
 !-------------------------------------------------------------------------
-      SUBROUTINE ELMO_DRIVER( CGRID, JDATE, JTIME, TSTEP, INIT_TIME, INIT_STEP )
+      SUBROUTINE ELMO_DRIVER( CGRID, JDATE, JTIME, TSTEP, INIT_TIME )
 !     This subroutine maps the PM diagnostic variables that the user has
 !       requested to the entries in the ELMO_DATA table.
 !-------------------------------------------------------------------------
@@ -3071,6 +3071,8 @@
      &                        CFRAC, DZ, PV, ZH
       use centralized_io_module, only : interpolate_var, pv_avail
       use RUNTIME_VARS
+      Use phot_mod, Only: init_phot_shared 
+
 #ifdef sens
       USE DDM3D_DEFN, ONLY : SENGRID
 #endif 
@@ -3084,7 +3086,7 @@
       INTEGER, INTENT( IN ) :: TSTEP(3)
       LOGICAL, INTENT( IN ) :: INIT_TIME        ! Is this the first time step 
                                                 !   of the simulation
-      LOGICAL, INTENT( IN ) :: INIT_STEP        ! Is the time step beginning
+      LOGICAL :: INIT_STEP        ! Is the time step beginning
 
       ! Variable to set time step for writing visibility file
       INTEGER, SAVE :: WSTEP  = 0          ! local write counter
@@ -3118,7 +3120,7 @@
       IF ( FIRSTIME ) THEN
           FIRSTIME = .FALSE.
           ! Initialize Number of Steps Used for Calculating Average
-          ELMO_AVRG_STEP = 0
+          ELMO_NSTEP = 0.
 
           ALLOCATE( PRES( NCOLS, NROWS, NLAYS),
      &              TA( NCOLS, NROWS, NLAYS ),
@@ -3133,15 +3135,16 @@
 
       ! Determine if this is a write step
       WRITE_STEP = .FALSE.
-      
-      IF ( INIT_STEP ) THEN
+      INIT_STEP  = .FALSE.
+      IF ( ELMO_NSTEP .LT. 1.0 ) THEN
          WSTEP = 0
+         INIT_STEP = .TRUE.
       ELSE
-         ELMO_AVRG_STEP = ELMO_AVRG_STEP + 1
          WSTEP = WSTEP + TIME2SEC( TSTEP( 2 ) )
          IF ( WSTEP .GE. TIME2SEC( TSTEP( 1 ) ) ) 
      &        WRITE_STEP = .TRUE.
       END IF
+      ELMO_NSTEP = ELMO_NSTEP + 1.0
      
       ! Get Meteorological Variables
 
@@ -3178,6 +3181,7 @@
       call interpolate_var ('ZH', jdate, jtime, ZHS)
 
       ! Calculate Heterogeneous Chemistry Rates
+      CALL INIT_PHOT_SHARED()
       CALL HETCHEM_RATES( TA, PRES, QV, CGRID, DENS )
 
       ! Process PM Diagnostics for Base Model
@@ -3403,25 +3407,27 @@ C *** Write data to the scalar output file.
          END IF
      
 C *** Write data to the average aerosol diagnostic file.
-         IF ( AVRG_ACTIVE .AND. .NOT.INIT_TIME ) THEN
-            IF ( .NOT. END_TIME ) THEN   ! ending time timestamp
-               CALL NEXTIME ( MDATE, MTIME, -TSTEP(1) )
-            END IF
-
-            IF ( .NOT. WRITE3( CTM_AELMO_1, 
-     &           ALLVAR3, MDATE, MTIME, 
-     &           ELMO_AVRG(:,:,:,:) / 2.0 / 
-     &           ELMO_AVRG_STEP ) ) THEN
-               XMSG = 'Could not write ' // CTM_AELMO_1 // ' file'
-               CALL M3EXIT ( PNAME, MDATE, MTIME, XMSG, XSTAT1 )
-            END IF
-
-            WRITE( LOGDEV, '( /5X, 3( A, :, 1X ), I8, ":", I6.6 )' )
-     &                     'Timestep written to', CTM_AELMO_1,
-     &                     'for date and time', MDATE, MTIME
-
-            ELMO_AVRG_STEP = 0
-
+         IF ( .NOT.INIT_TIME ) THEN
+           IF ( AVRG_ACTIVE ) THEN
+              IF ( .NOT. END_TIME ) THEN   ! ending time timestamp
+                 CALL NEXTIME ( MDATE, MTIME, -TSTEP(1) )
+              END IF
+          
+              IF ( .NOT. WRITE3( CTM_AELMO_1, 
+     &             ALLVAR3, MDATE, MTIME, 
+     &             ELMO_AVRG(:,:,:,:) / 2.0 / 
+     &             (ELMO_NSTEP-1.0) ) ) THEN
+                 XMSG = 'Could not write ' // CTM_AELMO_1 // ' file'
+                 CALL M3EXIT ( PNAME, MDATE, MTIME, XMSG, XSTAT1 )
+              END IF
+          
+              WRITE( LOGDEV, '( /5X, 3( A, :, 1X ), I8, ":", I6.6 )' )
+     &                       'Timestep written to', CTM_AELMO_1,
+     &                       'for date and time', MDATE, MTIME
+          
+          
+           END IF
+           ELMO_NSTEP = 0.
          END IF
       RETURN 
 

--- a/CCTM/src/driver/driver.F
+++ b/CCTM/src/driver/driver.F
@@ -106,7 +106,7 @@ C-----------------------------------------------------------------------
       USE RXNS_DATA             ! chemical mechanism data
       USE BUDGET_DEFN
       USE AERO_DATA
-      USE ELMO_DATA, ONLY : L_ELMO
+      USE ELMO_DATA, ONLY : L_ELMO, ELMO_NSTEP
       USE ELMO_PROC, ONLY : ELMO_DRIVER, WRITE_ELMO, MAP_ELMO
 #ifdef mpas
       USE CGRID_SPCS            ! CGRID mechanism species
@@ -707,15 +707,13 @@ C Compute ELMO Values at Beginning of Main Time Step
              
              ! Calculate all ELMO variables for both Instantaneous and
              ! Average parameters
-             CALL ELMO_DRIVER( CGRID, JDATE, JTIME, TSTEP,
-     &                         INIT_TIME=.TRUE., INIT_STEP=.TRUE. )
+             CALL ELMO_DRIVER( CGRID, JDATE, JTIME, TSTEP, INIT_TIME=.TRUE.)
              ! Print Instantaneous Values at first time step
              CALL WRITE_ELMO( JDATE, JTIME, TSTEP, INIT_TIME=.TRUE. )
 
-        ELSE
+        ELSE IF ( ELMO_NSTEP .LT. 1.0 ) THEN
              ! Calculate all ELMO Variables for averaging but do not output them
-             CALL ELMO_DRIVER( CGRID, JDATE, JTIME, TSTEP,
-     &                         INIT_TIME=.FALSE., INIT_STEP=.TRUE. )
+             CALL ELMO_DRIVER( CGRID, JDATE, JTIME, TSTEP, INIT_TIME=.FALSE. )
         END IF
       END IF
 
@@ -773,8 +771,7 @@ C Use trapezoidal rule to time-average data
 
 #endif
          ! OUTPUT DIAGNOSTIC INFORMATION
-         IF ( L_ELMO ) CALL ELMO_DRIVER( CGRID, JDATE, JTIME, TSTEP, 
-     &                      INIT_TIME=.FALSE., INIT_STEP=.FALSE. )
+         IF ( L_ELMO ) CALL ELMO_DRIVER( CGRID, JDATE, JTIME, TSTEP, INIT_TIME=.FALSE. )
 
       END DO
 

--- a/CCTM/src/init/initscen.F
+++ b/CCTM/src/init/initscen.F
@@ -72,7 +72,7 @@ C-----------------------------------------------------------------------
       USE HGRD_DEFN             ! horizontal domain specifications
       USE CGRID_SPCS            ! CGRID mechanism species
       USE UTILIO_DEFN
-      USE ELMO_DATA, ONLY : L_ELMO, ELMO_AVRG_STEP 
+      USE ELMO_DATA, ONLY : L_ELMO, ELMO_NSTEP 
       USE ELMO_PROC, ONLY : OPEN_ELMO
 #ifdef parallel
       USE SE_MODULES            ! stenex (using SE_UTIL_MODULE)
@@ -233,7 +233,7 @@ C Test opening existing conc file for update
 C *** Open the aerosol parameters file (diameters and standard deviations).
       IF ( L_ELMO .AND. IO_PE_INCLUSIVE ) THEN
            CALL OPEN_ELMO ( STDATE, STTIME, TSTEP( 1 ) )
-           ELMO_AVRG_STEP = 0
+           ELMO_NSTEP = 0.0
       END IF
 
       IF ( .NOT. OPEN3( CTM_CONC_1, FSRDWR3, PNAME ) ) THEN


### PR DESCRIPTION
**Contact:**  
Ben Murphy, Center for Environmental Measurement and Modeling, US EPA

**Priority:**  High

**Description and/or issue being addressed**:  ELMO gives erroneous results in WRF-CMAQ and when using met inputs not aligned with hour time steps.

**Impact on results:**  This PR resolves the problem by adjusting the algorithm for identifying when the initial time step is hit for the simulation and synchronization cycles.

**Issue:**  
This Pull Request addresses issue #179 

**Significance:**   This model bug fix should be adopted as soon as possible for any user running WRF-CMAQ or using met inputs with time steps not aligned with hourly structure. Simulations for offline CMAQ with hourly met inputs are unaffected.

**Tests conducted:**  
The code has been checked for the 2016 Southeast benchmark domain using 5 min met inputs. It's also been checked on the 2018 NE benchmark with default inputs. Only intel in optimized mode has been run. Reviewers within EPA have run this code for the 12 km CONUS case using WRF-CMAQ and the differences in results between the ELMO and CONC files are of the same magnitude as numerical noise. 
