### PR TITLE
Add precision to logfile proces timing

### DIFF
--- a/CCTM/src/driver/sciproc.F
+++ b/CCTM/src/driver/sciproc.F
@@ -314,7 +314,7 @@ C decouple CGRID for cloud and chemistry
 ! Print Summary Timing for Master time step      
       CALL TIMING_SPLIT ( CPU_TIME_START_MASTER, 2 )
 
-1002  FORMAT ( 2x, A15, ' completed... ', F6.1, ' seconds' )
+1002  FORMAT ( 2x, A15, ' completed... ', F12.3, ' seconds' )
 
       RETURN
       END

--- a/CCTM/src/util/util/RUNTIME_VARS.F
+++ b/CCTM/src/util/util/RUNTIME_VARS.F
@@ -1160,7 +1160,7 @@
       CASE ( 1 )
           ! Write Out The Time to Complete Each Sub-Process
           WRITE( XMSG, 1002 ),TRIM( CPROC ), CPU_TIME_FINISH-CPU_TIME_START
-1002      FORMAT ( 2x, A15, ' completed... ', F6.1, ' seconds' )
+1002      FORMAT ( 2x, A15, ' completed... ', F12.4, ' seconds' )
 
       CASE ( 2 ) 
           ! Write out the time to complete the entire master time step
@@ -1169,14 +1169,14 @@
 #ifndef twoway
           IF ( MYPE .EQ. 0 ) CALL LOG_MESSAGE( OUTDEV, XMSG )
 #endif
-          WRITE( XMSG, '(7x,A24,F6.1,A8)' ),'Processing completed... ',
+          WRITE( XMSG, '(7x,A24,F12.4,A8)' ),'Processing completed... ',
      &                     (CPU_TIME_FINISH-CPU_TIME_START),' seconds'
           CALL LOG_MESSAGE( LOGDEV, XMSG )
           WRITE( LOGDEV, * )
 
       CASE ( 3 ) 
           ! Write out the time to complete the output procedure
-          WRITE( XMSG, '(1x,A32,F4.1,A)' ), '=--> Data Output completed...   ',
+          WRITE( XMSG, '(1x,A32,F10.4,A)' ), '=--> Data Output completed...   ',
      &                     (CPU_TIME_FINISH-CPU_TIME_START),' seconds'
           CALL LOG_MESSAGE( LOGDEV, XMSG )
           WRITE( LOGDEV, * )


### PR DESCRIPTION
**Contact:**  
Ben Murphy, US EPA

**Type of code change:**   
Minor formatting change

**Description and/or issue being addressed**:  At high computational efficiency, the default precision provided for the timing metrics in the logfile was yielding 0.0. When aggregated, this underestimated the time taken by these processes. This PR adds 3 decimal places of precision to the timing output.

**Impact on results:**  None

**Tests conducted:**  
Ran on the NE Benchmark 2018 case for intel, gnu, and pgi in optimized and debug mode.
