### PR TITLE
Isam update 21april2023

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-issue-.md
+++ b/.github/ISSUE_TEMPLATE/new-issue-.md
@@ -1,0 +1,20 @@
+---
+name: 'New Issue '
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Description**
+A clear and concise description of the issue.
+
+**Scope and Impact**
+A description of how other users might be impacted by this issue.
+
+**Solution**
+Is there a known solution for the issue? If so, how/when will it be shared with other users. 
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+**Contact:**  
+Developers name and affiliation  
+
+**Type of code change:**   
+For example, bug fix, enhancement, new feature, documentation.
+
+**Description of changes:**   
+Clear and concise description of the problem, solution, and required changes.  
+
+**Issue:**  
+If this resolves a known issue, include the link to the GitHub Issue number.  
+
+**Summary of Impact:**  
+Please state whether this update changes the results of the core model predictions in terms of concentration, deposition, etc.  
+Please state the approximate impact this update has on model runtime, if any.  
+
+**Tests conducted:**  
+Describe tests that were conducted including domain and time period (e.g. BLDCHECK; June 1-2 2016 SEBENCH; Jan 2017 12US1) and results of the tests.  Include plots of relevant results.  
+
+
+

--- a/CCTM/src/cloud/acm_ae6/aqchem.F
+++ b/CCTM/src/cloud/acm_ae6/aqchem.F
@@ -159,7 +159,9 @@ C-----------------------------------------------------------------------
       USE AERO_DATA
       USE UTILIO_DEFN
 #ifdef isam
-      USE SA_DEFN, ONLY: DEPSUM_SAVE, DS4_SAVE, REMOV_SAVE
+      USE SA_DEFN, ONLY: DEPSUM_SAVE, DS4_SAVE, REMOV_SAVE,
+     &                   DEPSUM_AORGC_SAVE, DGLY1_SAVE, DMGLY1_SAVE,
+     &                   REMOV_AORGC_SAVE
 #endif
 
 #ifdef sens
@@ -647,6 +649,11 @@ C...make initializations
       S_DGLY1  = 0.0D0
       S_DMGLY1 = 0.0D0
       S_DORGC  = 0.0D0
+#endif
+
+#ifdef isam
+      DGLY1_SAVE = 0.0D0
+      DMGLY1_SAVE = 0.0D0
 #endif
 
 C...compute fractional weights for several species
@@ -2168,6 +2175,12 @@ C...  and methylglyoxal is assumed
 
         DORGC = DORGC - ( 0.04D0 * ( DGLYDT + DMGLYDT ) * DTW( 0 ) )
 
+#ifdef isam
+        DGLY1_SAVE  = DGLY1_SAVE  - 0.04D0 * DGLYDT  * DTW( 0 )
+        DMGLY1_SAVE = DMGLY1_SAVE - 0.04D0 * DMGLYDT * DTW( 0 )
+#endif
+
+
 #ifdef sens
         DO NP = 1, NPMAX
 
@@ -2539,6 +2552,12 @@ C... store sulfate production/loss quantities
       DEPSUM_SAVE =        DEPSUM * XL * RECIPAP1
       DS4_SAVE    = -1.0 * DS4(0) * XL * RECIPAP1
       REMOV_SAVE  = WETDEP( LSO4ACCL ) + WETDEP( LHSO4ACCL )
+
+C... store AORGC production/loss quantities      
+      DEPSUM_AORGC_SAVE = WETDEP( LORGCL ) * XC1 * XL * RECIPAP1
+      DGLY1_SAVE        = DGLY1_SAVE  * XL * RECIPAP1
+      DMGLY1_SAVE       = DMGLY1_SAVE * XL * RECIPAP1
+      REMOV_AORGC_SAVE  = WETDEP( LORGCL )
 #endif
 
       RETURN

--- a/CCTM/src/cloud/acm_ae6/cldproc_acm.F
+++ b/CCTM/src/cloud/acm_ae6/cldproc_acm.F
@@ -564,6 +564,9 @@ C...determine no. of moles of tracer gas per moles of air by volume
 c ISAM  unit conversion
       DO SPC = 1, NSPC_SA
         VAR = MAP_SAtoCGR(SPC)
+
+        IF ( VAR .EQ. RHOJ_LOC  ) CYCLE    ! RHOJ 
+
         IF ( VAR .LE. N_GC_SPC .OR. VAR .GE. NR_STRT ) THEN ! this is not an aerosol
           DO ITAG = 1, NTAG_SA
             DO LAY = 1, NLAYS
@@ -890,6 +893,9 @@ C...convert to ppmV tracer gas
 c ISAM  unit conversion
       DO SPC = 1, NSPC_SA
         VAR = MAP_SAtoCGR(SPC)
+
+        IF ( VAR .EQ. RHOJ_LOC ) CYCLE    ! RHOJ 
+
         IF ( VAR .LE. N_GC_SPC .OR. VAR .GE. NR_STRT ) THEN ! this is not an aerosol
           DO ITAG = 1, NTAG_SA
             DO LAY = 1, NLAYS

--- a/CCTM/src/cloud/acm_ae6/convcld_acm.F
+++ b/CCTM/src/cloud/acm_ae6/convcld_acm.F
@@ -153,7 +153,9 @@ C-----------------------------------------------------------------------
 #ifdef isam
       USE SA_DEFN, ONLY: ISAM, NSPC_SA, NTAG_SA, MAP_SAtoCGR, OTHRTAG,
      &                   ISAM_SPEC, DEPSUM_SAVE, DS4_SAVE, REMOV_SAVE,
-     &                   ITAG
+     &                   ITAG,
+     &                   DEPSUM_AORGC_SAVE, DGLY1_SAVE, DMGLY1_SAVE,
+     &                   REMOV_AORGC_SAVE
 #endif
 
 #ifdef sens
@@ -459,12 +461,14 @@ C...........Statement Functions
 
       INTEGER, SAVE           :: S_SO2, S_SO4J, S_SULF, S_N2O5
       INTEGER, SAVE           :: C_SO2, C_SO4J, C_SULF
+      INTEGER, SAVE           :: S_GLY, S_MGLY, S_AORGCJ
+      INTEGER, SAVE           :: C_GLY, C_MGLY, C_AORGCJ
+      REAL, ALLOCATABLE, SAVE :: SA_DCSOA_GLY    ( : )
+      REAL, ALLOCATABLE, SAVE :: SA_DCSOA_MGLY   ( : )
       INTEGER CSPC
 
       REAL BLNC
       REAL                    :: SA_SUM
-
-
 #endif
 
 
@@ -705,6 +709,17 @@ C Move this to a better place later
           XMSG = 'Failure allocating SA arrays'
           CALL M3EXIT( PNAME, JDATE, JTIME, XMSG, XSTAT1 )
         END IF
+
+        S_GLY    = INDEX1( 'GLY', NSPC_SA, ISAM_SPEC(:,OTHRTAG) )
+        S_MGLY   = INDEX1( 'MGLY', NSPC_SA, ISAM_SPEC(:,OTHRTAG) )
+        S_AORGCJ = INDEX1( 'AORGCJ', NSPC_SA, ISAM_SPEC(:,OTHRTAG) )
+
+        C_GLY    = INDEX1( 'GLY',   N_GC_SPC, GC_SPC )
+        C_MGLY   = INDEX1( 'MGLY', N_GC_SPC, GC_SPC )
+        C_AORGCJ = INDEX1( 'AORGCJ',  N_AE_SPC, AE_SPC ) + 1 + N_GC_SPC
+        ALLOCATE ( SA_DCSOA_GLY ( NTAG_SA ),
+     &             SA_DCSOA_MGLY ( NTAG_SA ),
+     &             STAT = ALLOCSTAT )
 #endif
 
 #ifdef sens
@@ -1722,9 +1737,12 @@ C...POLC in mol sp/m2
 
                   SA_PCLD( CSPC,LAY,ITAG ) = F( LAY ) * ( FSIDE( LAY ) * CONDIS )
      &                                     + ( 1.0 - F( LAY ) ) * SA_BASE0( CSPC,ITAG )
-                  IF ( ( CCR( SPC,LAY ) / FRAC) .EQ. PCLD( SPC,LAY ) ) THEN
-                    SA_PCLD( CSPC,LAY,ITAG ) = SA_CCR( CSPC,LAY,ITAG ) / FRAC 
-                  END IF
+c                 IF ( ( CCR( SPC,LAY ) / FRAC) .EQ. PCLD( SPC,LAY ) ) THEN
+c                   SA_PCLD( CSPC,LAY,ITAG ) = SA_CCR( CSPC,LAY,ITAG ) / FRAC 
+c                 END IF
+
+                  SA_PCLD( CSPC,LAY,ITAG ) = MIN( SA_PCLD( CSPC,LAY,ITAG ), SA_CCR( CSPC,LAY,ITAG ) / FRAC )
+
                   SA_POLC( CSPC,ITAG ) = SA_POLC( CSPC,ITAG )
      &                              + SA_PCLD( CSPC,LAY,ITAG ) * RHOM2( LAY )
                 END DO
@@ -1815,7 +1833,7 @@ C...  below cloud concentrations in mol sp/mol air
                 IF ( CSPC .NE. 0) THEN
                   DO ITAG = 1, NTAG_SA
 
-                     BCLDWT = SA_CONC( CSPC,LAY,ITAG ) / MAX( SA_BASE0( CSPC, ITAG ),1.0E-30 )
+c                    BCLDWT = SA_CONC( CSPC,LAY,ITAG ) / MAX( SA_BASE0( CSPC, ITAG ),1.0E-30 )
                      SA_PCLD( CSPC,LAY, ITAG ) = BCLDWT * SA_BASEF( CSPC,ITAG )
 
                      IF ( ICLDTYPE .EQ. 1 ) THEN
@@ -1828,6 +1846,7 @@ C...  below cloud concentrations in mol sp/mol air
 #endif
 
               END DO
+
             END DO
 
 C...Compute cloud mean quantities
@@ -1977,11 +1996,8 @@ C...  mimic this for the ASO4GASJ tracking species
 
 #ifdef isam
             DO SPC = 1, NSPC_SA ! general case
-
               CSPC = MAP_SAtoCGR(SPC)
-
               DO ITAG = 1, NTAG_SA
-c               IF ( POLC( CSPC ) .GT. 1.0E-30 .AND. CEND( CSPC ) .GT. 1.0E-09) THEN
                 IF ( POLC( CSPC ) .GT. 1.0E-30 ) THEN
                   SA_CEND( SPC,ITAG ) = SA_POLC( SPC,ITAG )
      &                                * ( CEND( CSPC )
@@ -1994,23 +2010,18 @@ c               IF ( POLC( CSPC ) .GT. 1.0E-30 .AND. CEND( CSPC ) .GT. 1.0E-09) 
                   SA_REMOV( SPC,ITAG ) = 0.0
                 END IF
               END DO
-
             END DO
-
-            IF ( S_N2O5 .NE. 0 ) THEN
+            IF ( S_N2O5 .NE. 0 ) THEN   
               DO ITAG = 1, NTAG_SA
                 SA_CEND( S_N2O5,ITAG )  = 0.0
               END DO
             END IF
-
             IF (S_SO4J .NE. 0 ) THEN ! sulfate case
 
               DO ITAG = 1, NTAG_SA  ! sulfate from H2SO4
                 SA_DS4( ITAG ) = SA_POLC( S_SULF,ITAG )
                 SA_CEND( S_SULF,ITAG )  = 1.0E-30
               END DO
-
-c             DS4_SAVE = MAX( ( DS4_SAVE - SUM( SA_DS4 ) ), 0.0 ) ! sulfate produced from SO2
 
               DO ITAG = 1, NTAG_SA
                 SA_DS4( ITAG ) = SA_DS4( ITAG ) + DS4_SAVE ! total sulfate produced
@@ -2034,8 +2045,38 @@ c             DS4_SAVE = MAX( ( DS4_SAVE - SUM( SA_DS4 ) ), 0.0 ) ! sulfate prod
               END DO
 
             END IF
-#endif
 
+            IF (S_AORGCJ .NE. 0 ) THEN ! AORGCJ case
+               SA_DCSOA_GLY = 0.0
+               SA_DCSOA_MGLY = 0.0
+               DO ITAG = 1, NTAG_SA
+                  IF ( S_GLY .NE. 0 ) THEN
+                    SA_DCSOA_GLY( ITAG ) = DGLY1_SAVE
+     &                               * SA_POLC( S_GLY,ITAG )
+     &                               / MAX( 1.0E-25, SUM ( SA_POLC( S_GLY,: ) ) )
+                  END IF
+                  IF ( S_MGLY .NE. 0 ) THEN
+                     SA_DCSOA_MGLY( ITAG ) = DMGLY1_SAVE
+     &                               * SA_POLC( S_MGLY,ITAG )
+     &                               / MAX( 1.0E-25, SUM ( SA_POLC( S_MGLY,: ) ) )
+                  END IF
+                  SA_CEND( S_AORGCJ,ITAG ) = SA_POLC( S_AORGCJ,ITAG ) ! AORGCJ before removal
+     &                                         + SA_DCSOA_GLY( ITAG )
+     &                                         + SA_DCSOA_MGLY( ITAG )
+               END DO
+               SA_SUM = MAX( 1.0E-25, SUM ( SA_CEND( S_AORGCJ,: ) ) ) ! total apportioned AORGCJ before removal
+               DO ITAG = 1, NTAG_SA ! final AORGCJ removal and concentration
+                  SA_REMOV( S_AORGCJ,ITAG ) = REMOV_AORGC_SAVE
+     &                                        * SA_CEND( S_AORGCJ,ITAG )
+     &                                        / SA_SUM
+                  SA_CEND( S_AORGCJ,ITAG ) = SA_CEND( S_AORGCJ,ITAG )
+     &                                       - DEPSUM_AORGC_SAVE
+     &                                       * SA_CEND( S_AORGCJ,ITAG )
+     &                                       / SA_SUM
+                  SA_CEND( S_AORGCJ,ITAG ) = MAX ( SA_CEND( S_AORGCJ,ITAG ), 1.0E-30 )
+               END DO
+            END IF
+#endif
           END IF
 
           DO SPC = 1, NSPCSD
@@ -2223,6 +2264,7 @@ C...   include raining region below cld base
                   OUTCLOUD = PCLD( SPC,LAY )
                   CGRID( COL,ROW,LAY,SPC ) = FRAC * INCLOUD
      &                                     + ( 1.0 - FRAC ) * OUTCLOUD
+
 #ifdef sens
                   DO NP = 1, NPMAX
                     IF( ABS( S_POLC( NP, SPC ) ) .LT. DDM3D_CONCMINL ) THEN
@@ -2279,16 +2321,51 @@ C...   include raining region below cld base
                   END DO
                 END IF
 
-c               IF (PCLD( MAP_SAtoCGR(SPC),LAY ) .GT. 1.0E-09) THEN
                 DO ITAG = 1, NTAG_SA
                   OUTCLOUD = SA_PCLD( S_SO4J,LAY,ITAG )
                   ISAM( COL,ROW,LAY,S_SO4J,ITAG ) = FRAC * SA_INCLOUD( ITAG )
      &                                       + ( 1.0 - FRAC ) * OUTCLOUD
                   ISAM( COL,ROW,LAY,S_SO4J,ITAG ) = MAX( ISAM( COL,ROW,LAY,S_SO4J,ITAG ), 1.0E-30 )
                 END DO
-c               END IF
 
               END IF
+
+              IF (S_AORGCJ .NE. 0 ) THEN ! AORGCJ case
+
+                CONDIS = 0.0
+                DO ITAG = 1, NTAG_SA
+                  SA_INCLOUD( ITAG ) = PCLD( C_AORGCJ,LAY ) * ( SA_CEND( S_AORGCJ,ITAG ) 
+     &                    / MAX( POLC( C_AORGCJ ), CONCMINL( C_AORGCJ,LAY ) ) )
+     &                    - ( PCLD( C_AORGCJ,LAY ) * CEND( C_AORGCJ ) / MAX( POLC( C_AORGCJ ), CONCMINL( C_AORGCJ,LAY ) ) )
+     &                    * SA_POLC( S_AORGCJ,ITAG ) / MAX( POLC( C_AORGCJ ), CONCMINL( C_AORGCJ,LAY ) )
+     &                    + SA_PCLD( S_AORGCJ,LAY,ITAG ) * CEND( C_AORGCJ ) / MAX( POLC( C_AORGCJ ), CONCMINL( C_AORGCJ,LAY ) )
+                  IF ( SA_INCLOUD( ITAG ) .LT. 0.0 ) THEN
+                    CONDIS = CONDIS + SA_INCLOUD( ITAG )
+                    SA_INCLOUD( ITAG )  = 0.0
+                  END IF
+                END DO
+
+                IF ( CONDIS .NE. 0.0 ) THEN
+                 BLNC = ( CONDIS + SUM( SA_INCLOUD( : ) ) ) / MAX( SUM( SA_INCLOUD( : ) ), CONCMINL( C_AORGCJ,LAY ) )
+                  DO ITAG = 1, NTAG_SA
+                    IF ( SA_INCLOUD( ITAG ) .GT. 0.0 ) THEN
+                      SA_INCLOUD( ITAG ) = BLNC * SA_INCLOUD( ITAG )
+                    END IF
+                  END DO
+                END IF
+
+                DO ITAG = 1, NTAG_SA
+                  INCLOUD = SA_PCLD( S_AORGCJ,LAY,ITAG ) * SA_CEND( S_AORGCJ,ITAG )
+     &                  / MAX( SA_POLC( S_AORGCJ,ITAG ), CONCMINL( SPC,LAY ) )
+c                 INCLOUD = MAX( INCLOUD, CONCMINL( C_AORGCJ,LAY ) )
+                  OUTCLOUD = SA_PCLD( S_AORGCJ,LAY,ITAG )
+                  ISAM( COL,ROW,LAY,S_AORGCJ,ITAG ) = FRAC * SA_INCLOUD( ITAG )
+     &                                       + ( 1.0 - FRAC ) * OUTCLOUD
+                  ISAM( COL,ROW,LAY,S_AORGCJ,ITAG ) = MAX( ISAM( COL,ROW,LAY,S_AORGCJ,ITAG ), 1.0E-30 )
+                END DO
+
+              END IF
+
 #endif
             END DO
           ELSE
@@ -2303,15 +2380,13 @@ c               END IF
               END DO
 #ifdef isam
               DO SPC = 1, NSPC_SA
-                IF (PCLD( MAP_SAtoCGR(SPC),LAY ) .GT. 1.0E-09) THEN
+c               IF (PCLD( MAP_SAtoCGR(SPC),LAY ) .GT. 1.0E-09) THEN
                 DO ITAG = 1, NTAG_SA
                   ISAM( COL,ROW,LAY,SPC,ITAG ) = SA_PCLD( SPC, LAY, ITAG )
                 END DO
-                END IF
+c               END IF
               END DO
 #endif
-
-
             END DO
           END IF
 
@@ -2362,7 +2437,6 @@ C...Now do changes in cloudy layers:
 #ifdef isam
             DO SPC = 1, NSPC_SA ! general case
               CSPC = MAP_SAtoCGR(SPC)
-
 c             IF (CEND( MAP_SAtoCGR(SPC) ) .GT. 1.0E-09) THEN
               DO ITAG = 1, NTAG_SA
                 INCLOUD = SA_PCLD( SPC,LAY,ITAG ) * ( SA_CEND( SPC,ITAG )
@@ -2395,9 +2469,29 @@ c             END IF
      &                                       + ( 1.0 - FRAC ) * OUTCLOUD
               END DO
             END IF
+
+
+            IF (S_AORGCJ .NE. 0 ) THEN ! AORGCJ case
+              DO ITAG = 1, NTAG_SA
+                INCLOUD = PCLD( C_AORGCJ,LAY ) * SA_CEND( S_AORGCJ,ITAG ) / MAX( POLC( C_AORGCJ ), CONCMINL( C_AORGCJ,LAY ) )
+     &                  - ( PCLD( C_AORGCJ,LAY ) * CEND( C_AORGCJ ) / MAX( POLC( C_AORGCJ ), CONCMINL( C_AORGCJ,LAY ) ) )
+     &                  * SA_POLC( S_AORGCJ,ITAG ) / MAX( POLC( C_AORGCJ ), CONCMINL( C_AORGCJ,LAY ) ) 
+     &                  + SA_PCLD( S_AORGCJ,LAY,ITAG ) * CEND( C_AORGCJ ) / MAX( POLC( C_AORGCJ ), CONCMINL( C_AORGCJ,LAY ) )
+
+                INCLOUD = SA_PCLD( S_AORGCJ,LAY,ITAG ) * SA_CEND( S_AORGCJ,ITAG )
+     &                  / MAX( SA_POLC( S_AORGCJ,ITAG ), CONCMINL( SPC,LAY ) )
+c               INCLOUD = MAX( INCLOUD, CONCMINL( C_AORGCJ,LAY ) )
+
+                OUTCLOUD = ( SA_CCR( S_AORGCJ,LAY,ITAG ) - FRAC * SA_PCLD( S_AORGCJ,LAY,ITAG ) )
+     &                   / ( 1.0 - FRAC )
+                OUTCLOUD = MAX( OUTCLOUD, CONCMINL( CSPC,LAY ) )
+
+                ISAM( COL,ROW,LAY,S_AORGCJ,ITAG ) = FRAC * INCLOUD
+     &                                       + ( 1.0 - FRAC ) * OUTCLOUD
+
+              END DO
+            END IF
 #endif
-
-
           END DO
         GO TO 301
 

--- a/CCTM/src/cloud/acm_ae6/rescld.F
+++ b/CCTM/src/cloud/acm_ae6/rescld.F
@@ -93,8 +93,9 @@ C-----------------------------------------------------------------------
 #ifdef isam
       USE SA_DEFN, ONLY: ISAM, NSPC_SA, NTAG_SA, MAP_SAtoCGR, OTHRTAG, 
      &                   ISAM_SPEC, DEPSUM_SAVE, DS4_SAVE, REMOV_SAVE,
-     &                   ITAG
-
+     &                   ITAG,
+     &                   DEPSUM_AORGC_SAVE, DGLY1_SAVE, DMGLY1_SAVE,
+     &                   REMOV_AORGC_SAVE
 #endif
 
 #ifdef sens
@@ -213,6 +214,10 @@ C Latitude and longitude for zenith angle calculation: Golam Sarwar * July 1, 20
       REAL, ALLOCATABLE, SAVE :: SA_DS4    ( : )
       REAL                    :: SA_SUM
       REAL, ALLOCATABLE, SAVE :: SA_REMOV  ( :,: )
+      INTEGER, SAVE           :: S_GLY, S_MGLY, S_AORGCJ
+      INTEGER, SAVE           :: C_GLY, C_MGLY, C_AORGCJ
+      REAL, ALLOCATABLE, SAVE :: SA_DCSOA_GLY    ( : )
+      REAL, ALLOCATABLE, SAVE :: SA_DCSOA_MGLY   ( : )
 #endif
 
 C...........External Functions:
@@ -327,6 +332,17 @@ C...  the met timestep in hours
           XMSG = 'Failure allocating SA_POLC or SA_CEND'
           CALL M3EXIT( PNAME, JDATE, JTIME, XMSG, XSTAT1 )
         END IF
+
+        S_GLY    = INDEX1( 'GLY', NSPC_SA, ISAM_SPEC(:,OTHRTAG) )
+        S_MGLY   = INDEX1( 'MGLY', NSPC_SA, ISAM_SPEC(:,OTHRTAG) )
+        S_AORGCJ = INDEX1( 'AORGCJ', NSPC_SA, ISAM_SPEC(:,OTHRTAG) )
+
+        C_GLY    = INDEX1( 'GLY',   N_GC_SPC, GC_SPC )
+        C_MGLY   = INDEX1( 'MGLY', N_GC_SPC, GC_SPC )
+        C_AORGCJ = INDEX1( 'AORGCJ',  N_AE_SPC, AE_SPC ) + 1 + N_GC_SPC
+        ALLOCATE ( SA_DCSOA_GLY ( NTAG_SA ),
+     &             SA_DCSOA_MGLY ( NTAG_SA ),
+     &             STAT = ALLOCSTAT )
 #endif
 
 #ifdef sens
@@ -670,7 +686,6 @@ C...  mimic this for the ASO4GASJ tracking species
                   DO SPC = 1, NSPC_SA ! general case
                     CSPC = MAP_SAtoCGR(SPC)
                     DO ITAG = 1, NTAG_SA
-c                     IF ( POLC( CSPC ) .GT. 1.0E-30 .AND. CEND( CSPC ) .GT. 1.0E-09 ) THEN
                       IF ( POLC( CSPC ) .GT. 1.0E-30 ) THEN
                         SA_CEND( SPC, ITAG ) = SA_POLC( SPC,ITAG )
      &                                       * ( CEND( CSPC )
@@ -691,8 +706,6 @@ c                     IF ( POLC( CSPC ) .GT. 1.0E-30 .AND. CEND( CSPC ) .GT. 1.0
                       SA_DS4( ITAG ) = SA_POLC( S_SULF,ITAG )
                       SA_CEND( S_SULF,ITAG )  = 1.0E-30
                     END DO
-
-c                   DS4_SAVE = MAX( ( DS4_SAVE - SUM( SA_DS4 ) ), 0.0 ) !sulfate produced from SO2
 
                     DO ITAG = 1, NTAG_SA
                       SA_DS4( ITAG ) = SA_DS4( ITAG ) + DS4_SAVE ! total sulfate produced
@@ -715,6 +728,37 @@ c                   DS4_SAVE = MAX( ( DS4_SAVE - SUM( SA_DS4 ) ), 0.0 ) !sulfate
                       SA_CEND( S_SO4J,ITAG ) = MAX ( SA_CEND( S_SO4J,ITAG ), 1.0E-30 )
                     END DO
           
+                  END IF
+
+                  IF (S_AORGCJ .NE. 0 ) THEN ! AORGCJ case
+                    SA_DCSOA_GLY = 0.0
+                    SA_DCSOA_MGLY = 0.0
+                    DO ITAG = 1, NTAG_SA
+                      IF ( S_GLY .NE. 0 ) THEN
+                        SA_DCSOA_GLY( ITAG ) = DGLY1_SAVE
+     &                               * SA_POLC( S_GLY,ITAG )
+     &                               / MAX( 1.0E-25, SUM ( SA_POLC( S_GLY,: ) ) )
+                      END IF
+                      IF ( S_MGLY .NE. 0 ) THEN
+                        SA_DCSOA_MGLY( ITAG ) = DMGLY1_SAVE
+     &                               * SA_POLC( S_MGLY,ITAG )
+     &                               / MAX( 1.0E-25, SUM ( SA_POLC( S_MGLY,: ) ) )
+                      END IF
+                      SA_CEND( S_AORGCJ,ITAG ) = SA_POLC( S_AORGCJ,ITAG ) ! AORGCJ before removal
+     &                                         + SA_DCSOA_GLY( ITAG )
+     &                                         + SA_DCSOA_MGLY( ITAG )
+                    END DO
+                    SA_SUM = MAX( 1.0E-25, SUM ( SA_CEND( S_AORGCJ,: ) ) ) ! total apportioned AORGCJ before removal
+                    DO ITAG = 1, NTAG_SA ! final AORGCJ removal and concentration
+                      SA_REMOV( S_AORGCJ,ITAG ) = REMOV_AORGC_SAVE
+     &                                        * SA_CEND( S_AORGCJ,ITAG )
+     &                                        / SA_SUM
+                      SA_CEND( S_AORGCJ,ITAG ) = SA_CEND( S_AORGCJ,ITAG )
+     &                                       - DEPSUM_AORGC_SAVE
+     &                                       * SA_CEND( S_AORGCJ,ITAG )
+     &                                       / SA_SUM
+                      SA_CEND( S_AORGCJ,ITAG ) = MAX ( SA_CEND( S_AORGCJ,ITAG ), 1.0E-30 )
+                    END DO
                   END IF
 #endif
                 END IF

--- a/CCTM/src/isam/SA_DEFN.F
+++ b/CCTM/src/isam/SA_DEFN.F
@@ -116,6 +116,11 @@ c...Logical values for tagging species
       REAL, SAVE :: DS4_SAVE    = 0.0
       REAL, SAVE :: REMOV_SAVE  = 0.0
 
+      REAL, SAVE :: DEPSUM_AORGC_SAVE = 0.0
+      REAL, SAVE :: DGLY1_SAVE        = 0.0 
+      REAL, SAVE :: DMGLY1_SAVE       = 0.0  
+      REAL, SAVE :: REMOV_AORGC_SAVE  = 0.0
+
 c...Final, combined tags
       INTEGER                      :: N_SPCTAG
       INTEGER,         ALLOCATABLE :: S_SPCTAG( : )
@@ -489,31 +494,31 @@ c----------------------------------------------------------
 
         ! PRESCRIBE VOC SPECIES
         !CB6R3_AE7_AQ
-        ALLOCATE( ISAM_SPEC_VOC( 1 )%LIST( 27 ) )
+        ALLOCATE( ISAM_SPEC_VOC( 1 )%LIST( 28 ) )
         ISAM_SPEC_VOC( 1 )%LIST = (/'ALD2   ','ALDX   ','ETH    ',
      &          'ETHA   ','ETOH   ','FORM   ','IOLE   ','ISOP   ',
      &          'MEOH   ','OLE    ','PAR    ','TERP   ','TOL    ',
      &          'XYLMN  ','NAPH   ','ETHY   ','PRPA   ','ACET   ',
      &          'KET    ','GLY    ','BENZENE','GLYD   ','MEPX   ',
-     &          'APIN   ','SOAALK ','ECH4   ','CO     '/)
+     &          'APIN   ','SOAALK ','ECH4   ','CO     ','MGLY   '/)
 
         !CB6R5_AE7_AQ
-        ALLOCATE( ISAM_SPEC_VOC( 2 )%LIST( 27 ) )
+        ALLOCATE( ISAM_SPEC_VOC( 2 )%LIST( 28 ) )
         ISAM_SPEC_VOC( 2 )%LIST = (/'ALD2   ','ALDX   ','ETH    ',
      &          'ETHA   ','ETOH   ','FORM   ','IOLE   ','ISOP   ',
      &          'MEOH   ','OLE    ','PAR    ','TERP   ','TOL    ',
      &          'XYLMN  ','NAPH   ','ETHY   ','PRPA   ','ACET   ',
      &          'KET    ','GLY    ','BENZENE','GLYD   ','MEPX   ',
-     &          'APIN   ','SOAALK ','ECH4   ','CO     '/)
+     &          'APIN   ','SOAALK ','ECH4   ','CO     ','MGLY   '/)
 
         !CB6R5M_AE7_AQ
-        ALLOCATE( ISAM_SPEC_VOC( 3 )%LIST( 27 ) )
+        ALLOCATE( ISAM_SPEC_VOC( 3 )%LIST( 28 ) )
         ISAM_SPEC_VOC( 3 )%LIST = (/'ALD2   ','ALDX   ','ETH    ',
      &          'ETHA   ','ETOH   ','FORM   ','IOLE   ','ISOP   ',
      &          'MEOH   ','OLE    ','PAR    ','TERP   ','TOL    ',
      &          'XYLMN  ','NAPH   ','ETHY   ','PRPA   ','ACET   ',
      &          'KET    ','GLY    ','BENZENE','GLYD   ','MEPX   ',
-     &          'APIN   ','SOAALK ','ECH4   ','CO     '/)
+     &          'APIN   ','SOAALK ','ECH4   ','CO     ','MGLY   '/)
 
         !SAPRC07TC_AE6_AQ
         ALLOCATE( ISAM_SPEC_VOC( 4 )%LIST( 41 ) )
@@ -1087,6 +1092,7 @@ c----------------------------------------------------------
         ! Add Ozone if Requested
         IF ( INDEX( TAGCLASSES,'OZONE' ) .NE. 0 .OR. L_OZONE ) THEN
 
+          L_OZONE   = .TRUE.
           L_NO3     = .TRUE.
           L_VOC     = .TRUE.
           FOUND_SPECIES = .FALSE.

--- a/CCTM/src/isam/SA_WRAP_AE.F
+++ b/CCTM/src/isam/SA_WRAP_AE.F
@@ -321,9 +321,11 @@ Ckrt Identify species index in ISAM array
                 DO L = 1,NLAYS
                    IF ( BULK_TRANS_SRC( C,R,L ) .LT. 0.0 ) THEN
                      ! Assume that net losses pull proportionally from water species
-                     SPEC_BULK0( C,R,L ) = SUM( ISAM0( C,R,L,JAER(IM),: ) )
-                     ISAM1( C,R,L,JAER(IM),: ) = ISAM0( C,R,L,JAER(IM),: ) *
+                     IF ( JAER(IM) .NE. 0 ) THEN
+                       SPEC_BULK0( C,R,L ) = SUM( ISAM0( C,R,L,JAER(IM),: ) )
+                       ISAM1( C,R,L,JAER(IM),: ) = ISAM0( C,R,L,JAER(IM),: ) *
      &                       ( 1.0 + BULK_TRANS_SRC( C,R,L )/SPEC_BULK0( C,R,L ) )
+                     END IF
                    ELSE
                      ! Assume that net gains are apportioned like current non-water aerosol
                      ! Determine the total non-water mass separating
@@ -334,13 +336,15 @@ Ckrt Identify species index in ISAM array
      &                            OMH2O .EQV. L_MASK_OM   .AND.
      &                            IM .EQ. L_MASK_IM   ) )
                      DO K = 1,NTAG_SA
-                        ISAM1( C,R,L,JAER(IM),K ) = ISAM0( C,R,L,JAER(IM),K ) +
+                       IF ( JAER(IM) .NE. 0 ) THEN
+                          ISAM1( C,R,L,JAER(IM),K ) = ISAM0( C,R,L,JAER(IM),K ) +
      &                      SUM( ISAM0( C,R,L,:,K ),
      &                          MASK = (L_MASK_AERO .AND. 
      &                                L_MASK_TYPE .NE. 'H2O'  .AND.
      &                                OMH2O .EQV. L_MASK_OM   .AND. 
      &                                IM .EQ. L_MASK_IM  ) )
      &                          /SPEC_BULK0( C,R,L ) * BULK_TRANS_SRC( C,R,L )
+                       END IF
                      END DO
                    END IF
                 END DO

--- a/CCTM/src/vdiff/acm2_m3dry/vdiffacmx.F
+++ b/CCTM/src/vdiff/acm2_m3dry/vdiffacmx.F
@@ -169,6 +169,7 @@ C ACM Local Variables
 
       REAL, ALLOCATABLE,SAVE :: SAFRAC( : )
       REAL, ALLOCATABLE,SAVE :: SA_NO2( : )      
+      REAL, ALLOCATABLE,SAVE :: SA_SUM( : )
 
       INTEGER, SAVE              :: ISAM_INDEX_NO2 = 0   ! ...Index locating NO2 in ISAM
       INTEGER, SAVE              :: ISAM_INDEX_NH3 = 0   ! ...Index locating NH3 in ISAM
@@ -289,6 +290,7 @@ C set auxiliary depv arrays
             CALL M3EXIT( PNAME, MDATE, MTIME, XMSG, XSTAT1 )
          END IF
          ALLOCATE (  SAFRAC ( N_SPCTAG ),
+     &               SA_SUM ( NSPC_SA ),
      &               ISAM_DEPV( N_SPCTAG ), STAT = ASTAT )
          IF ( ASTAT .NE. 0 ) THEN
             XMSG = 'Failure ISAM depv variables'
@@ -372,10 +374,10 @@ C set auxiliary depv arrays
               WRITE(LOGDEV,'(I2,3X,I4,8X,A16)')ITAG,JSPCTAG,'MISSING'
            END IF   
         END DO
-        WRITE(LOGDEV,* )'TAG_species, Default Partitioning Coeff.'
-        DO JSPCTAG = 1, N_SPCTAG
-          WRITE(LOGDEV,*)VNAM_SPCTAG( JSPCTAG ),' ,',SAFRAC( JSPCTAG )
-        END DO          
+c       WRITE(LOGDEV,* )'TAG_species, Default Partitioning Coeff.'
+c       DO JSPCTAG = 1, N_SPCTAG
+c         WRITE(LOGDEV,*)VNAM_SPCTAG( JSPCTAG ),' ,',SAFRAC( JSPCTAG )
+c       END DO          
         IF ( ABFLUX .AND. L_NH4 ) THEN
           ITAG = 0
           DO JSPCTAG = 1, N_SPCTAG
@@ -386,10 +388,10 @@ C set auxiliary depv arrays
             END IF
           END DO
 
-          DO ITAG = 1, NTAG_SA
-            JSPCTAG = INDEX_SA_NH3( ITAG )
-            SAFRAC( JSPCTAG ) = 0.0 ! to not double count the bi-di emmissions
-          END DO
+c         DO ITAG = 1, NTAG_SA
+c           JSPCTAG = INDEX_SA_NH3( ITAG )
+c           SAFRAC( JSPCTAG ) = 0.0 ! to not double count the bi-di emmissions
+c         END DO
         END IF
 #endif
 
@@ -544,6 +546,26 @@ C-----------------------------------------------------------------------
 #endif
 
 #ifdef isam
+         SA_SUM = 0.0
+         DO V = 1, NSPC_SA
+            DO ITAG = 1, NTAG_SA
+               SA_SUM( V ) = SA_SUM( V ) + ISAM( C,R,1,V,ITAG )
+            END DO
+            SA_SUM( V ) = MAX ( 1.0E-30, SA_SUM( V ) )
+         END DO
+
+         SAFRAC = 0.0
+         DO JSPCTAG = 1, N_SPCTAG
+            SAFRAC( JSPCTAG ) = SACONC( JSPCTAG,1 ) / SA_SUM ( S_SPCTAG( JSPCTAG )   ) 
+         END DO
+
+         IF ( ABFLUX .AND. L_NH4 ) THEN
+            DO ITAG = 1, NTAG_SA
+               JSPCTAG = INDEX_SA_NH3( ITAG )
+               SAFRAC( JSPCTAG ) = 0.0 ! to not double count the bi-di emmissions
+            END DO
+         END IF
+
          IF( L_NO3 .AND. SFC_HONO ) THEN
 ! compute the flux partitioning for HONO from NO2 surface reaction
             DO ITAG = 1, NTAG_SA
@@ -1027,6 +1049,12 @@ C Load into CGRID
 #endif
             END DO
             
+
+
+
+
+
+
             DO V = 1, N_SPC_DEPV
 
 C --------- HET HONO RX -----------------

--- a/CCTM/src/vdiff/acm2_stage/vdiffacmx.F
+++ b/CCTM/src/vdiff/acm2_stage/vdiffacmx.F
@@ -165,6 +165,7 @@ C ACM Local Variables
 
       REAL, ALLOCATABLE,SAVE :: SAFRAC( : )
       REAL, ALLOCATABLE,SAVE :: SA_NO2( : )      
+      REAL, ALLOCATABLE,SAVE :: SA_SUM( : )
 
       INTEGER, SAVE              :: ISAM_INDEX_NO2 = 0   ! ...Index locating NO2 in ISAM
       INTEGER, SAVE              :: ISAM_INDEX_NH3 = 0   ! ...Index locating NH3 in ISAM
@@ -291,6 +292,7 @@ C set auxiliary depv arrays
             CALL M3EXIT( PNAME, MDATE, MTIME, XMSG, XSTAT1 )
          END IF
          ALLOCATE (  SAFRAC ( N_SPCTAG ),
+     &               SA_SUM ( NSPC_SA ),
      &               ISAM_DEPV( N_SPCTAG ), STAT = ASTAT )
          IF ( ASTAT .NE. 0 ) THEN
             XMSG = 'Failure ISAM depv variables'
@@ -380,10 +382,10 @@ C set auxiliary depv arrays
               WRITE(LOGDEV,'(I2,3X,I4,8X,A16)')ITAG,JSPCTAG,'MISSING'
            END IF   
         END DO
-        WRITE(LOGDEV,* )'TAG_species, Default Partitioning Coeff.'
-        DO JSPCTAG = 1, N_SPCTAG
-          WRITE(LOGDEV,*)VNAM_SPCTAG( JSPCTAG ),' ,',SAFRAC( JSPCTAG )
-        END DO          
+c       WRITE(LOGDEV,* )'TAG_species, Default Partitioning Coeff.'
+c       DO JSPCTAG = 1, N_SPCTAG
+c         WRITE(LOGDEV,*)VNAM_SPCTAG( JSPCTAG ),' ,',SAFRAC( JSPCTAG )
+c       END DO          
 
         IF ( ABFLUX .AND. L_NH4 ) THEN
           ITAG = 0
@@ -395,10 +397,10 @@ C set auxiliary depv arrays
             END IF
           END DO
 
-          DO ITAG = 1, NTAG_SA
-            JSPCTAG = INDEX_SA_NH3( ITAG )
-            SAFRAC( JSPCTAG ) = 0.0 ! to not double count the bi-di emmissions
-          END DO
+c         DO ITAG = 1, NTAG_SA
+c           JSPCTAG = INDEX_SA_NH3( ITAG )
+c           SAFRAC( JSPCTAG ) = 0.0 ! to not double count the bi-di emmissions
+c         END DO
         END IF
 #endif
  
@@ -491,6 +493,26 @@ C-----------------------------------------------------------------------
 #endif
 
 #ifdef isam
+         SA_SUM = 0.0
+         DO V = 1, NSPC_SA
+            DO ITAG = 1, NTAG_SA
+               SA_SUM( V ) = SA_SUM( V ) + ISAM( C,R,1,V,ITAG )
+            END DO
+            SA_SUM( V ) = MAX ( 1.0E-30, SA_SUM( V ) )
+         END DO
+
+         SAFRAC = 0.0
+         DO JSPCTAG = 1, N_SPCTAG
+            SAFRAC( JSPCTAG ) = SACONC( JSPCTAG,1 ) / SA_SUM ( S_SPCTAG( JSPCTAG )   ) 
+         END DO
+
+         IF ( ABFLUX .AND. L_NH4 ) THEN
+            DO ITAG = 1, NTAG_SA
+               JSPCTAG = INDEX_SA_NH3( ITAG )
+               SAFRAC( JSPCTAG ) = 0.0 ! to not double count the bi-di emmissions
+            END DO
+         END IF
+
          IF( L_NO3 .AND. SFC_HONO ) THEN
 ! compute the flux partitioning for HONO from NO2 surface reaction
             DO ITAG = 1, NTAG_SA

--- a/DOCS/Users_Guide/CMAQ_UG_ch11_ISAM.md
+++ b/DOCS/Users_Guide/CMAQ_UG_ch11_ISAM.md
@@ -46,7 +46,7 @@ Note, using this ioapi-large version is not required for the CMAQ-ISAM Benchmark
 If a user needs to use larger setting for MXFILE3 and MXVAR3 to support their application, note that the memory requirements will be increased.
 This version is available as a zip file from the following address:
 
-https://www.cmascenter.org/ioapi/download/ioapi-3.2-large-2020220.tar.gz
+https://www.cmascenter.org/ioapi/download/ioapi-3.2-large-20200828.tar.gz
 
 ## 11.3 Run Instructions
 

--- a/DOCS/Users_Guide/Tutorials/CMAQ_UG_tutorial_build_library_gcc.md
+++ b/DOCS/Users_Guide/Tutorials/CMAQ_UG_tutorial_build_library_gcc.md
@@ -1,64 +1,81 @@
 ## Install netCDF-C
 
-1. If your compute server uses modules use the following command to see what packages are available
+### This tutorial assumes that you are using the C-shell, (csh or tcsh), GCC version 9.1.0, and OpenMPI 4.0.1
+
+1. To enter the csh shell you can type the following at the command line:
+
+```
+csh
+```
+
+2. To verify what shell you are in
+
+```
+echo $SHELL
+```
+
+3. If your compute server uses modules use the following command to see what packages are available
 
 ```
 module avail
 ```
-2. Load module environment for a compiler (Intel|GCC|PGI) and mpi package corresponding to that compiler (e.g. openmpi).
+
+4. Load module environment for a compiler (Intel|GCC|PGI) and mpi package corresponding to that compiler (e.g. openmpi).
 
 ```
 module load gcc9.1.0
 module load openmpi_4.0.1/gcc_9.1.0
 ```
 
-3. Create a LIBRARY directory where you would like to install the libraries required for CMAQ
+5. Create a LIBRARY directory where you would like to install the libraries required for CMAQ
 
 ```
 /[your_install_path]/LIBRARIES
 
 ```
 
-4. Change directories to the new LIBRARIES Directory
+6. Change directories to the new LIBRARIES Directory
 
+```
 cd /[your_install_path]/LIBRARIES
-
-5. Download netCDF-C from the following website https://www.unidata.ucar.edu/downloads/netcdf/index.jsp
-
-```
-wget ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-c-4.7.0.tar.gz
 ```
 
-6. Untar the netCDF-C tar.gz file
+7. Download netCDF-C from the following website https://www.unidata.ucar.edu/downloads/netcdf/index.jsp
 
 ```
-tar -xzvf netcdf-c-4.7.0.tar.gz
+wget https://github.com/Unidata/netcdf-c/archive/refs/tags/v4.8.1.tar.gz
 ```
 
-7. Change directories into the extracted directory
+8. Untar the netCDF-C tar.gz file
+
 ```
-cd netcdf-c-4.7.0
+tar -xzvf v4.8.1.tar.gz
 ```
 
-8. Review the installation instructions for netcdf-c-4.7.0 for building Classic netCDF
+9. Change directories into the extracted directory
+```
+cd netcdf-c-4.8.1
+```
+
+10. Review the installation instructions for netcdf-c-4.7.0 for building Classic netCDF
 
 ```
 more INSTALL.md
 ```
 
-9. Create a target installation directory that includes the loaded module environment name
+11. Create a target installation directory that includes the loaded module environment name
 
 ```
-mkdir ../netcdf-c-4.7.0-gcc9.1.0
+mkdir ../netcdf
 ```
 
 
-10. Run the configure --help command to see what settings can be used for the build.
+12. Run the configure --help command to see what settings can be used for the build.
 ```
 ./configure --help
 ```
 
-11. Set the Compiler environment variables
+13. Set the Compiler environment variables
 
 Make sure these compilers can be found.
 ```
@@ -76,25 +93,25 @@ setenv CC gcc
 setenv CXX g++
 ```
 
-12. Run the configure command
+14. Run the configure command
 
 ```
-./configure --prefix=$cwd/../netcdf-c-4.7.0-gcc9.1.0 --disable-netcdf-4 --disable-dap
+./configure --prefix=$cwd/../netcdf --disable-netcdf-4 --disable-dap
 ```
 
-13. Check that the configure command worked correctly, then run the install command
+15. Check that the configure command worked correctly, then run the install command
 
 ```
 make check install
 ```
 
-14. Verify that the following message is obtained
+16. Verify that the following message is obtained
 
 ```
 | Congratulations! You have successfully installed netCDF!    |
 ```
 
-15. Change directories to one level up from your current directory
+17. Change directories to one level up from your current directory
 ```
 cd ..
 ```
@@ -104,36 +121,25 @@ cd ..
 1. Download netCDF-Fortran from the following website https://www.unidata.ucar.edu/downloads/netcdf/index.jsp
 
 ```
-wget ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-fortran-4.4.5.tar.gz 
+wget https://github.com/Unidata/netcdf-fortran/archive/refs/tags/v4.5.4.tar.gz
 ```
 
 2. Untar the tar.gz file
 
 ```
-tar -xzvf netcdf-fortran-4.4.5.tar.gz
+tar -xzvf v4.5.4.tar.gz
 ```
 
-3. Change directories to netcdf-fortran-4.4.5
+3. Change directories to netcdf-fortran-4.5.4
 
 ```
-cd netcdf-fortran-4.4.5
+cd netcdf-fortran-4.5.4
 ```
 
-4. Make an install directory that matches the name of your loaded module environment
+4. Review the installation document http://www.unidata.ucar.edu/software/netcdf/docs/building_netcdf_fortran.html
 
-```
-mkdir ../netcdf-fortran-4.4.5-gcc9.1.0
-```
 
-5. Review the installation document http://www.unidata.ucar.edu/software/netcdf/docs/building_netcdf_fortran.html
-
-6. Set the environment variable NCDIR to specify the install directory
-
-```
-setenv NCDIR $cwd/../netcdf-c-4.7.0-gcc9.1.0
-```
-
-7. Set the CC environment variable to use the gcc and gfortran compilers
+5. Set the CC environment variable to use the gcc and gfortran compilers
 
 ```
 which gfortran
@@ -145,35 +151,36 @@ setenv CC gcc
 setenv CXX g++
 ```
 
-8. Set your LD_LIBRARY_PATH to include the netcdf-C library path for netCDF build
+6. Set your LD_LIBRARY_PATH to include the netcdf-C library path for netCDF build
 
 ```
-setenv NCDIR $cwd/../netcdf-c-4.7.0-gcc9.1.0
+setenv NCDIR $cwd/../netcdf
 setenv LD_LIBRARY_PATH ${NCDIR}/lib:${LD_LIBRARY_PATH}
 ```
 
-9. Check your LD_LIBRARY_PATH
+7. Check your LD_LIBRARY_PATH
 
 ```
 echo $LD_LIBRARY_PATH
 ```
 
-10. Set the install directory for netCDF fortran
+8. Set the install directory for netCDF fortran (note it will be the same location as the install directory for netCDF C libraries)
 
 ```
-setenv NFDIR $cwd/../netcdf-fortran-4.4.5-gcc9.1.0
+setenv NFDIR $cwd/../netcdf
 
 setenv CPPFLAGS -I${NCDIR}/include
 setenv LDFLAGS -L${NCDIR}/lib
+setenv LIBS "-lnetcdf"
 ```
 
-11. Run the configure command
+9. Run the configure command
 
 ```
-./configure --prefix=${NFDIR}
+./configure --disable-shared --prefix=${NFDIR}
 ```
 
-12. Run the make check command
+10. Run the make check command
 
 ```
 make check
@@ -188,7 +195,9 @@ Testsuite summary for netCDF-Fortran 4.4.5
 # PASS:  6
 ```
 
-13. Run the make install command
+Note, this often fails, even if the library is ok.
+
+11. Run the make install command
 
 ```
 make install
@@ -197,7 +206,7 @@ make install
 Output successful if you see Libraries have been installed in the install directory
 
 ```
-ls $cwd/../netcdf-fortran-4.4.5-gcc9.1.0
+ls $cwd/../netcdf
 ```
 
 If you ever happen to want to link against installed libraries
@@ -212,13 +221,41 @@ flag during linking and do at least one of the following:
    - have your system administrator add LIBDIR to '/etc/ld.so.conf'
 
 
-14. set your LD_LIBRARY_PATH to include the netcdf-Fortran library path for netCDF build
+12. set your LD_LIBRARY_PATH to include the netcdf-Fortran library path for netCDF build
 
 ```
-setenv NFDIR $cwd/../netcdf-fortran-4.4.5-gcc9.1.0
+setenv NFDIR $cwd/../netcdf
 setenv LD_LIBRARY_PATH ${NFDIR}/lib:${LD_LIBRARY_PATH}
 ```
-(may need to add the NCDIR and NFDIR to .cshrc)
+
+13. Update the library bin directory path and LD_LIBRARY_PATH to use  $NCDIR and $NFDIR to in your .cshrc.
+
+Verify the paths for $NCDIR and $NFDIR
+
+```
+echo $NCDIR
+echo $NFDIR
+```
+
+14. Edit the .cshrc file in your home directory to add the paths to the libraries.
+Note, in this case we installed both NetCDF C and NetCDF Fortran into the same location.
+
+vi ~/.cshrc
+
+```
+# start .cshrc
+set $NCDIR /your_path/netcdf
+set $NFDIR /your_path/netcdf
+set path = ($path $NCDIR\bin $NFDIR\bin )
+setenv LD_LIBRARY_PATH ${NCDIR}/lib:${NFDIR}/lib:${LD_LIBRARY_PATH}
+```
+
+15. Source your updated .cshrc file by restarting the c-shell
+
+```
+csh
+```
+
 
 ## Install I/O API
 Note
@@ -264,25 +301,34 @@ cd ioapi
 cp Makefile.nocpl Makefile
 ```
 
-5. Set the BIN environment variable to include the module that will be used to compile CMAQ
+
+5. Set the BIN environment variable to specify the compiler version used.
 This will help future users identify what compiler version is compatible with this library.
 
 ```
-setenv BIN Linux2_x86_64gfort_openmpi_4.0.1_gcc_9.1.0
+setenv BIN Linux2_x86_64gfort_gcc_9.1.0
 ```
 
 6. Copy an existing Makeinclude file to have this BIN name at the end
 
 ```
-cp Makeinclude.Linux2_x86_64gfort Makeinclude.Linux2_x86_64gfort_openmpi_4.0.1_gcc_9.1.0
+cp Makeinclude.Linux2_x86_64gfort Makeinclude.Linux2_x86_64gfort_gcc_9.1.0
 ```
 
-7. Edit the Makeinclude.Linux2_x86_64gfort_openmpi_4.0.1_gcc_9.1.0 to comment out OMPFLAG and OMPLIBS 
+:. Edit Makeinclude file to include ‘-DIOAPI_NCF4=1’ to the MFLAGS make-variable to avoid multiple definition of `nf_get_vara_int64_’
+
+```
+vi  Makeinclude.Linux2_x86_64gfort_gcc_9.1.0
+edit line 32
+MFLAGS    = -ffast-math -funroll-loops -m64 -DIOAPI_NCF4=1 #  -Wall -Wsurprising -march=native -mtune=native
+```
+
+7. Edit the Makeinclude.Linux2_x86_64gfort_gcc_9.1.0 to comment out OMPFLAG and OMPLIBS 
 settings.  This will remove the need to link the shared memory OPENMP libraries when compiling CMAQ and WRF-CMAQ.
 
 ```
-#OMPFLAGS  = -fopenmp
-#OMPLIBS   =  -fopenmp
+OMPFLAGS  = # -fopenmp
+OMPLIBS   = # -fopenmp
 ```
 
 8. Create a BIN directory where the library and m3tools executables will be installed
@@ -295,7 +341,7 @@ mkdir ../$BIN
 
 ```
 cd ../
-ln -s Linux2_x86_64gfort_openmpi_4.0.1_gcc_9.1.0 Linux2_x86_64gfort
+ln -s Linux2_x86_64gfort_gcc_9.1.0 Linux2_x86_64gfort
 ```
 
 10. Set the HOME environment variable to be your LIBRARY install directory and run the make command to compile and link the ioapi library
@@ -337,8 +383,9 @@ cp Makefile.nocpl Makefile
 
 15. Run make to compile the m3tools
 ```
-make |& tee make.log
+make 'HOME=[your_install_path]/LIBRARIES' |& tee make.log
 ```
+
 16. Check to see that the m3tools have been installed successfully
 ```
 cd ../$BIN
@@ -346,4 +393,5 @@ ls -rlt m3xtract
 ```
 
 17. After successfull completion of this tutorial, the user is now ready to proceed to the [CMAQ Installation & Benchmarking Tutorial](./CMAQ_UG_tutorial_benchmark.md)
+
 


### PR DESCRIPTION
Contact:
[[Sergey Napelenok](mailto:napelenok.sergeyl@epa.gov)], U.S. Environmental Protection Agency

Type of code change:
Bug fix

Description of changes:
This fixes several recently identified ISAM issues including:

ISAM is crashing when compiled in debug mode and PM_TOT tagclass is activated. Some logic was added to SA_WRAP_AE to limit calculations when JAEM array contains zero indexes.

AORGCJ is not calculated correctly. AORGCJ is tracked when 'ALL' tagclass is invoked, however, no calculations for this species were added to aqchem. Similarly MGLY is missing from ISAM gas species, but it is a precursor to AORGCJ.

ISAM crashes in debug mode with the 'TAG CLASSES |ALL' configuration.

Ground level PROD/LOSS calculation is incorrect in layer 1.

Summary of Impact:
Should have no impact on CMAQ concentrations. ISAM output now performs calculations as directed when in PM_TOT tagclass mode and more correctly calculates attribution of AORGCJ and both standard and debug compilations. The necessary addition of MGLY to the ISAM species lists may slightly impact ozone chemistry apportionment in some ISAM applications.

Tests conducted:
This PR passes the following build and run checks:

Compilers: Intel, GNU, Portland Group
Compile Mode: Optimized, Debug
Model Scenario: 2016 Southeast U.S. Benchmark
Tests conducted have been on the 2018 benchmark domain and fortran compiler in debug mode. More extensive evaluation was performed for hemispheric EQUATES ISAM application comparing based release version and this update.

Here is a spatial comparison of differences in tags for ATOTIJ and AORGCJ for the new and old code. This shows that the updated code does not always produce higher tag contributions (except for AORGCJ), indicating that the changes to the vdiff code can impact a number of different tags and species. For example, many tags show decreases rather than increases west of India for ATOTIJ, despite the addition of non-zero AORGCJ (note: V54P in the plot labels below is equivalent to BASE):

![image](https://user-images.githubusercontent.com/17143709/233457083-df1acd89-33bb-4952-8534-a4dd7a872d76.png)
![image](https://user-images.githubusercontent.com/17143709/233457135-d37cdd0a-bddc-4560-9d9b-880369586223.png)
Finally, this set of plots compares the sum of tags from the two runs not only to each other, but also to the bulk concentrations from the ACONC files from the corresponding runs
![image](https://user-images.githubusercontent.com/17143709/233457247-57329ad2-db7e-4cf0-8428-b4e21a113fb9.png)

