### PR TITLE
  fixed a bug in creating u and v components

### DIFF
--- a/CCTM/src/twoway/twoway_aqprep.F90
+++ b/CCTM/src/twoway/twoway_aqprep.F90
@@ -111,6 +111,8 @@ SUBROUTINE aqprep (grid, config_flags, t_phy_wrf, p_phy_wrf, rho_wrf,     &
 !           26 Jul 2022  (David Wong)
 !              -- Added a prefix tw_ for these variables: sc, ec, sr, er sc_d, ec_d,
 !                 sr_d, and er_d to avoid naming conflicts
+!           16 Mar 2023  (David Wong)
+!              -- fixed a bug in creating u and v components
 !===============================================================================
 
   USE module_domain                                ! WRF module
@@ -1206,11 +1208,6 @@ SUBROUTINE aqprep (grid, config_flags, t_phy_wrf, p_phy_wrf, rho_wrf,     &
 
         ENDDO
      ENDDO
-
-  metcro3d_data_wrf (:,:,1:nlays,15) = zf (:,:,1:nlays)
-
-  metcro3d_data_wrf (:,:,1:nlays,16) = zf (:,:,1:nlays)
-
   ENDDO
 
   metcro3d_data_wrf (:,:,1:nlays,14) = zf (:,:,1:nlays)


### PR DESCRIPTION
  On branch update_54

**Contact:**  
David Wong US EPA 

**Type of code change:** 
bug fix

**Description of changes:**  

Fixed a bug in creating u and v components by removing the following two lines

  metcro3d_data_wrf (:,:,1:nlays,15) = zf (:,:,1:nlays)
  metcro3d_data_wrf (:,:,1:nlays,16) = zf (:,:,1:nlays)

which overwrote the proper calculations:

   metcro3d_data_wrf (c,r,kk,15) = grid%u_phy(ii,kk,jj)   ! store u wind component on mass point
   metcro3d_data_wrf (c,r,kk,16) = grid%v_phy(ii,kk,jj)   ! store v wind component on mass point

**Issue:**  
N/A

**Summary of Impact:**  
Wind u and v components were incorrectly represented by level high. In turns it impacted the wind speed calculation as well as the plume rise calculation.

**Tests conducted:**  
A one day test was conducted based on the NE 2018 Benchmark dataset. Here are some snapshot of the difference (new - old) with respect to four variables: O3, ASO4J, SWDOWN, and T2.

![2018_07_01_o3](https://user-images.githubusercontent.com/17147652/234113363-8c6f7100-bb80-4265-a2c8-ed589f12ecff.png)

![2018_07_01_aso4j](https://user-images.githubusercontent.com/17147652/234113407-30e99e1f-3085-4a44-b3ec-a1d788b95e27.png)

![2018_07_01_swdown](https://user-images.githubusercontent.com/17147652/234113423-bb1d214b-e03c-42c4-a736-f5414c886e8f.png)

![2018_07_01_t2](https://user-images.githubusercontent.com/17147652/234113449-c4907b7c-09c1-41d3-9127-819c94e6d723.png)
