### PR TITLE
Adding important Mercator parameter (truelat1) to GRIDDESC, so is congruent with PROJ, WRF and documentation.

### DIFF
--- a/PREP/mcip/src/ll2xy_merc.f90
+++ b/PREP/mcip/src/ll2xy_merc.f90
@@ -27,6 +27,7 @@ SUBROUTINE ll2xy_merc (phi, lambda, truelat1, lambda0, xx, yy)
 ! Revised:  23 Sep 2009  Original version.  (T. Otte)
 !           12 Feb 2010  Removed unused variable FAC.  (T. Otte)
 !           07 Sep 2011  Updated disclaimer.  (T. Otte)
+!           09 May 2023  Equation corrections based on PROJ documentation. (R. Espada)
 !-------------------------------------------------------------------------------
 
   USE const, ONLY: rearth

--- a/PREP/mcip/src/ll2xy_merc.f90
+++ b/PREP/mcip/src/ll2xy_merc.f90
@@ -16,7 +16,7 @@
 !  subject to their copyright restrictions.                                    !
 !------------------------------------------------------------------------------!
 
-SUBROUTINE ll2xy_merc (phi, lambda, lambda0, xx, yy)
+SUBROUTINE ll2xy_merc (phi, lambda, truelat1, lambda0, xx, yy)
 
 !-------------------------------------------------------------------------------
 ! Name:     Latitude-Longitude to (X,Y) for Mercator Projection
@@ -46,6 +46,9 @@ SUBROUTINE ll2xy_merc (phi, lambda, lambda0, xx, yy)
   REAL,          INTENT(OUT)   :: xx      ! X-coordinate from origin
   REAL,          INTENT(OUT)   :: yy      ! Y-coordinate from origin
 
+  REAL(8)                      :: k0
+  REAL,          INTENT(IN)    :: truelat1
+  REAL(8)                      :: truelat1rad
 !-------------------------------------------------------------------------------
 ! Compute constants.
 !-------------------------------------------------------------------------------
@@ -63,8 +66,11 @@ SUBROUTINE ll2xy_merc (phi, lambda, lambda0, xx, yy)
   phirad     = DBLE(phi)     * deg2rad  ! convert degrees to radians
   lambdarad  = DBLE(lambda)  * deg2rad  ! convert degrees to radians
   lambda0rad = DBLE(lambda0) * deg2rad  ! convert degrees to radians
+  truelat1rad= DBLE(truelat1)* deg2rad  ! convert degrees to radians
 
-  xx  = REAL( drearth * (lambdarad - lambda0rad) )
-  yy  = REAL( drearth * DLOG( DTAN( piover4 + (phirad/2.0d0) ) ) )
+  k0=DCOS(DBLE(truelat1rad))
+
+  xx  =  REAL( k0 * drearth * (lambdarad - lambda0rad) )
+  yy  =  REAL( k0 * drearth * DLOG( DTAN( piover4 + (phirad/2.0d0) ) ) )
 
 END SUBROUTINE ll2xy_merc

--- a/PREP/mcip/src/rdwrfem.f90
+++ b/PREP/mcip/src/rdwrfem.f90
@@ -2191,7 +2191,7 @@ SUBROUTINE rdwrfem (mcip_now)
             yyin = met_yyctr -  &
                    ( met_rjctr_dot - (FLOAT(j) + yoff) ) * met_resoln
 
-            CALL xy2ll_merc (xxin, yyin, met_proj_clon,  &
+            CALL xy2ll_merc (xxin, yyin, met_tru1, met_proj_clon,  &
                              latdot(i,j), londot(i,j))
 
             mapdot(i,j) = mapfac_merc (latdot(i,j))
@@ -2213,7 +2213,7 @@ SUBROUTINE rdwrfem (mcip_now)
               yyin = met_yyctr -  &
                      ( met_rjctr_dot - (FLOAT(j) + yoff) ) * met_resoln
 
-              CALL xy2ll_merc (xxin, yyin, met_proj_clon,  &
+              CALL xy2ll_merc (xxin, yyin, met_tru1, met_proj_clon,  &
                                latu(i,j), lonu(i,j))
 
               mapu(i,j) = mapfac_merc (latu(i,j))
@@ -2233,7 +2233,7 @@ SUBROUTINE rdwrfem (mcip_now)
               yyin = met_yyctr -  &
                      ( met_rjctr_dot - (FLOAT(j) + yoff) ) * met_resoln
 
-              CALL xy2ll_merc (xxin, yyin, met_proj_clon,  &
+              CALL xy2ll_merc (xxin, yyin, met_tru1, met_proj_clon,  &
                                latv(i,j), lonv(i,j))
 
               mapv(i,j) = mapfac_merc (latv(i,j))

--- a/PREP/mcip/src/setup_wrfem.f90
+++ b/PREP/mcip/src/setup_wrfem.f90
@@ -494,7 +494,7 @@ SUBROUTINE setup_wrfem (cdfid, ctmlays)
       met_cone_fac = 0.0                      ! cone factor
       met_ref_lat  = -999.0                   ! not used
 
-      CALL ll2xy_merc (met_cen_lat, met_cen_lon, met_proj_clon,  &
+      CALL ll2xy_merc (met_cen_lat, met_cen_lon,met_tru1, met_proj_clon,  &
                        met_xxctr, met_yyctr)
     
     CASE DEFAULT

--- a/PREP/mcip/src/setup_wrfem.f90
+++ b/PREP/mcip/src/setup_wrfem.f90
@@ -488,7 +488,7 @@ SUBROUTINE setup_wrfem (cdfid, ctmlays)
                      met_xxctr, met_yyctr)
     
     CASE (3)  ! Mercator
-      met_p_alp_d  = 0.0                      ! lat of coord origin [deg]
+      met_p_alp_d  = met_tru1 !0.0            ! lat of coord origin [deg]
       met_p_bet_d  = 0.0                      ! (not used)
       met_p_gam_d  = met_proj_clon            ! lon of coord origin [deg]
       met_cone_fac = 0.0                      ! cone factor

--- a/PREP/mcip/src/xy2ll_merc.f90
+++ b/PREP/mcip/src/xy2ll_merc.f90
@@ -16,7 +16,7 @@
 !  subject to their copyright restrictions.                                    !
 !------------------------------------------------------------------------------!
 
-SUBROUTINE xy2ll_merc (xx, yy, lambda0, phi, lambda)
+SUBROUTINE xy2ll_merc (xx, yy, truelat1, lambda0, phi, lambda)
 
 !-------------------------------------------------------------------------------
 ! Name:     (X,Y) to Latitude-Longitude for Polar Stereographic Projection
@@ -49,6 +49,8 @@ SUBROUTINE xy2ll_merc (xx, yy, lambda0, phi, lambda)
   REAL,          INTENT(IN)    :: yy         ! Y-coordinate from origin
   REAL(8)                      :: yyd
 
+  REAL(8)                      :: k0
+  REAL,          INTENT(IN)    :: truelat1 
 !-------------------------------------------------------------------------------
 ! Compute constants.
 !-------------------------------------------------------------------------------
@@ -61,6 +63,7 @@ SUBROUTINE xy2ll_merc (xx, yy, lambda0, phi, lambda)
 
   drearth = DBLE(rearth)
 
+  k0=DCOS(DBLE(truelat1))
 !-------------------------------------------------------------------------------
 ! Set up geometric constants.
 !-------------------------------------------------------------------------------
@@ -72,7 +75,7 @@ SUBROUTINE xy2ll_merc (xx, yy, lambda0, phi, lambda)
 ! Compute latitude (PHI).
 !-------------------------------------------------------------------------------
 
-  phirad  = ( 2.0d0 * DATAN ( DEXP(yyd/drearth) ) ) - piover2
+  phirad  = ( 2.0d0 * DATAN ( DEXP(yyd/drearth/k0) ) ) - piover2
   phi     = REAL( phirad * rad2deg )
 
 !-------------------------------------------------------------------------------
@@ -80,7 +83,7 @@ SUBROUTINE xy2ll_merc (xx, yy, lambda0, phi, lambda)
 !-------------------------------------------------------------------------------
 
   lambda0rad = DBLE(lambda0) * deg2rad
-  lambdarad  = lambda0rad + xxd/drearth
+  lambdarad  = lambda0rad + xxd/drearth/k0
   lambda     = REAL( lambdarad * rad2deg )
 
 END SUBROUTINE xy2ll_merc

--- a/PREP/mcip/src/xy2ll_merc.f90
+++ b/PREP/mcip/src/xy2ll_merc.f90
@@ -26,6 +26,7 @@ SUBROUTINE xy2ll_merc (xx, yy, truelat1, lambda0, phi, lambda)
 !           by Frederick Pearson, II (1990), pp. 190-192.
 ! Revised:  18 Sep 2009  Original version.  (T. Otte)
 !           07 Sep 2011  Updated disclaimer.  (T. Otte)
+!           09 May 2023  Equation corrections based on PROJ documentation. (R. Espada)
 !-------------------------------------------------------------------------------
 
   USE const, ONLY: rearth
@@ -63,7 +64,7 @@ SUBROUTINE xy2ll_merc (xx, yy, truelat1, lambda0, phi, lambda)
 
   drearth = DBLE(rearth)
 
-  k0=DCOS(DBLE(truelat1))
+  k0=DCOS(DBLE(truelat1*deg2rad))
 !-------------------------------------------------------------------------------
 ! Set up geometric constants.
 !-------------------------------------------------------------------------------
@@ -75,7 +76,7 @@ SUBROUTINE xy2ll_merc (xx, yy, truelat1, lambda0, phi, lambda)
 ! Compute latitude (PHI).
 !-------------------------------------------------------------------------------
 
-  phirad  = ( 2.0d0 * DATAN ( DEXP(yyd/drearth/k0) ) ) - piover2
+  phirad  = piover2 - 2.0d0 * DATAN ( DEXP(- yyd/drearth/k0) ) 
   phi     = REAL( phirad * rad2deg )
 
 !-------------------------------------------------------------------------------


### PR DESCRIPTION
Hi, 

I noticed that GRIDDESC doesn't contains the "truelat1" parameter for mercator projection (is allways set to 0). This parameter is quite important, in fact is the only parameter needded in the WRF namelist when this projection is choosen.

So for the sake of don't miss information and to be congruent with documentation I think it worth adding it.