### PR TITLE
Fix functionality of RBSTATS when using ROS3

### DIFF
--- a/CCTM/src/gas/ros3/rbdriver.F
+++ b/CCTM/src/gas/ros3/rbdriver.F
@@ -184,7 +184,7 @@ C..Local Variables:
       INTEGER, ALLOCATABLE, SAVE         :: STAT_SUM( :,:,:,: )
       INTEGER  EDATE, ETIME
 
-      REAL     ALLOCATABLE, SAVE         :: STATOUT( :, :, : )
+      REAL,    ALLOCATABLE, SAVE         :: STATOUT( :, :, : )
 
 #endif
 
@@ -745,8 +745,8 @@ ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
             IF ( .NOT. WRITE3( CTM_RBSTATS_1, VSTATS( S ),
      &            EDATE, ETIME, STATOUT ) ) THEN
-               XMSG = 'Could not write ' // CTM_RBSTATS_1 // ' file'
-               CALL M3EXIT( PNAME, JDATE, JTIME, XMSG, XSTAT1 )
+               MSG = 'Could not write ' // CTM_RBSTATS_1 // ' file'
+               CALL M3EXIT( PNAME, JDATE, JTIME, MSG, XSTAT1 )
             END IF  
 
          END DO


### PR DESCRIPTION
**Contact:**  
Simon Rosanka, University of California, Irvine (UCI)

**Type of code change:**   
bug fix

**Description of changes:**
Compiling CMAQ crashes when using the conditional `rbstats` option due to incorrectly referencing `XMSG` as error message. This was fixed by referencing `MSG`, which is used for error messages within `rbdriver.F`. In addition, the Intel compiler complained about the incorrect declaration of `STATOUT`, which was fixed as well. 

**Issue:**  
Does not resolve any known issue. The frozen `main` branch is also affected by this issue.

**Summary of Impact:**  
No impact on model predictions.  

**Tests conducted:**  
These code changes were tested by compiling CMAQ using the Intel compiler with OpenMPI, followed by a standard run test. Following these changes, the `rbstats` output is created as intended.