### PR TITLE
Update CMAQv5.2.1 run script

### DIFF
--- a/CCTM/scripts/run_cctm.csh
+++ b/CCTM/scripts/run_cctm.csh
@@ -141,7 +141,7 @@ setenv PA_BLEV_ELEV "1  4"
 setenv IOAPI_LOG_WRITE F     #> turn on excess WRITE3 logging [ options: T | F ]
 setenv FL_ERR_STOP N         #> stop on inconsistent input files
 setenv PROMPTFLAG F          #> turn on I/O-API PROMPT*FILE interactive mode [ options: T | F ]
-setenv IOAPI_OFFSET_64 NO    #> support large timestep records (>2GB/timestep record) [ options: YES | NO ]
+setenv IOAPI_OFFSET_64 YES    #> support large timestep records (>2GB/timestep record) [ options: YES | NO ]
 setenv CTM_EMISCHK N         #> Abort CMAQ if missing surrogates from emissions Input files
 
 #> Aerosol Diagnostic Controls


### PR DESCRIPTION
**Type of code change:**   
Correct run script option

**Description of changes:**   
The sample run script released with CMAQv5.2.1 had IOAPI_OFFSET_64 incorrectly set to NO.  This is now changed to YES. 

**Issue:**  
This issue was identified on the CMAS User Forum: https://forum.cmascenter.org/t/error-running-cctm-of-cmaq5-2-1/4442

**Summary of Impact:**  
The updated run script will avoid model crashes such as what was described in the user forum post. 




