### PR TITLE
Corrected molecular weight of HGIIGAS as 271.5 g/mol rather than 200.6.

### DIFF
--- a/CCTM/src/MECHS/mechanism_information/cb6r3_ae7_aq/cb6r3_ae7_aq_species_table.md
+++ b/CCTM/src/MECHS/mechanism_information/cb6r3_ae7_aq/cb6r3_ae7_aq_species_table.md
@@ -46,7 +46,7 @@
 | HCO3              | radical from HO2 reactions with formaldehyde                                 | 63                   | E                      |
 | HG                | elemental mercury                                                            | 200.6                | E                      |
 | HGIIAER           | precursor of aerosol divalent mercury                                        | 200.6                | E                      |
-| HGIIGAS           | divalent mercury                                                             | 200.6                | E                      |
+| HGIIGAS           | divalent mercury                                                             | 271.5                | E                      |
 | HNO3              | nitric acid                                                                  | 63                   | E                      |
 | HO2               | hydroperoxy radical                                                          | 33                   | E                      |
 | HOCL              | hypochlorous acid                                                            | 52.5                 | E                      |

--- a/CCTM/src/MECHS/mechanism_information/cb6r5hap_ae7_aq/cb6r5hap_ae7_aq_species_table.md
+++ b/CCTM/src/MECHS/mechanism_information/cb6r5hap_ae7_aq/cb6r5hap_ae7_aq_species_table.md
@@ -47,7 +47,7 @@
 | HCO3              | radical from HO2 reactions with formaldehyde                                 | 63                   | E                      |
 | HG                | elemental mercury                                                            | 200.6                | E                      |
 | HGIIAER           | precursor of aerosol divalent mercury                                        | 200.6                | E                      |
-| HGIIGAS           | divalent mercury                                                             | 200.6                | E                      |
+| HGIIGAS           | divalent mercury                                                             | 271.5                | E                      |
 | HNO3              | nitric acid                                                                  | 63                   | E                      |
 | HO2               | hydroperoxy radical                                                          | 33                   | E                      |
 | HOCL              | hypochlorous acid                                                            | 52.5                 | E                      |

--- a/CCTM/src/MECHS/mechanism_information/cb6r5m_ae7_aq/cb6r5m_ae7_aq_species_table.md
+++ b/CCTM/src/MECHS/mechanism_information/cb6r5m_ae7_aq/cb6r5m_ae7_aq_species_table.md
@@ -56,7 +56,7 @@
 | HCO3              | radical from HO2 reactions with formaldehyde                                 | 63                   | E                      |
 | HG                | elemental mercury                                                            | 200.6                | E                      |
 | HGIIAER           | precursor of aerosol divalent mercury                                        | 200.6                | E                      |
-| HGIIGAS           | divalent mercury                                                             | 200.6                | E                      |
+| HGIIGAS           | divalent mercury                                                             | 271.5                | E                      |
 |HI                 | hydrogen iodide       |  127.9    | E |
 | HNO3              | nitric acid                                                                  | 63                   | E                      |
 | HO2               | hydroperoxy radical                                                          | 33                   | E                      |


### PR DESCRIPTION
This is a documentation update and has no impact on model results. 

Many thanks to Shengpo on the CMAS User Forum for identifying this typo. 
https://forum.cmascenter.org/t/error-of-the-molecular-weight-for-hgiigas/4673

This issue was confirmed by J. Bash and B. Hutzell who provided this reference for the molecular weight of HGIIGAS: 
Deanna L. Donohoue, Dieter Bauer, and Anthony J. Hynes. The Journal of Physical Chemistry A 2005 109 (34), 7732-7741. DOI: 10.1021/jp051354l




