### PR TITLE
fix bug in calculation of PMF_OC

### DIFF
--- a/CCTM/src/driver/ELMO_PROC.F
+++ b/CCTM/src/driver/ELMO_PROC.F
@@ -2577,8 +2577,8 @@
             ! just carbon mass
             VAL = 0.0
             DO IOA = 1,N_OA_NotTracers
-                ! Just Select Secondary Species
-                IF ( .NOT. OASPC( IOA )%PRIMARY ) THEN  
+                ! Skip primary species and those with negative OM:OC
+                IF ( OASPC( IOA )%OMtoOC .GT. 0.0 .AND. .NOT. OASPC( IOA )%PRIMARY ) THEN
                       VAL = VAL + SUM( AEROSPC_CONC( MAP_OAtoAERO(IOA),: ),
      &                            MASK = AEROMODE(:)%FINE_MASK ) 
      &                          / OASPC( IOA )%OMtoOC
@@ -2592,9 +2592,12 @@
             ! just carbon mass
             VAL = 0.0
             DO IOA = 1,N_OA_NotTracers
-               VAL = VAL + SUM( AEROSPC_CONC( MAP_OAtoAERO(IOA),: ),
-     &                     MASK = AEROMODE(:)%FINE_MASK ) 
-     &                   / OASPC( IOA )%OMtoOC
+               ! Skip species with negative OM:OC
+               IF ( OASPC( IOA )%OMtoOC .GT. 0.0 ) THEN
+                  VAL = VAL + SUM( AEROSPC_CONC( MAP_OAtoAERO(IOA),: ),
+     &                        MASK = AEROMODE(:)%FINE_MASK ) 
+     &                      / OASPC( IOA )%OMtoOC
+               END IF
             END DO
             OUTVAL = VAL  
 


### PR DESCRIPTION
**Contact:**  
Chris Nolte, US EPA  

**Type of code change:**   
Bug fix

**Description of changes:**   
This fixes a bug in the calculation of the ELMO parameter PMF_OC, which inadvertently subtracts off non-carbonaceous mass that should instead be skipped. Because PMF_NCOM is calculated using the value of PMF_OC, this bug affects PMF_NCOM as well. 

**Issue:**  
Resolves issue [213](https://github.com/USEPA/CMAQ/issues/213) 

**Summary of Impact:**  
This change affects only PMF_OC and PMF_NCOM in the ELMO/AELMO outputs. There is no change in CONC/ACONC, CGRID, or deposition outputs. If using the default treatment of semivolatile organics, in which POC and PNCOM are mapped to VSVPO1, VSVPO2, VSVPO3, and VIVPO1 (see CMAQ_Control_DESID_\<MECH\>.nml), then the impact is minimal. However, if using the older method of treating POA as nonvolatile, with POC mapped to APOC and PNCOM mapped to APNCOM, then this bug has a significant impact on PMF_OC and PMF_NCOM.

**Testing Performed:**
This was tested against the research branch by running one day of the 2018_12NE3 benchmark case using the intel21.4 compiler. CGRID files were unchanged. On the research branch, PMF_OC did not equal the sum of PMF_POC and PMF_SOC, as it should. Instead, PMF_OC was less by the value of APNCOMI+APNCOMJ. Using the modified code in this PR resulted in the correct result, where PMF_OC = PMF_POC + PMF_SOC.

This code change was separately tested by running the bld_check script on both the 5.4+ branch (prior to this fix) and the modified code, executing the first day of the 2016_12SE1 benchmark case. The code compiled and ran in standard and debug modes using the intel21.4, gcc9.5, and pgi22.4 compilers. CGRID files were unchanged across each of the six pairs of runs. Additionally, I verified that PMF_OC = PMF_POC + PMF_SOC in each of the six runs using the modified code.

