### PR TITLE
Minor fixes to ELMO output algorithms

### DIFF
--- a/CCTM/src/MECHS/cb6r3_ae7_aq/SpecDef_Conc_cb6r3_ae7_aq.txt
+++ b/CCTM/src/MECHS/cb6r3_ae7_aq/SpecDef_Conc_cb6r3_ae7_aq.txt
@@ -1,0 +1,342 @@
+!#start   YYYYJJJ  010000
+!#end     YYYYJJJ  000000
+#layer         1
+
+/
+! This Species Definition File is for Use with the COMBINE tool built for 
+! post-processing CMAQ output. It is compatible with CMAQv5.4.
+! Date: May 12 2017
+
+! Output variables that begin with 'PM' represent those in which a size cut was 
+! applied based on modeled aerosol mode parameters.  For example, PM25_NA is all 
+! sodium that falls below 2.5 um diameter. These 'PM' variables are used for 
+! comparisons at IMPROVE and CSN sites.
+
+! Output variables that begin with 'PMAMS' represent the mass that would have
+! been detected  by an Aerosol Mass Spectrometer.
+
+! Output variables beginning with 'A' (aside from AIR_DENS) represent a 
+! combination of aerosol species in which no size cut was applied.  For example, 
+! ASO4IJ is the sum of i-mode and j-mode sulfate.  These 'A' variables are used 
+! for comparisons at CASTNet sites.
+
+! Output variables beginning with 'PMC' refer to the coarse fraction of total PM,
+! computed by summing all modes and subtracting the PM2.5 fraction.  These 'PMC'
+! variables are used for comparisons at SEARCH sites.
+
+! This Species Definition File is just for use with the uncoupled, offline CMAQ,
+! model. If you are processing WRF-CMAQ results, a different Species Definition
+! file is required.
+
+/ File [1]: CMAQ conc/aconc file
+/ File [2]: METCRO3D file
+/ File [3]: ELMO/AELMO file
+/ File [4]: METCRO2D file
+/
+/new species    ,units     ,expression
+                                         
+!-------------------------------------------!
+!------------- Meteorology -----------------!
+!-------------------------------------------!
+AIR_DENS        ,kg m-3    ,DENS[2]
+RH              ,%         ,100.00*RH[3]
+SFC_TMP         ,C         ,(TEMP2[4]-273.15)
+PBLH            ,m         ,PBL[4]
+SOL_RAD         ,W m-2     ,RGRND[4]
+precip          ,cm        ,RC[4]>=0 ? RN[4]+RC[4] : RN[4]
+WSPD10          ,m s-1     ,WSPD10[4]
+WDIR10          ,deg       ,WDIR10[4]
+
+!-------------------------------------------!
+!--------------- Gases ---------------------!
+!-------------------------------------------!
+ALD2            ,ppbV      ,1000.0*ALD2[1]
+BENZENE         ,ppbV      ,1000.0*BENZENE[1]
+CO              ,ppbV      ,1000.0*CO[1]
+ETH             ,ppbV      ,1000.0*ETH[1]
+ETHA            ,ppbV      ,1000.0*ETHA[1]
+FORM            ,ppbV      ,1000.0*FORM[1]
+H2O2            ,ppbV      ,1000.0*H2O2[1]
+HNO3            ,ppbV      ,1000.0*HNO3[1]
+HNO3_UGM3       ,ug m-3    ,1000.0*(HNO3[1]*2.1756*DENS[2])
+HONO            ,ppbV      ,1000.0*HONO[1]
+HOX             ,ppbV      ,1000.0*(OH[1]+HO2[1])
+OH              ,ppbV      ,1000.0*(OH[1])
+ISOP            ,ppbV      ,1000.0*ISOP[1]
+N2O5            ,ppbV      ,1000.0*N2O5[1]
+NH3             ,ppbV      ,1000.0*NH3[1]
+NH3_UGM3        ,ug m-3    ,1000.0*(NH3[1]*0.5880*DENS[2])
+NHX             ,ug m-3    ,1000.0*(NH3[1]*0.5880*DENS[2])+ANH4I[1]+ANH4J[1]+ANH4K[1]
+NO              ,ppbV      ,1000.0*NO[1]
+NO2             ,ppbV      ,1000.0*NO2[1]
+NOX             ,ppbV      ,1000.0*(NO[1] + NO2[1])
+ANO3_PPB        ,ppbV      ,(ANO3I[1]+ANO3J[1]+ANO3K[1])/(DENS[2]*(62.0/28.97))
+NTR             ,ppbV      ,1000.0*(NTR1[1]+NTR2[1]+INTR[1])
+PANS            ,ppbV      ,1000.0*(PAN[1]+PANX[1]+OPAN[1])
+NOY             ,ppbV      ,1000.0* (NO[1]+NO2[1]+NO3[1]+2*N2O5[1]+HONO[1]+HNO3[1]+PNA[1] \
+                                     +CRON[1]+CLNO2[1]+CLNO3[1]) \
+                                     +PANS[0]+NTR[0]+ANO3_PPB[0]
+O3              ,ppbV      ,1000.0*O3[1]
+SO2             ,ppbV      ,1000.0*SO2[1]
+SO2_UGM3        ,ug m-3    ,1000.0*(SO2[1]*2.2118*DENS[2])
+TERP            ,ppbV      ,1000.0*TERP[1]
+TOL             ,ppbV      ,1000.0*TOL[1]
+XYL             ,ppbV      ,1000.0*XYLMN[1]
+
+!Additional Toxic gases
+!ACROLEIN        ,ug m-3    ,1000.0*(ACROLEIN[1]*1.9365*DENS[2])
+!ACRO_PRIMARY    ,ug m-3    ,1000.0*(ACRO_PRIMARY*1.9365*DENS[2])
+!ALD2_PRIMARY    ,ug m-3    ,1000.0*(ALD2_PRIMARY[1]*1.5188*DENS[2])
+!FORM_PRIMARY    ,ug m-3    ,1000.0*(FORM_PRIMARY[1]*1.0356*DENS[2])
+!BUTADIENE13     ,ug m-3    ,1000.0*(BUTADIENE13[1]*1.8674*DENS[2])
+!HCL             ,ppbV      ,1000.0*HCL[1]
+!TOLUENE         ,ppbV      ,1000.0*TOLU[1]
+
+!Mercuric gas species
+!HG_0            ,ng/m3     ,1000.0*(HG[1]*8.3330*DENS[2]*1000.0)       
+!HG_II           ,ng/m3     ,1000.0*(HGIIGAS[1]*8.3330*DENS[2]*1000.0) 
+
+!! Unused Gases. Presented Here for illustration. Users can uncomment
+!! them if they choose.
+!ALDX            ,ppbV      ,1000.0*ALDX[1]
+!IOLE            ,ppbV      ,1000.0*IOLE[1]
+!OLE             ,ppbV      ,1000.0*OLE[1]
+!PAR             ,ppbV      ,1000.0*PAR[1]
+!PAN             ,ppbV      ,1000.0*PAN[1]
+!SULF            ,ppbV      ,1000.0*SULF[1]
+! emitted VOCs
+!VOC             ,ppbC      ,1000.0* (PAR[1] +2.0*ETHA[1] +3.0*PRPA[1] +MEOH[1]\
+!                            +2.0*ETH[1] +2.0*ETOH[1] +2.0*OLE[1] +3.0*ACET[1] \
+!                            +7.0*TOL[1] +8.0*XYLMN[1] +6.0*BENZENE[1] \
+!                            +FORM[1] +3.0*GLY[1] +4.0*KET[1] +2.0*ETHY[1] \
+!                           +2.0*ALD2[1] + 4.0*IOLE[1] + 2.0*ALDX[1]  \
+!                           +5.0*ISOP[1] + 10.0*TERP[1]+ 10.0*NAPH[1] +10.*APIN[1])
+
+!-------------------------------------------!
+!--------------- Particles -----------------!
+!-------------------------------------------!
+!! Crustal Elements
+AFEJ            ,ug m-3    ,AFEJ[1]
+AALJ            ,ug m-3    ,AALJ[1]
+ASIJ            ,ug m-3    ,ASIJ[1]
+ATIJ            ,ug m-3    ,ATIJ[1]
+ACAJ            ,ug m-3    ,ACAJ[1]
+AMGJ            ,ug m-3    ,AMGJ[1]
+AKJ             ,ug m-3    ,AKJ[1]
+AMNJ            ,ug m-3    ,AMNJ[1]
+ASOILJ          ,ug m-3    ,2.20*AALJ[1]+2.49*ASIJ[1]+1.63*ACAJ[1]+2.42*AFEJ[1]+1.94*ATIJ[1]
+
+!! Non-Crustal Inorganic Particle Species
+AHPLUSIJ        ,umol m-3  ,(AH3OPI[1]+AH3OPJ[1])*1.0/19.0
+ANAK            ,ug m-3    ,0.8373*ASEACAT[1]+0.0626*ASOIL[1]+0.0023*ACORS[1]
+AMGK            ,ug m-3    ,0.0997*ASEACAT[1]+0.0170*ASOIL[1]+0.0032*ACORS[1]
+AKK             ,ug m-3    ,0.0310*ASEACAT[1]+0.0242*ASOIL[1]+0.0176*ACORS[1]
+ACAK            ,ug m-3    ,0.0320*ASEACAT[1]+0.0838*ASOIL[1]+0.0562*ACORS[1]
+ACLIJ           ,ug m-3    ,ACLI[1]+ACLJ[1]
+AECIJ           ,ug m-3    ,AECI[1]+AECJ[1]
+ANAIJ           ,ug m-3    ,ANAJ[1]+ANAI[1]
+ANO3IJ          ,ug m-3    ,ANO3I[1]+ANO3J[1]
+ANO3K           ,ug m-3    ,ANO3K[1]
+TNO3            ,ug m-3    ,2175.6*(HNO3[1]*DENS[2])+ANO3I[1]+ANO3J[1]+ANO3K[1]
+ANH4IJ          ,ug m-3    ,ANH4I[1]+ANH4J[1]
+ANH4K           ,ug m-3    ,ANH4K[1]
+ASO4IJ          ,ug m-3    ,ASO4I[1]+ASO4J[1]
+ASO4K           ,ug m-3    ,ASO4K[1]
+
+!! Organic Particle Species
+APOCI           ,ugC m-3   ,ALVPO1I[1]/1.39 + ASVPO1I[1]/1.32 + ASVPO2I[1]/1.26 \
+                            +APOCI[1]
+APOCJ           ,ugC m-3   ,ALVPO1J[1]/1.39 + ASVPO1J[1]/1.32 + ASVPO2J[1]/1.26 \
+                           +ASVPO3J[1]/1.21 + AIVPO1J[1]/1.17  + APOCJ[1]
+APOCIJ          ,ugC m-3   ,APOCI[0] + APOCJ[0]
+
+APOMI           ,ug m-3    ,ALVPO1I[1] + ASVPO1I[1] + ASVPO2I[1] + APOCI[1]    \
+                            +APNCOMI[1]
+APOMJ           ,ug m-3    ,ALVPO1J[1] + ASVPO1J[1] + ASVPO2J[1] + APOCJ[1]    \
+                           +ASVPO3J[1] + AIVPO1J[1]  + APNCOMJ[1]
+APOMIJ          ,ug m-3    ,APOMI[0] + APOMJ[0]
+
+ASOCI           ,ugC m-3   ,ALVOO1I[1]/2.27 + ALVOO2I[1]/2.06  \
+                           +ASVOO1I[1]/1.88 + ASVOO2I[1]/1.73
+ASOCJ           ,ugC m-3   ,AISO1J[1]/2.20  + AISO2J[1]/2.23  + AISO3J[1]/2.80  \
+                           +AMT1J[1]/1.67   + AMT2J[1]/1.67   + AMT3J[1]/1.72   \
+                           +AMT4J[1]/1.53   + AMT5J[1]/1.57   + AMT6J[1]/1.40   \
+                           +AMTNO3J[1]/1.90 + AMTHYDJ[1]/1.54                   \
+                           +AGLYJ[1]/2.13   + ASQTJ[1]/1.52                     \
+                           +AORGCJ[1]/2.00  + AOLGBJ[1]/2.10  + AOLGAJ[1]/2.50  \
+                           +ALVOO1J[1]/2.27 + ALVOO2J[1]/2.06 + ASVOO1J[1]/1.88 \
+                           +ASVOO2J[1]/1.73 + ASVOO3J[1]/1.60                   \
+                           +AAVB1J[1]/2.70  + AAVB2J[1]/2.35  + AAVB3J[1]/2.17  \
+                           +AAVB4J[1]/1.99 + APCSOJ[1]/2.00
+ASOCIJ          ,ugC m-3   ,ASOCI[0] + ASOCJ[0]
+
+ASOMI           ,ug m-3    ,ALVOO1I[1] + ALVOO2I[1] + ASVOO1I[1] + ASVOO2I[1] 
+ASOMJ           ,ug m-3    ,+AISO1J[1]+ AISO2J[1]  + AISO3J[1]              \
+                            +AMT1J[1]   + AMT2J[1]   + AMT3J[1]             \
+                            +AMT4J[1]   + AMT5J[1]   + AMT6J[1]             \
+                            +AMTNO3J[1] + AMTHYDJ[1]                        \
+                            +AGLYJ[1]   + ASQTJ[1]                          \
+                            +AORGCJ[1]  + AOLGBJ[1]  + AOLGAJ[1]            \
+                            +ALVOO1J[1] + ALVOO2J[1] + ASVOO1J[1]           \
+                            +ASVOO2J[1] + ASVOO3J[1] + APCSOJ[1]            \
+                            +AAVB1J[1]  + AAVB2J[1]  + AAVB3J[1]            \
+                            +AAVB4J[1]
+ASOMIJ          ,ug m-3    ,ASOMI[0] + ASOMJ[0]
+ 
+AOCI            ,ugC m-3    ,APOCI[0]  + ASOCI[0]
+AOCJ            ,ugC m-3    ,APOCJ[0]  + ASOCJ[0]
+
+AOCIJ           ,ugC m-3    ,APOCIJ[0] + ASOCIJ[0]
+
+
+AOMI            ,ug m-3     ,APOMI[0]  + ASOMI[0]
+AOMJ            ,ug m-3     ,APOMJ[0]  + ASOMJ[0]
+
+AOMIJ           ,ug m-3     ,APOMIJ[0] + ASOMIJ[0]
+
+!!! Anthropogenic-VOC Derived Organic Aerosol
+AORGAI          ,ug m-3    ,ALVOO1I[1] + ALVOO2I[1] + ASVOO1I[1]       \ 
+                           +ASVOO2I[1]
+AORGAJ          ,ug m-3    ,ALVOO1J[1] + ALVOO2J[1]                    \
+                           +ASVOO1J[1] + ASVOO2J[1] + ASVOO3J[1]       \
+                           +AAVB1J[1] + AAVB2J[1] + AAVB3J[1]          \
+                           +AAVB4J[1] + AOLGAJ[1] + APCSOJ[1]   
+AORGAIJ         ,ug m-3    ,AORGAI[0] + AORGAJ[0]                           
+
+!!! Biogenic-VOC Derived Organic Aerosol
+AORGBIJ         ,ug m-3    ,AMT1J[1] + AMT2J[1] + AMT3J[1] + AMT4J[1]  \
+                           +AMT5J[1] + AMT6J[1] + AMTNO3J[1]           \
+                           +AMTHYDJ[1] + AISO1J[1] + AISO2J[1]         \
+                           +AISO3J[1] + ASQTJ[1] + AOLGBJ[1] 
+
+!!! Cloud-Processed  SOA
+AORGCJ          ,ug m-3    ,AORGCJ[1]
+!!! Remaining SOA
+AGLYJ           ,ug m-3    ,AGLYJ[1]
+
+!!! OM/OC ratios
+AOMOCRAT_TOT    ,           ,AOMIJ[0]/AOCIJ[0]
+
+!! Total PM Aggregates
+ATOTI           ,ug m-3    ,ASO4I[1] + ANH4I[1] + ANO3I[1] + ANAI[1]   \
+                           +ACLI[1] + AECI[1] + AOMI[0] + AOTHRI[1] 
+ATOTJ           ,ug m-3    ,ASO4J[1] + ANH4J[1] + ANO3J[1] + ANAJ[1]   \
+                           +ACLJ[1] + AECJ[1] + AOMJ[0] + AOTHRJ[1]    \
+                           +AFEJ[1] + AALJ[1] + ASIJ[1] + ATIJ[1]      \
+                           +ACAJ[1] + AMGJ[1] + AKJ[1] + AMNJ[1]        
+                            
+ATOTK           ,ug m-3    ,ASO4K[1] + ANH4K[1] + ANO3K[1] + ACLK[1]   \
+                           +ACORS[1] + ASOIL[1] + ASEACAT[1]   
+ATOTIJ          ,ug m-3    ,ATOTI[0] + ATOTJ[0] 
+ATOTIJK         ,ug m-3    ,ATOTI[0] + ATOTJ[0] + ATOTK[0]
+
+!! Unspeciated PM including non-carbon organic mass
+AUNSPEC1IJ      ,ug m-3    ,ATOTIJ[0] - (ASO4IJ[0] + ANO3IJ[0]         \
+                                         +ANH4IJ[0] + ACLIJ[0]         \
+                                         +ANAIJ[0] + AECIJ[0]          \
+                                         +AOCIJ[0] + ASOILJ[0])       
+!! Non-Carbon Organic Mass
+ANCOMIJ         ,ug m-3    ,AOMIJ[0] - AOCIJ[0]
+
+!! Unspeciated PM excluding non-carbon organic mass
+AUNSPEC2IJ      ,ug m-3     ,AUNSPEC1IJ[0] - ANCOMIJ[0]
+
+!! AMS Projection of Output Concentrations
+PMAMS_CL        ,ug m-3    ,ACLI[1] *FAMSAIT[3] +ACLJ[1]*FAMSACC[3]+ACLK[1] *FAMSCOR[3]
+PMAMS_NH4       ,ug m-3    ,ANH4I[1]*FAMSAIT[3]+ANH4J[1]*FAMSACC[3]+ANH4K[1]*FAMSCOR[3]
+PMAMS_NO3       ,ug m-3    ,ANO3I[1]*FAMSAIT[3]+ANO3J[1]*FAMSACC[3]+ANO3K[1]*FAMSCOR[3]
+PMAMS_OA        ,ug m-3    ,AOMI[0] *FAMSAIT[3]+AOMJ[0] *FAMSACC[3]
+PMAMS_SO4       ,ug m-3    ,ASO4I[1]*FAMSAIT[3]+ASO4J[1]*FAMSACC[3]+ASO4K[1]*FAMSCOR[3]
+
+!! PM1 Cutoff Output
+PM1_TOT         ,ug m-3    ,ATOTI[0]*FPM1AIT[3]+ATOTJ[0]*FPM1ACC[3]+ATOTK[0]*FPM1COR[3]
+
+!! Unused PM1 Species. Included Here for demonstration
+!PM1_EC         ,ug m-3    ,AECI[1] *FPM1AIT[3] +AECJ[1] *FPM1ACC[3]
+!PM1_OC         ,ugC m-3   ,AOCI[0] *FPM1AIT[3] +AOCJ[0] *FPM1ACC[3]
+!PM1_OM         ,ug m-3    ,AOMI[0] *FPM1AIT[3] +AOMJ[0] *FPM1ACC[3]
+!PM1_SO4        ,ug m-3    ,ASO4I[1]*FPM1AIT[3] +ASO4J[1]*FPM1ACC[3] +ASO4K[1]*FPM1COR[3]
+!PM1_CL         ,ug m-3    ,ACLI[1] *FPM1AIT[3] +ACLJ[1] *FPM1ACC[3] +ACLK[1] *FPM1COR[3]
+!PM1_NA         ,ug m-3    ,ANAI[1] *FPM1AIT[3] +ANAJ[1] *FPM1ACC[3] +ANAK[0] *FPM1COR[3]
+!PM1_MG         ,ug m-3    ,                     AMGJ[1] *FPM1ACC[3] +AMGK[0] *FPM1COR[3]
+!PM1_K          ,ug m-3    ,                     AKJ[1]  *FPM1ACC[3] +AKK[0]  *FPM1COR[3]
+!PM1_CA         ,ug m-3    ,                     ACAJ[1] *FPM1ACC[3] +ACAK[0] *FPM1COR[3]
+!PM1_NH4        ,ug m-3    ,ANH4I[1] *FPM1AIT[3]+ANH4J[1]*FPM1ACC[3] +ANH4K[1]*FPM1COR[3]
+!PM1_NO3        ,ug m-3    ,ANO3I[1] *FPM1AIT[3]+ANO3J[1]*FPM1ACC[3] +ANO3K[1]*FPM1COR[3] 
+!PM1_SOIL       ,ug m-3    ,ASOILJ[0]*FPM1ACC[3]+(ASOIL[1]+ACORS[1])*FPM1COR[3]
+!PM1_UNSPEC1    ,ug m-3    ,PM1_TOT[0] - (PM1_CL[0] + PM1_EC[0]+ PM1_NA[0]  + PM1_NH4[0] +  \
+!                                         PM1_NO3[0]+ PM1_OC[0]+ PM1_SOIL[0]+ PM1_SO4[0] ) 
+!PM1_UNSPCRS    ,ug m-3    ,ATOTK[0] *FPM1COR[3] - (ASO4K[1]*FPM1COR[3] \
+!                                                  +ACLK[1]*FPM1COR[3]  \
+!                                                  +ANAK[0]*FPM1COR[3]  \
+!                                                  +AMGK[0]*FPM1COR[3]  \
+!                                                  +AKK[0]*FPM1COR[3]   \
+!                                                  +ACAK[0]*FPM1COR[3]  \
+!                                                  +ANH4K[1]*FPM1COR[3] \
+!                                                  +ANO3K[1]*FPM1COR[3]) 
+ 
+!! PM2.5 species computed using modeled size distribution
+PM25_HP         ,ug m-3    ,(AH3OPI[1]*FPM25AIT[3]+AH3OPJ[1]*FPM25ACC[3]+AH3OPK[1]*FPM25COR[3])*1.0/19.0
+PM25_CL         ,ug m-3    ,ACLI[1]*FPM25AIT[3]+ACLJ[1]*FPM25ACC[3]+ACLK[1]*FPM25COR[3]
+PM25_EC         ,ug m-3    ,AECI[1]*FPM25AIT[3]+AECJ[1]*FPM25ACC[3]
+PM25_NA         ,ug m-3    ,ANAI[1]*FPM25AIT[3]+ANAJ[1]*FPM25ACC[3]+ANAK[0]*FPM25COR[3]
+PM25_MG         ,ug m-3    ,                    AMGJ[1]*FPM25ACC[3]+AMGK[0]*FPM25COR[3]
+PM25_K          ,ug m-3    ,                    AKJ[1] *FPM25ACC[3]+AKK[0] *FPM25COR[3]
+PM25_CA         ,ug m-3    ,                    ACAJ[1]*FPM25ACC[3]+ACAK[0]*FPM25COR[3]
+PM25_NH4        ,ug m-3    ,ANH4I[1]*FPM25AIT[3]+ANH4J[1]*FPM25ACC[3]+ANH4K[1]*FPM25COR[3]
+PM25_NO3        ,ug m-3    ,ANO3I[1]*FPM25AIT[3]+ANO3J[1]*FPM25ACC[3]+ANO3K[1]*FPM25COR[3]
+PM25_OC         ,ugC m-3   ,AOCI[0] *FPM25AIT[3]+AOCJ[0]*FPM25ACC[3]
+PM25_OM         ,ug m-3    ,AOMI[0] *FPM25AIT[3]+AOMJ[0]*FPM25ACC[3]
+PM25_SOIL       ,ug m-3    ,ASOILJ[0]*FPM25ACC[3]+ASOIL[1]*FPM25COR[3]
+PM25_SO4        ,ug m-3    ,ASO4I[1]*FPM25AIT[3]+ASO4J[1]*FPM25ACC[3]+ASO4K[1]*FPM25COR[3]
+PM25_TOT        ,ug m-3    ,ATOTI[0]*FPM25AIT[3]+ATOTJ[0]*FPM25ACC[3]+ATOTK[0]*FPM25COR[3]
+PM25_UNSPEC1    ,ug m-3    ,PM25_TOT[0]-(PM25_CL[0]+PM25_EC[0]+PM25_NA[0]+PM25_NH4[0] \
+                           +PM25_NO3[0]+PM25_OC[0]+PM25_SOIL[0]+PM25_SO4[0])
+PM25_UNSPCRS    ,ug m-3    ,ATOTK[0]*FPM25COR[3] - (ASO4K[1]*FPM25COR[3] \
+                                                  +ACLK[1]*FPM25COR[3]  \
+                                                  +ANAK[0]*FPM25COR[3]  \
+                                                  +AMGK[0]*FPM25COR[3]  \
+                                                  +AKK[0]*FPM25COR[3]   \
+                                                  +ACAK[0]*FPM25COR[3]  \
+                                                  +ANH4K[1]*FPM25COR[3] \
+                                                  +ANO3K[1]*FPM25COR[3]) 
+
+
+!! Fine particle acidity (pH). pH is undefined if there is no aerosol water. 
+!Do not trust predictions when hourly water is <0.01 ug m-3. FINEPHF will 
+!have large negative value (-9.999E36) when pH is not to be trusted.
+!AH2OIJ         ,ug m-3     ,AH2OI[1]+AH2OJ[1]
+!HPMOLAL        ,mol kg-1   ,AHPLUSIJ[0]/AH2OIJ[0]*1000.0
+!ACIDITYTEMP    ,           ,-1*LOG10(HPMOLAL[0])
+!FINEPHF        ,           ,AH2OIJ[0]>0.01 ? ACIDITYTEMP[0] : -9.999E36
+
+!! PM10.0 and Coarse-Sized Species
+PM10            ,ug m-3    ,ATOTI[0]*FPM10AIT[3]+ATOTJ[0]*FPM10ACC[3]+ATOTK[0]*FPM10COR[3]
+
+PMC_CL          ,ug m-3    ,ACLI[1]*FPM10AIT[3] +ACLJ[1]*FPM10ACC[3] +ACLK[1]*FPM10COR[3] -PM25_CL[0]
+PMC_NA          ,ug m-3    ,ANAI[1]*FPM10AIT[3] +ANAJ[1]*FPM10ACC[3] +ANAK[0]*FPM10COR[3] -PM25_NA[0]
+PMC_NH4         ,ug m-3    ,ANH4I[1]*FPM10AIT[3]+ANH4J[1]*FPM10ACC[3]+ANH4K[1]*FPM10COR[3]-PM25_NH4[0]
+PMC_NO3         ,ug m-3    ,ANO3I[1]*FPM10AIT[3]+ANO3J[1]*FPM10ACC[3]+ANO3K[1]*FPM10COR[3]-PM25_NO3[0]
+PMC_SO4         ,ug m-3    ,ASO4I[1]*FPM10AIT[3]+ASO4J[1]*FPM10ACC[3]+ASO4K[1]*FPM10COR[3]-PM25_SO4[0]
+PMC_TOT         ,ug m-3    ,PM10[0]-PM25_TOT[0]
+
+!! FRM PM Equivalent Calculation
+!! This section calculates the FRM applicable PM species, PMIJ_FRM and
+!! PM25_FRM. The intermediate variablse K...ANH4IJ_loss are needed to 
+!! calculate the final quantities.
+K               ,ppb2      ,exp(118.87-24084/TEMP2[4]-6.025*log(TEMP2[4]))
+P1              ,          ,exp(8763/TEMP2[4]+19.12*log(TEMP2[4])-135.94)
+P2              ,          ,exp(9969/TEMP2[4]+16.22*log(TEMP2[4])-122.65)
+P3              ,          ,exp(13875/TEMP2[4]+24.46*log(TEMP2[4])-182.61)
+a               ,          ,1-RH[0]/100
+K_prime         ,ppb2      ,(P1[0]-P2[0]*a[0]+(P3[0]*a[0]*a[0]))*(a[0]^1.75)*K[0]
+sqrt_Ki         ,ppb       ,sqrt(RH[0]<=61 ? K[0] : K_prime[0])
+max_NO3_loss    ,ug m-3     ,745.7/TEMP2[4]*sqrt_Ki[0]
+PM25_NO3_loss   ,ug m-3     ,max_NO3_loss[0]<=PM25_NO3[0] ? max_NO3_loss[0] : PM25_NO3[0]
+ANO3IJ_loss     ,ug m-3     ,max_NO3_loss[0]<=ANO3IJ[0] ? max_NO3_loss[0] : ANO3IJ[0]
+PM25_NH4_loss   ,ug m-3     ,PM25_NO3_loss[0]*(18/62)
+ANH4IJ_loss     ,ug m-3     ,ANO3IJ_loss[0]*(18/62)
+PMIJ_FRM        ,ug m-3     ,ATOTIJ[0]-(ANO3IJ_loss[0]+ANH4IJ_loss[0]) \
+                            +0.24*(ASO4IJ[0]+ANH4IJ[0]-ANH4IJ_loss[0])+0.5
+PM25_FRM        ,ug m-3     ,PM25_TOT[0]-(PM25_NO3_loss[0]+PM25_NH4_loss[0]) \
+                            +0.24*(PM25_SO4[0]+PM25_NH4[0]-PM25_NH4_loss[0])+0.5

--- a/CCTM/src/MECHS/cb6r3_ae7_aq/SpecDef_cb6r3_ae7_aq.txt
+++ b/CCTM/src/MECHS/cb6r3_ae7_aq/SpecDef_cb6r3_ae7_aq.txt
@@ -154,10 +154,10 @@ AOCIJ           ,ugC m-3   ,PMF_OC[3]
 AOMIJ           ,ug m-3    ,PMF_OA[3]
 
 !!! Anthropogenic-VOC Derived Organic Aerosol
-AORGAJ          ,ug m-3    ,PMF_ASOA[3]
+AORGAIJ         ,ug m-3    ,PMF_ASOA[3]
 
 !!! Biogenic-VOC Derived Organic Aerosol
-AORGBJ          ,ug m-3    ,PMF_BSOA[3]
+AORGBIJ         ,ug m-3    ,PMF_BSOA[3]
 
 !!! Cloud-Processed  SOA
 AORGCJ          ,ug m-3    ,AORGCJ[1]

--- a/CCTM/src/MECHS/cb6r5_ae7_aq/SpecDef_Conc_cb6r5_ae7_aq.txt
+++ b/CCTM/src/MECHS/cb6r5_ae7_aq/SpecDef_Conc_cb6r5_ae7_aq.txt
@@ -1,0 +1,346 @@
+!#start   YYYYJJJ  010000
+!#end     YYYYJJJ  000000
+#layer         1
+
+/
+! This Species Definition File is for Use with the COMBINE tool built for 
+! post-processing CMAQ output. It is compatible with CMAQv5.4.
+! Date: May 12 2017
+
+! Output variables that begin with 'PM' represent those in which a size cut was 
+! applied based on modeled aerosol mode parameters.  For example, PM25_NA is all 
+! sodium that falls below 2.5 um diameter. These 'PM' variables are used for 
+! comparisons at IMPROVE and CSN sites.
+
+! Output variables that begin with 'PMAMS' represent the mass that would have
+! been detected  by an Aerosol Mass Spectrometer.
+
+! Output variables beginning with 'A' (aside from AIR_DENS) represent a 
+! combination of aerosol species in which no size cut was applied.  For example, 
+! ASO4IJ is the sum of i-mode and j-mode sulfate.  These 'A' variables are used 
+! for comparisons at CASTNet sites.
+
+! Output variables beginning with 'PMC' refer to the coarse fraction of total PM,
+! computed by summing all modes and subtracting the PM2.5 fraction.  These 'PMC'
+! variables are used for comparisons at SEARCH sites.
+
+! This Species Definition File is just for use with the uncoupled, offline CMAQ,
+! model. If you are processing WRF-CMAQ results, a different Species Definition
+! file is required.
+
+/ File [1]: CMAQ conc/aconc file
+/ File [2]: METCRO3D file
+/ File [3]: ELMO/AELMO file
+/ File [4]: METCRO2D file
+/
+/new species    ,units     ,expression
+                                         
+!-------------------------------------------!
+!------------- Meteorology -----------------!
+!-------------------------------------------!
+AIR_DENS        ,kg m-3    ,DENS[2]
+RH              ,%         ,100.00*RH[3]
+SFC_TMP         ,C         ,(TEMP2[4]-273.15)
+PBLH            ,m         ,PBL[4]
+SOL_RAD         ,W m-2     ,RGRND[4]
+precip          ,cm        ,RC[4]>=0 ? RN[4]+RC[4] : RN[4]
+WSPD10          ,m s-1     ,WSPD10[4]
+WDIR10          ,deg       ,WDIR10[4]
+
+!-------------------------------------------!
+!--------------- Gases ---------------------!
+!-------------------------------------------!
+ALD2            ,ppbV      ,1000.0*ALD2[1]
+BENZENE         ,ppbV      ,1000.0*BENZENE[1]
+CO              ,ppbV      ,1000.0*CO[1]
+ETH             ,ppbV      ,1000.0*ETH[1]
+ETHA            ,ppbV      ,1000.0*ETHA[1]
+FORM            ,ppbV      ,1000.0*FORM[1]
+H2O2            ,ppbV      ,1000.0*H2O2[1]
+HNO3            ,ppbV      ,1000.0*HNO3[1]
+HNO3_UGM3       ,ug m-3    ,1000.0*(HNO3[1]*2.1756*DENS[2])
+HONO            ,ppbV      ,1000.0*HONO[1]
+HOX             ,ppbV      ,1000.0*(OH[1]+HO2[1])
+OH              ,ppbV      ,1000.0*(OH[1])
+ISOP            ,ppbV      ,1000.0*ISOP[1]
+N2O5            ,ppbV      ,1000.0*N2O5[1]
+NH3             ,ppbV      ,1000.0*NH3[1]
+NH3_UGM3        ,ug m-3    ,1000.0*(NH3[1]*0.5880*DENS[2])
+NHX             ,ug m-3    ,1000.0*(NH3[1]*0.5880*DENS[2])+ANH4I[1]+ANH4J[1]+ANH4K[1]
+NO              ,ppbV      ,1000.0*NO[1]
+NO2             ,ppbV      ,1000.0*NO2[1]
+NOX             ,ppbV      ,1000.0*(NO[1] + NO2[1])
+ANO3_PPB        ,ppbV      ,(ANO3I[1]+ANO3J[1]+ANO3K[1])/(DENS[2]*(62.0/28.97))
+NTR             ,ppbV      ,1000.0*(NTR1[1]+NTR2[1]+INTR[1])
+PANS            ,ppbV      ,1000.0*(PAN[1]+PANX[1]+OPAN[1])
+NOY             ,ppbV      ,1000.0* (NO[1]+NO2[1]+NO3[1]+2*N2O5[1]+HONO[1]+HNO3[1]+PNA[1] \
+                                     +CRON[1]+CLNO2[1]+CLNO3[1]) \
+                                     +PANS[0]+NTR[0]+ANO3_PPB[0]
+O3              ,ppbV      ,1000.0*O3[1]
+SO2             ,ppbV      ,1000.0*SO2[1]
+SO2_UGM3        ,ug m-3    ,1000.0*(SO2[1]*2.2118*DENS[2])
+TERP            ,ppbV      ,1000.0*TERP[1]
+TOL             ,ppbV      ,1000.0*TOL[1]
+XYL             ,ppbV      ,1000.0*XYLMN[1]
+
+!Additional Toxic gases
+!ACROLEIN        ,ug m-3    ,1000.0*(ACROLEIN[1]*1.9365*DENS[2])
+!ACRO_PRIMARY    ,ug m-3    ,1000.0*(ACRO_PRIMARY*1.9365*DENS[2])
+!ALD2_PRIMARY    ,ug m-3    ,1000.0*(ALD2_PRIMARY[1]*1.5188*DENS[2])
+!FORM_PRIMARY    ,ug m-3    ,1000.0*(FORM_PRIMARY[1]*1.0356*DENS[2])
+!BUTADIENE13     ,ug m-3    ,1000.0*(BUTADIENE13[1]*1.8674*DENS[2])
+!HCL             ,ppbV      ,1000.0*HCL[1]
+!TOLUENE         ,ppbV      ,1000.0*TOLU[1]
+
+!Mercuric gas species
+!HG_0            ,ng/m3     ,1000.0*(HG[1]*8.3330*DENS[2]*1000.0)       
+!HG_II           ,ng/m3     ,1000.0*(HGIIGAS[1]*8.3330*DENS[2]*1000.0) 
+
+!! Unused Gases. Presented Here for illustration. Users can uncomment
+!! them if they choose.
+!ALDX            ,ppbV      ,1000.0*ALDX[1]
+!IOLE            ,ppbV      ,1000.0*IOLE[1]
+!OLE             ,ppbV      ,1000.0*OLE[1]
+!PAR             ,ppbV      ,1000.0*PAR[1]
+!PAN             ,ppbV      ,1000.0*PAN[1]
+!SULF            ,ppbV      ,1000.0*SULF[1]
+! emitted VOCs
+!VOC             ,ppbC      ,1000.0* (PAR[1] +2.0*ETHA[1] +3.0*PRPA[1] +MEOH[1]\
+!                            +2.0*ETH[1] +2.0*ETOH[1] +2.0*OLE[1] +3.0*ACET[1] \
+!                            +7.0*TOL[1] +8.0*XYLMN[1] +6.0*BENZENE[1] \
+!                            +FORM[1] +3.0*GLY[1] +4.0*KET[1] +2.0*ETHY[1] \
+!                           +2.0*ALD2[1] + 4.0*IOLE[1] + 2.0*ALDX[1]  \
+!                           +5.0*ISOP[1] + 10.0*TERP[1]+ 10.0*NAPH[1] +10.*APIN[1])
+
+!! DMS and MSA. Users can uncomment them if they choose.
+DMS            ,ppbV      ,1000.0*DMS[1]
+MSA            ,ppbV      ,1000.0*MSA[1]
+
+!-------------------------------------------!
+!--------------- Particles -----------------!
+!-------------------------------------------!
+!! Crustal Elements
+AFEJ            ,ug m-3    ,AFEJ[1]
+AALJ            ,ug m-3    ,AALJ[1]
+ASIJ            ,ug m-3    ,ASIJ[1]
+ATIJ            ,ug m-3    ,ATIJ[1]
+ACAJ            ,ug m-3    ,ACAJ[1]
+AMGJ            ,ug m-3    ,AMGJ[1]
+AKJ             ,ug m-3    ,AKJ[1]
+AMNJ            ,ug m-3    ,AMNJ[1]
+ASOILJ          ,ug m-3    ,2.20*AALJ[1]+2.49*ASIJ[1]+1.63*ACAJ[1]+2.42*AFEJ[1]+1.94*ATIJ[1]
+
+!! Non-Crustal Inorganic Particle Species
+AHPLUSIJ        ,umol m-3  ,(AH3OPI[1]+AH3OPJ[1])*1.0/19.0
+ANAK            ,ug m-3    ,0.8373*ASEACAT[1]+0.0626*ASOIL[1]+0.0023*ACORS[1]
+AMGK            ,ug m-3    ,0.0997*ASEACAT[1]+0.0170*ASOIL[1]+0.0032*ACORS[1]
+AKK             ,ug m-3    ,0.0310*ASEACAT[1]+0.0242*ASOIL[1]+0.0176*ACORS[1]
+ACAK            ,ug m-3    ,0.0320*ASEACAT[1]+0.0838*ASOIL[1]+0.0562*ACORS[1]
+ACLIJ           ,ug m-3    ,ACLI[1]+ACLJ[1]
+AECIJ           ,ug m-3    ,AECI[1]+AECJ[1]
+ANAIJ           ,ug m-3    ,ANAJ[1]+ANAI[1]
+ANO3IJ          ,ug m-3    ,ANO3I[1]+ANO3J[1]
+ANO3K           ,ug m-3    ,ANO3K[1]
+TNO3            ,ug m-3    ,2175.6*(HNO3[1]*DENS[2])+ANO3I[1]+ANO3J[1]+ANO3K[1]
+ANH4IJ          ,ug m-3    ,ANH4I[1]+ANH4J[1]
+ANH4K           ,ug m-3    ,ANH4K[1]
+ASO4IJ          ,ug m-3    ,ASO4I[1]+ASO4J[1]
+ASO4K           ,ug m-3    ,ASO4K[1]
+
+!! Organic Particle Species
+APOCI           ,ugC m-3   ,ALVPO1I[1]/1.39 + ASVPO1I[1]/1.32 + ASVPO2I[1]/1.26 \
+                            +APOCI[1]
+APOCJ           ,ugC m-3   ,ALVPO1J[1]/1.39 + ASVPO1J[1]/1.32 + ASVPO2J[1]/1.26 \
+                           +ASVPO3J[1]/1.21 + AIVPO1J[1]/1.17  + APOCJ[1]
+APOCIJ          ,ugC m-3   ,APOCI[0] + APOCJ[0]
+
+APOMI           ,ug m-3    ,ALVPO1I[1] + ASVPO1I[1] + ASVPO2I[1] + APOCI[1]    \
+                            +APNCOMI[1]
+APOMJ           ,ug m-3    ,ALVPO1J[1] + ASVPO1J[1] + ASVPO2J[1] + APOCJ[1]    \
+                           +ASVPO3J[1] + AIVPO1J[1]  + APNCOMJ[1]
+APOMIJ          ,ug m-3    ,APOMI[0] + APOMJ[0]
+
+ASOCI           ,ugC m-3   ,ALVOO1I[1]/2.27 + ALVOO2I[1]/2.06  \
+                           +ASVOO1I[1]/1.88 + ASVOO2I[1]/1.73
+ASOCJ           ,ugC m-3   ,AISO1J[1]/2.20  + AISO2J[1]/2.23  + AISO3J[1]/2.80  \
+                           +AMT1J[1]/1.67   + AMT2J[1]/1.67   + AMT3J[1]/1.72   \
+                           +AMT4J[1]/1.53   + AMT5J[1]/1.57   + AMT6J[1]/1.40   \
+                           +AMTNO3J[1]/1.90 + AMTHYDJ[1]/1.54                   \
+                           +AGLYJ[1]/2.13   + ASQTJ[1]/1.52                     \
+                           +AORGCJ[1]/2.00  + AOLGBJ[1]/2.10  + AOLGAJ[1]/2.50  \
+                           +ALVOO1J[1]/2.27 + ALVOO2J[1]/2.06 + ASVOO1J[1]/1.88 \
+                           +ASVOO2J[1]/1.73 + ASVOO3J[1]/1.60                   \
+                           +AAVB1J[1]/2.70  + AAVB2J[1]/2.35  + AAVB3J[1]/2.17  \
+                           +AAVB4J[1]/1.99 + APCSOJ[1]/2.00
+ASOCIJ          ,ugC m-3   ,ASOCI[0] + ASOCJ[0]
+
+ASOMI           ,ug m-3    ,ALVOO1I[1] + ALVOO2I[1] + ASVOO1I[1] + ASVOO2I[1] 
+ASOMJ           ,ug m-3    ,+AISO1J[1]+ AISO2J[1]  + AISO3J[1]              \
+                            +AMT1J[1]   + AMT2J[1]   + AMT3J[1]             \
+                            +AMT4J[1]   + AMT5J[1]   + AMT6J[1]             \
+                            +AMTNO3J[1] + AMTHYDJ[1]                        \
+                            +AGLYJ[1]   + ASQTJ[1]                          \
+                            +AORGCJ[1]  + AOLGBJ[1]  + AOLGAJ[1]            \
+                            +ALVOO1J[1] + ALVOO2J[1] + ASVOO1J[1]           \
+                            +ASVOO2J[1] + ASVOO3J[1] + APCSOJ[1]            \
+                            +AAVB1J[1]  + AAVB2J[1]  + AAVB3J[1]            \
+                            +AAVB4J[1]
+ASOMIJ          ,ug m-3    ,ASOMI[0] + ASOMJ[0]
+ 
+AOCI            ,ugC m-3    ,APOCI[0]  + ASOCI[0]
+AOCJ            ,ugC m-3    ,APOCJ[0]  + ASOCJ[0]
+
+AOCIJ           ,ugC m-3    ,APOCIJ[0] + ASOCIJ[0]
+
+
+AOMI            ,ug m-3     ,APOMI[0]  + ASOMI[0]
+AOMJ            ,ug m-3     ,APOMJ[0]  + ASOMJ[0]
+
+AOMIJ           ,ug m-3     ,APOMIJ[0] + ASOMIJ[0]
+
+!!! Anthropogenic-VOC Derived Organic Aerosol
+AORGAI          ,ug m-3    ,ALVOO1I[1] + ALVOO2I[1] + ASVOO1I[1]       \ 
+                           +ASVOO2I[1]
+AORGAJ          ,ug m-3    ,ALVOO1J[1] + ALVOO2J[1]                    \
+                           +ASVOO1J[1] + ASVOO2J[1] + ASVOO3J[1]       \
+                           +AAVB1J[1] + AAVB2J[1] + AAVB3J[1]          \
+                           +AAVB4J[1] + AOLGAJ[1] + APCSOJ[1]   
+AORGAIJ         ,ug m-3    ,AORGAI[0] + AORGAJ[0]                           
+
+!!! Biogenic-VOC Derived Organic Aerosol
+AORGBIJ         ,ug m-3    ,AMT1J[1] + AMT2J[1] + AMT3J[1] + AMT4J[1]  \
+                           +AMT5J[1] + AMT6J[1] + AMTNO3J[1]           \
+                           +AMTHYDJ[1] + AISO1J[1] + AISO2J[1]         \
+                           +AISO3J[1] + ASQTJ[1] + AOLGBJ[1] 
+
+!!! Cloud-Processed  SOA
+AORGCJ          ,ug m-3    ,AORGCJ[1]
+!!! Remaining SOA
+AGLYJ           ,ug m-3    ,AGLYJ[1]
+
+!!! OM/OC ratios
+AOMOCRAT_TOT    ,           ,AOMIJ[0]/AOCIJ[0]
+
+!! Total PM Aggregates
+ATOTI           ,ug m-3    ,ASO4I[1] + ANH4I[1] + ANO3I[1] + ANAI[1]   \
+                           +ACLI[1] + AECI[1] + AOMI[0] + AOTHRI[1] 
+ATOTJ           ,ug m-3    ,ASO4J[1] + ANH4J[1] + ANO3J[1] + ANAJ[1]   \
+                           +ACLJ[1] + AECJ[1] + AOMJ[0] + AOTHRJ[1]    \
+                           +AFEJ[1] + AALJ[1] + ASIJ[1] + ATIJ[1]      \
+                           +ACAJ[1] + AMGJ[1] + AKJ[1] + AMNJ[1]        
+                            
+ATOTK           ,ug m-3    ,ASO4K[1] + ANH4K[1] + ANO3K[1] + ACLK[1]   \
+                           +ACORS[1] + ASOIL[1] + ASEACAT[1]   
+ATOTIJ          ,ug m-3    ,ATOTI[0] + ATOTJ[0] 
+ATOTIJK         ,ug m-3    ,ATOTI[0] + ATOTJ[0] + ATOTK[0]
+
+!! Unspeciated PM including non-carbon organic mass
+AUNSPEC1IJ      ,ug m-3    ,ATOTIJ[0] - (ASO4IJ[0] + ANO3IJ[0]         \
+                                         +ANH4IJ[0] + ACLIJ[0]         \
+                                         +ANAIJ[0] + AECIJ[0]          \
+                                         +AOCIJ[0] + ASOILJ[0])       
+!! Non-Carbon Organic Mass
+ANCOMIJ         ,ug m-3    ,AOMIJ[0] - AOCIJ[0]
+
+!! Unspeciated PM excluding non-carbon organic mass
+AUNSPEC2IJ      ,ug m-3     ,AUNSPEC1IJ[0] - ANCOMIJ[0]
+
+!! AMS Projection of Output Concentrations
+PMAMS_CL        ,ug m-3    ,ACLI[1] *FAMSAIT[3] +ACLJ[1]*FAMSACC[3]+ACLK[1] *FAMSCOR[3]
+PMAMS_NH4       ,ug m-3    ,ANH4I[1]*FAMSAIT[3]+ANH4J[1]*FAMSACC[3]+ANH4K[1]*FAMSCOR[3]
+PMAMS_NO3       ,ug m-3    ,ANO3I[1]*FAMSAIT[3]+ANO3J[1]*FAMSACC[3]+ANO3K[1]*FAMSCOR[3]
+PMAMS_OA        ,ug m-3    ,AOMI[0] *FAMSAIT[3]+AOMJ[0] *FAMSACC[3]
+PMAMS_SO4       ,ug m-3    ,ASO4I[1]*FAMSAIT[3]+ASO4J[1]*FAMSACC[3]+ASO4K[1]*FAMSCOR[3]
+
+!! PM1 Cutoff Output
+PM1_TOT         ,ug m-3    ,ATOTI[0]*FPM1AIT[3]+ATOTJ[0]*FPM1ACC[3]+ATOTK[0]*FPM1COR[3]
+
+!! Unused PM1 Species. Included Here for demonstration
+!PM1_EC         ,ug m-3    ,AECI[1] *FPM1AIT[3] +AECJ[1] *FPM1ACC[3]
+!PM1_OC         ,ugC m-3   ,AOCI[0] *FPM1AIT[3] +AOCJ[0] *FPM1ACC[3]
+!PM1_OM         ,ug m-3    ,AOMI[0] *FPM1AIT[3] +AOMJ[0] *FPM1ACC[3]
+!PM1_SO4        ,ug m-3    ,ASO4I[1]*FPM1AIT[3] +ASO4J[1]*FPM1ACC[3] +ASO4K[1]*FPM1COR[3]
+!PM1_CL         ,ug m-3    ,ACLI[1] *FPM1AIT[3] +ACLJ[1] *FPM1ACC[3] +ACLK[1] *FPM1COR[3]
+!PM1_NA         ,ug m-3    ,ANAI[1] *FPM1AIT[3] +ANAJ[1] *FPM1ACC[3] +ANAK[0] *FPM1COR[3]
+!PM1_MG         ,ug m-3    ,                     AMGJ[1] *FPM1ACC[3] +AMGK[0] *FPM1COR[3]
+!PM1_K          ,ug m-3    ,                     AKJ[1]  *FPM1ACC[3] +AKK[0]  *FPM1COR[3]
+!PM1_CA         ,ug m-3    ,                     ACAJ[1] *FPM1ACC[3] +ACAK[0] *FPM1COR[3]
+!PM1_NH4        ,ug m-3    ,ANH4I[1] *FPM1AIT[3]+ANH4J[1]*FPM1ACC[3] +ANH4K[1]*FPM1COR[3]
+!PM1_NO3        ,ug m-3    ,ANO3I[1] *FPM1AIT[3]+ANO3J[1]*FPM1ACC[3] +ANO3K[1]*FPM1COR[3] 
+!PM1_SOIL       ,ug m-3    ,ASOILJ[0]*FPM1ACC[3]+(ASOIL[1]+ACORS[1])*FPM1COR[3]
+!PM1_UNSPEC1    ,ug m-3    ,PM1_TOT[0] - (PM1_CL[0] + PM1_EC[0]+ PM1_NA[0]  + PM1_NH4[0] +  \
+!                                         PM1_NO3[0]+ PM1_OC[0]+ PM1_SOIL[0]+ PM1_SO4[0] ) 
+!PM1_UNSPCRS    ,ug m-3    ,ATOTK[0] *FPM1COR[3] - (ASO4K[1]*FPM1COR[3] \
+!                                                  +ACLK[1]*FPM1COR[3]  \
+!                                                  +ANAK[0]*FPM1COR[3]  \
+!                                                  +AMGK[0]*FPM1COR[3]  \
+!                                                  +AKK[0]*FPM1COR[3]   \
+!                                                  +ACAK[0]*FPM1COR[3]  \
+!                                                  +ANH4K[1]*FPM1COR[3] \
+!                                                  +ANO3K[1]*FPM1COR[3]) 
+ 
+!! PM2.5 species computed using modeled size distribution
+PM25_HP         ,ug m-3    ,(AH3OPI[1]*FPM25AIT[3]+AH3OPJ[1]*FPM25ACC[3]+AH3OPK[1]*FPM25COR[3])*1.0/19.0
+PM25_CL         ,ug m-3    ,ACLI[1]*FPM25AIT[3]+ACLJ[1]*FPM25ACC[3]+ACLK[1]*FPM25COR[3]
+PM25_EC         ,ug m-3    ,AECI[1]*FPM25AIT[3]+AECJ[1]*FPM25ACC[3]
+PM25_NA         ,ug m-3    ,ANAI[1]*FPM25AIT[3]+ANAJ[1]*FPM25ACC[3]+ANAK[0]*FPM25COR[3]
+PM25_MG         ,ug m-3    ,                    AMGJ[1]*FPM25ACC[3]+AMGK[0]*FPM25COR[3]
+PM25_K          ,ug m-3    ,                    AKJ[1] *FPM25ACC[3]+AKK[0] *FPM25COR[3]
+PM25_CA         ,ug m-3    ,                    ACAJ[1]*FPM25ACC[3]+ACAK[0]*FPM25COR[3]
+PM25_NH4        ,ug m-3    ,ANH4I[1]*FPM25AIT[3]+ANH4J[1]*FPM25ACC[3]+ANH4K[1]*FPM25COR[3]
+PM25_NO3        ,ug m-3    ,ANO3I[1]*FPM25AIT[3]+ANO3J[1]*FPM25ACC[3]+ANO3K[1]*FPM25COR[3]
+PM25_OC         ,ugC m-3   ,AOCI[0] *FPM25AIT[3]+AOCJ[0]*FPM25ACC[3]
+PM25_OM         ,ug m-3    ,AOMI[0] *FPM25AIT[3]+AOMJ[0]*FPM25ACC[3]
+PM25_SOIL       ,ug m-3    ,ASOILJ[0]*FPM25ACC[3]+ASOIL[1]*FPM25COR[3]
+PM25_SO4        ,ug m-3    ,ASO4I[1]*FPM25AIT[3]+ASO4J[1]*FPM25ACC[3]+ASO4K[1]*FPM25COR[3]
+PM25_TOT        ,ug m-3    ,ATOTI[0]*FPM25AIT[3]+ATOTJ[0]*FPM25ACC[3]+ATOTK[0]*FPM25COR[3]
+PM25_UNSPEC1    ,ug m-3    ,PM25_TOT[0]-(PM25_CL[0]+PM25_EC[0]+PM25_NA[0]+PM25_NH4[0] \
+                           +PM25_NO3[0]+PM25_OC[0]+PM25_SOIL[0]+PM25_SO4[0])
+PM25_UNSPCRS    ,ug m-3    ,ATOTK[0]*FPM25COR[3] - (ASO4K[1]*FPM25COR[3] \
+                                                  +ACLK[1]*FPM25COR[3]  \
+                                                  +ANAK[0]*FPM25COR[3]  \
+                                                  +AMGK[0]*FPM25COR[3]  \
+                                                  +AKK[0]*FPM25COR[3]   \
+                                                  +ACAK[0]*FPM25COR[3]  \
+                                                  +ANH4K[1]*FPM25COR[3] \
+                                                  +ANO3K[1]*FPM25COR[3]) 
+
+
+!! Fine particle acidity (pH). pH is undefined if there is no aerosol water. 
+!Do not trust predictions when hourly water is <0.01 ug m-3. FINEPHF will 
+!have large negative value (-9.999E36) when pH is not to be trusted.
+!AH2OIJ         ,ug m-3     ,AH2OI[1]+AH2OJ[1]
+!HPMOLAL        ,mol kg-1   ,AHPLUSIJ[0]/AH2OIJ[0]*1000.0
+!ACIDITYTEMP    ,           ,-1*LOG10(HPMOLAL[0])
+!FINEPHF        ,           ,AH2OIJ[0]>0.01 ? ACIDITYTEMP[0] : -9.999E36
+
+!! PM10.0 and Coarse-Sized Species
+PM10            ,ug m-3    ,ATOTI[0]*FPM10AIT[3]+ATOTJ[0]*FPM10ACC[3]+ATOTK[0]*FPM10COR[3]
+
+PMC_CL          ,ug m-3    ,ACLI[1]*FPM10AIT[3] +ACLJ[1]*FPM10ACC[3] +ACLK[1]*FPM10COR[3] -PM25_CL[0]
+PMC_NA          ,ug m-3    ,ANAI[1]*FPM10AIT[3] +ANAJ[1]*FPM10ACC[3] +ANAK[0]*FPM10COR[3] -PM25_NA[0]
+PMC_NH4         ,ug m-3    ,ANH4I[1]*FPM10AIT[3]+ANH4J[1]*FPM10ACC[3]+ANH4K[1]*FPM10COR[3]-PM25_NH4[0]
+PMC_NO3         ,ug m-3    ,ANO3I[1]*FPM10AIT[3]+ANO3J[1]*FPM10ACC[3]+ANO3K[1]*FPM10COR[3]-PM25_NO3[0]
+PMC_SO4         ,ug m-3    ,ASO4I[1]*FPM10AIT[3]+ASO4J[1]*FPM10ACC[3]+ASO4K[1]*FPM10COR[3]-PM25_SO4[0]
+PMC_TOT         ,ug m-3    ,PM10[0]-PM25_TOT[0]
+
+!! FRM PM Equivalent Calculation
+!! This section calculates the FRM applicable PM species, PMIJ_FRM and
+!! PM25_FRM. The intermediate variablse K...ANH4IJ_loss are needed to 
+!! calculate the final quantities.
+K               ,ppb2      ,exp(118.87-24084/TEMP2[4]-6.025*log(TEMP2[4]))
+P1              ,          ,exp(8763/TEMP2[4]+19.12*log(TEMP2[4])-135.94)
+P2              ,          ,exp(9969/TEMP2[4]+16.22*log(TEMP2[4])-122.65)
+P3              ,          ,exp(13875/TEMP2[4]+24.46*log(TEMP2[4])-182.61)
+a               ,          ,1-RH[0]/100
+K_prime         ,ppb2      ,(P1[0]-P2[0]*a[0]+(P3[0]*a[0]*a[0]))*(a[0]^1.75)*K[0]
+sqrt_Ki         ,ppb       ,sqrt(RH[0]<=61 ? K[0] : K_prime[0])
+max_NO3_loss    ,ug m-3     ,745.7/TEMP2[4]*sqrt_Ki[0]
+PM25_NO3_loss   ,ug m-3     ,max_NO3_loss[0]<=PM25_NO3[0] ? max_NO3_loss[0] : PM25_NO3[0]
+ANO3IJ_loss     ,ug m-3     ,max_NO3_loss[0]<=ANO3IJ[0] ? max_NO3_loss[0] : ANO3IJ[0]
+PM25_NH4_loss   ,ug m-3     ,PM25_NO3_loss[0]*(18/62)
+ANH4IJ_loss     ,ug m-3     ,ANO3IJ_loss[0]*(18/62)
+PMIJ_FRM        ,ug m-3     ,ATOTIJ[0]-(ANO3IJ_loss[0]+ANH4IJ_loss[0]) \
+                            +0.24*(ASO4IJ[0]+ANH4IJ[0]-ANH4IJ_loss[0])+0.5
+PM25_FRM        ,ug m-3     ,PM25_TOT[0]-(PM25_NO3_loss[0]+PM25_NH4_loss[0]) \
+                            +0.24*(PM25_SO4[0]+PM25_NH4[0]-PM25_NH4_loss[0])+0.5

--- a/CCTM/src/MECHS/cb6r5_ae7_aq/SpecDef_cb6r5_ae7_aq.txt
+++ b/CCTM/src/MECHS/cb6r5_ae7_aq/SpecDef_cb6r5_ae7_aq.txt
@@ -113,8 +113,8 @@ XYL             ,ppbV      ,1000.0*XYLMN[1]
 !                           +5.0*ISOP[1] + 10.0*TERP[1]+ 10.0*NAPH[1] +10.*APIN[1])
 
 !! DMS and MSA. Users can uncomment them if they choose.
-!DMS            ,ppbV      ,1000.0*DMS[1]
-!MSA            ,ppbV      ,1000.0*MSA[1]
+DMS            ,ppbV      ,1000.0*DMS[1]
+MSA            ,ppbV      ,1000.0*MSA[1]
 
 !-------------------------------------------!
 !--------------- Particles -----------------!
@@ -156,10 +156,10 @@ AOCIJ           ,ugC m-3   ,PMF_OC[3]
 AOMIJ           ,ug m-3    ,PMF_OA[3]
 
 !!! Anthropogenic-VOC Derived Organic Aerosol
-AORGAJ          ,ug m-3    ,PMF_ASOA[3]
+AORGAIJ         ,ug m-3    ,PMF_ASOA[3]
 
 !!! Biogenic-VOC Derived Organic Aerosol
-AORGBJ          ,ug m-3    ,PMF_BSOA[3]
+AORGBIJ         ,ug m-3    ,PMF_BSOA[3]
 
 !!! Cloud-Processed  SOA
 AORGCJ          ,ug m-3    ,AORGCJ[1]

--- a/CCTM/src/MECHS/cb6r5hap_ae7_aq/SpecDef_Conc_cb6r5hap_ae7_aq.txt
+++ b/CCTM/src/MECHS/cb6r5hap_ae7_aq/SpecDef_Conc_cb6r5hap_ae7_aq.txt
@@ -1,0 +1,436 @@
+!#start   YYYYJJJ  010000
+!#end     YYYYJJJ  000000
+#layer         1
+
+/
+! This Species Definition File is for Use with the COMBINE tool built for 
+! post-processing CMAQ output. It is compatible with CMAQv5.4.
+! Date: May 12 2017
+
+! Output variables that begin with 'PM' represent those in which a size cut was 
+! applied based on modeled aerosol mode parameters.  For example, PM25_NA is all 
+! sodium that falls below 2.5 um diameter. These 'PM' variables are used for 
+! comparisons at IMPROVE and CSN sites.
+
+! Output variables that begin with 'PMAMS' represent the mass that would have
+! been detected  by an Aerosol Mass Spectrometer.
+
+! Output variables beginning with 'A' (aside from AIR_DENS) represent a 
+! combination of aerosol species in which no size cut was applied.  For example, 
+! ASO4IJ is the sum of i-mode and j-mode sulfate.  These 'A' variables are used 
+! for comparisons at CASTNet sites.
+
+! Output variables beginning with 'PMC' refer to the coarse fraction of total PM,
+! computed by summing all modes and subtracting the PM2.5 fraction.  These 'PMC'
+! variables are used for comparisons at SEARCH sites.
+
+! This Species Definition File is just for use with the uncoupled, offline CMAQ,
+! model. If you are processing WRF-CMAQ results, a different Species Definition
+! file is required.
+
+/ File [1]: CMAQ conc/aconc file
+/ File [2]: METCRO3D file
+/ File [3]: ELMO/AELMO file
+/ File [4]: METCRO2D file
+/
+/new species    ,units     ,expression
+                                         
+!-------------------------------------------!
+!------------- Meteorology -----------------!
+!-------------------------------------------!
+AIR_DENS        ,kg m-3    ,DENS[2]
+RH              ,%         ,100.00*RH[3]
+SFC_TMP         ,C         ,(TEMP2[4]-273.15)
+PBLH            ,m         ,PBL[4]
+SOL_RAD         ,W m-2     ,RGRND[4]
+precip          ,cm        ,RC[4]>=0 ? RN[4]+RC[4] : RN[4]
+WSPD10          ,m s-1     ,WSPD10[4]
+WDIR10          ,deg       ,WDIR10[4]
+
+!-------------------------------------------!
+!--------------- Gases ---------------------!
+!-------------------------------------------!
+ALD2            ,ppbV      ,1000.0*ALD2[1]
+BENZENE         ,ppbV      ,1000.0*BENZENE[1]
+CO              ,ppbV      ,1000.0*CO[1]
+ETH             ,ppbV      ,1000.0*ETH[1]
+ETHA            ,ppbV      ,1000.0*ETHA[1]
+FORM            ,ppbV      ,1000.0*FORM[1]
+H2O2            ,ppbV      ,1000.0*H2O2[1]
+HNO3            ,ppbV      ,1000.0*HNO3[1]
+HNO3_UGM3       ,ug m-3    ,1000.0*(HNO3[1]*2.1756*DENS[2])
+HONO            ,ppbV      ,1000.0*HONO[1]
+HOX             ,ppbV      ,1000.0*(OH[1]+HO2[1])
+OH              ,ppbV      ,1000.0*(OH[1])
+ISOP            ,ppbV      ,1000.0*ISOP[1]
+N2O5            ,ppbV      ,1000.0*N2O5[1]
+NH3             ,ppbV      ,1000.0*NH3[1]
+NH3_UGM3        ,ug m-3    ,1000.0*(NH3[1]*0.5880*DENS[2])
+NHX             ,ug m-3    ,1000.0*(NH3[1]*0.5880*DENS[2])+ANH4I[1]+ANH4J[1]+ANH4K[1]
+NO              ,ppbV      ,1000.0*NO[1]
+NO2             ,ppbV      ,1000.0*NO2[1]
+NOX             ,ppbV      ,1000.0*(NO[1] + NO2[1])
+ANO3_PPB        ,ppbV      ,(ANO3I[1]+ANO3J[1]+ANO3K[1])/(DENS[2]*(62.0/28.97))
+NTR             ,ppbV      ,1000.0*(NTR1[1]+NTR2[1]+INTR[1])
+PANS            ,ppbV      ,1000.0*(PAN[1]+PANX[1]+OPAN[1])
+NOY             ,ppbV      ,1000.0* (NO[1]+NO2[1]+NO3[1]+2*N2O5[1]+HONO[1]+HNO3[1]+PNA[1] \
+                                     +CRON[1]+CLNO2[1]+CLNO3[1]) \
+                                     +PANS[0]+NTR[0]+ANO3_PPB[0]
+O3              ,ppbV      ,1000.0*O3[1]
+SO2             ,ppbV      ,1000.0*SO2[1]
+SO2_UGM3        ,ug m-3    ,1000.0*(SO2[1]*2.2118*DENS[2])
+TERP            ,ppbV      ,1000.0*TERP[1]
+TOL             ,ppbV      ,1000.0*TOL[1]
+XYL             ,ppbV      ,1000.0*XYLMN[1]
+ 
+!! Additional Global, Regional and Urban Toxic gases
+ACROLEIN        ,ug/m3     ,1000.0*(ACROLEIN[1]*1.9365*DENS[2]) 
+ACRY_NITRILE    ,ug/m3     ,1000.0*(ACRY_NITRILE[1]*1.8329*DENS[2])        
+ALD2_UGM3       ,ug/m3     ,1000.0*(ALD2[1]*1.5188*DENS[2])                
+ALD2_PRIMARY    ,ug/m3     ,1000.0*(ALD2_PRIMARY[1]*1.5188*DENS[2])     
+BENZENE_UGM3    ,ug/m3     ,1000.0*(BENZENE[1]*2.6959*DENS[2])       
+BR2_C2_12       ,ug/m3     ,1000.0*(BR2_C2_12[1]*6.4860*DENS[2])    
+BUTADIENE13     ,ug/m3     ,1000.0*(BUTADIENE13[1]*1.8674*DENS[2]) 
+CHCL3           ,ug/m3     ,1000.0*(CHCL3[1]*4.1215*DENS[2])      
+CL_ETHE         ,ug/m3     ,1000.0*(CL_ETHE[1]*2.1574*DENS[2])   
+CL2             ,ppbV      ,1000.0*CL2[1]                       
+CL2_C2_12       ,ug/m3     ,1000.0*(CL2_C2_12[1]*3.4173*DENS[2])  
+CL2_ME          ,ug/m3     ,1000.0*(CL2_ME[1]*2.9306*DENS[2])    
+CL3_ETHE        ,ug/m3     ,1000.0*(CL3_ETHE[1]*4.5357*DENS[2]) 
+CL4_ETHE        ,ug/m3     ,1000.0*(CL4_ETHE[1]*5.7232*DENS[2])  
+CL4_ETHANE      ,ug/m3     ,1000.0*(CL4_ETHANE[1]*5.7956*DENS[2])  
+CARBONTET       ,ug/m3     ,1000.0*(CARBONTET[1]*5.3089*DENS[2])      
+DICL_BENZENE    ,ug/m3     ,1000.0*(DICL_BENZENE[1]*5.069*DENS[2])  
+DICL_PROPENE    ,ug/m3     ,1000.0*(DICL_PROPENE[1]*3.8316*DENS[2]) 
+ETOH            ,ppbV      ,1000.0*ETOH[1]           
+ETOX            ,ug/m3     ,1000.0*(ETOX[1]*1.5223*DENS[2])  
+FORM_UGM3       ,ug/m3     ,1000.0*(FORM[1]*1.0356*DENS[2])  
+FORM_PRIMARY    ,ug/m3     ,1000.0*(FORM_PRIMARY[1]*1.0356*DENS[2])  
+HCL             ,ppbV      ,1000.0*HCL[1]                           
+HEXMETH_DIS     ,ug/m3     ,1000.0*(HEXMETH_DIS[1]*5.8000*DENS[2]) 
+HYDRAZINE       ,ug/m3     ,1000.0*(HYDRAZINE[1]*3.3793*DENS[2])     
+MEOH            ,ppbV      ,1000.0*MEOH[1]                          
+XYLENE          ,ppbV      ,1000.0*XYLENE[1]                       
+MAL_ANHYDRID    ,ug/m3     ,1000.0*(MAL_ANHYDRID[1]*3.3843*DENS[2])  
+NAPHTHALENE     ,ug/m3     ,1000.0*(NAPHTHALENE[1]*4.4253*DENS[2])   
+PROPY_DICL      ,ug/m3     ,1000.0*(PROPYL_DICL[1]*3.9006*DENS[2])  
+QUINOLINE       ,ug/m3     ,1000.0*(QUINOLINE[1]*4.4598*DENS[2])      
+TOLU            ,ppbV      ,1000.0*TOLU[1]                           
+TOL_DIIS        ,ug/m3     ,1000.0*(TOL_DIIS[1]*6.0069*DENS[2])     
+TRIETHYLAMIN    ,ug/m3     ,1000.0*(TRIETHYLAMIN[1]*3.4986*DENS[2])  
+ACET_NITRILE    ,ug/m3     ,1000.0*(ACET_NITRILE[1]*1.4155*DENS[2])  
+STYRENE         ,ug/m3     ,1000.0*(STYRENE[1]*3.5914*DENS[2])      
+ACRYACID        ,ug/m3     ,1000.0*(ACRYACID[1]*2.4849*DENS[2])    
+HEXANE          ,ug/m3     ,1000.0*(HEXANE[1]*2.9717*DENS[2])     
+METHCHLORIDE    ,ug/m3     ,1000.0*(METHCHLORIDE[1]*1.7410*DENS[2])  
+CARBSULFIDE     ,ug/m3     ,1000.0*(CARBSULFIDE[1]*2.0714*DENS[2])  
+CHLOROPRENE     ,ug/m3     ,1000.0*(CHLOROPRENE[1]*3.0530*DENS[2]) 
+ETHYLBENZENE    ,ug/m3     ,1000.0*(ETHYLBENZENE[1]*3.6610*DENS[2])  
+
+!! Inert PAH tracers
+PAH_000E0       ,ug/m3     ,1000.0*(PAH_000E0[1]*6.4340*DENS[2])
+PAH_176E5       ,ug/m3     ,1000.0*(PAH_176E5[1]*6.8314*DENS[2])
+PAH_880E5       ,ug/m3     ,1000.0*(PAH_880E5[1]*6.8383*DENS[2])
+PAH_176E4       ,ug/m3     ,1000.0*(PAH_176E4[1]*8.7907*DENS[2])
+PAH_176E3       ,ug/m3     ,1000.0*(PAH_176E3[1]*9.6166*DENS[2])
+PAH_192E3       ,ug/m3     ,1000.0*(PAH_192E3[1]*9.2745*DENS[2])
+PAH_101E2       ,ug/m3     ,1000.0*(PAH_101E2[1]*10.4493*DENS[2])
+PAH_176E2       ,ug/m3     ,1000.0*(PAH_176E2[1]*8.8556*DENS[2])
+PAH_114E1       ,ug/m3     ,1000.0*(PAH_114E1[1]*3.3793*DENS[2])
+
+!Mercuric gas species
+HG_0            ,ng/m3     ,1000.0*(HG[1]*8.3330*DENS[2]*1000.0)       
+HG_II           ,ng/m3     ,1000.0*(HGIIGAS[1]*8.3330*DENS[2]*1000.0) 
+
+!! Unused Gases. Presented Here for illustration. Users can uncomment
+!! them if they choose.
+!ALDX            ,ppbV      ,1000.0*ALDX[1]
+!CLNO2           ,ppbV      ,1000.0*CLNO2[1] 
+!IOLE            ,ppbV      ,1000.0*IOLE[1]
+!OLE             ,ppbV      ,1000.0*OLE[1]
+!PAR             ,ppbV      ,1000.0*PAR[1]
+!PAN             ,ppbV      ,1000.0*PAN[1]
+!PANX            ,ppbV      ,1000.0*PANX[1]
+!SULF            ,ppbV      ,1000.0*SULF[1]
+!VOC             ,ppbC      ,1000.0* ( PAR[1]      + 2.0*ETH[1]  + MEOH[1]     + 2.0*ETOH[1]  \
+!                                     +2.0*OLE[1]  + 7.0*TOL[1]  + 8.0*XYLMN[1]+ FORM[1]      \
+!                                     +2.0*ALD2[1] + 2.0*ETHA[1] + 4.0*IOLE[1] + 2.0*ALDX[1]  \
+!                                     +5.0*ISOP[1] + 10.0*TERP[1]+ 10.0*NAPH[1])
+ 
+!! DMS and MSA. Users can uncomment them if they choose.
+DMS            ,ppbV      ,1000.0*DMS[1]
+MSA            ,ppbV      ,1000.0*MSA[1]
+
+!-------------------------------------------!
+!--------------- Particles -----------------!
+!-------------------------------------------!
+!! Crustal Elements
+AFEJ            ,ug m-3    ,AFEJ[1]
+AALJ            ,ug m-3    ,AALJ[1]
+ASIJ            ,ug m-3    ,ASIJ[1]
+ATIJ            ,ug m-3    ,ATIJ[1]
+ACAJ            ,ug m-3    ,ACAJ[1]
+AMGJ            ,ug m-3    ,AMGJ[1]
+AKJ             ,ug m-3    ,AKJ[1]
+AMNJ            ,ug m-3    ,AMNJ[1]
+ASOILJ          ,ug m-3    ,2.20*AALJ[1]+2.49*ASIJ[1]+1.63*ACAJ[1]+2.42*AFEJ[1]+1.94*ATIJ[1]
+
+!! Non-Crustal Inorganic Particle Species
+AHPLUSIJ        ,umol m-3  ,(AH3OPI[1]+AH3OPJ[1])*1.0/19.0
+ANAK            ,ug m-3    ,0.8373*ASEACAT[1]+0.0626*ASOIL[1]+0.0023*ACORS[1]
+AMGK            ,ug m-3    ,0.0997*ASEACAT[1]+0.0170*ASOIL[1]+0.0032*ACORS[1]
+AKK             ,ug m-3    ,0.0310*ASEACAT[1]+0.0242*ASOIL[1]+0.0176*ACORS[1]
+ACAK            ,ug m-3    ,0.0320*ASEACAT[1]+0.0838*ASOIL[1]+0.0562*ACORS[1]
+ACLIJ           ,ug m-3    ,ACLI[1]+ACLJ[1]
+AECIJ           ,ug m-3    ,AECI[1]+AECJ[1]
+ANAIJ           ,ug m-3    ,ANAJ[1]+ANAI[1]
+ANO3IJ          ,ug m-3    ,ANO3I[1]+ANO3J[1]
+ANO3K           ,ug m-3    ,ANO3K[1]
+TNO3            ,ug m-3    ,2175.6*(HNO3[1]*DENS[2])+ANO3I[1]+ANO3J[1]+ANO3K[1]
+ANH4IJ          ,ug m-3    ,ANH4I[1]+ANH4J[1]
+ANH4K           ,ug m-3    ,ANH4K[1]
+ASO4IJ          ,ug m-3    ,ASO4I[1]+ASO4J[1]
+ASO4K           ,ug m-3    ,ASO4K[1]
+
+!! Organic Particle Species
+APOCI           ,ugC m-3   ,ALVPO1I[1]/1.39 + ASVPO1I[1]/1.32 + ASVPO2I[1]/1.26 \
+                            +APOCI[1]
+APOCJ           ,ugC m-3   ,ALVPO1J[1]/1.39 + ASVPO1J[1]/1.32 + ASVPO2J[1]/1.26 \
+                           +ASVPO3J[1]/1.21 + AIVPO1J[1]/1.17  + APOCJ[1]
+APOCIJ          ,ugC m-3   ,APOCI[0] + APOCJ[0]
+
+APOMI           ,ug m-3    ,ALVPO1I[1] + ASVPO1I[1] + ASVPO2I[1] + APOCI[1]    \
+                            +APNCOMI[1]
+APOMJ           ,ug m-3    ,ALVPO1J[1] + ASVPO1J[1] + ASVPO2J[1] + APOCJ[1]    \
+                           +ASVPO3J[1] + AIVPO1J[1]  + APNCOMJ[1]
+APOMIJ          ,ug m-3    ,APOMI[0] + APOMJ[0]
+
+ASOCI           ,ugC m-3   ,ALVOO1I[1]/2.27 + ALVOO2I[1]/2.06  \
+                           +ASVOO1I[1]/1.88 + ASVOO2I[1]/1.73
+ASOCJ           ,ugC m-3   ,AISO1J[1]/2.20  + AISO2J[1]/2.23  + AISO3J[1]/2.80  \
+                           +AMT1J[1]/1.67   + AMT2J[1]/1.67   + AMT3J[1]/1.72   \
+                           +AMT4J[1]/1.53   + AMT5J[1]/1.57   + AMT6J[1]/1.40   \
+                           +AMTNO3J[1]/1.90 + AMTHYDJ[1]/1.54                   \
+                           +AGLYJ[1]/2.13   + ASQTJ[1]/1.52                     \
+                           +AORGCJ[1]/2.00  + AOLGBJ[1]/2.10  + AOLGAJ[1]/2.50  \
+                           +ALVOO1J[1]/2.27 + ALVOO2J[1]/2.06 + ASVOO1J[1]/1.88 \
+                           +ASVOO2J[1]/1.73 + ASVOO3J[1]/1.60                   \
+                           +AAVB1J[1]/2.70  + AAVB2J[1]/2.35  + AAVB3J[1]/2.17  \
+                           +AAVB4J[1]/1.99 + APCSOJ[1]/2.00
+ASOCIJ          ,ugC m-3   ,ASOCI[0] + ASOCJ[0]
+
+ASOMI           ,ug m-3    ,ALVOO1I[1] + ALVOO2I[1] + ASVOO1I[1] + ASVOO2I[1] 
+ASOMJ           ,ug m-3    ,+AISO1J[1]+ AISO2J[1]  + AISO3J[1]              \
+                            +AMT1J[1]   + AMT2J[1]   + AMT3J[1]             \
+                            +AMT4J[1]   + AMT5J[1]   + AMT6J[1]             \
+                            +AMTNO3J[1] + AMTHYDJ[1]                        \
+                            +AGLYJ[1]   + ASQTJ[1]                          \
+                            +AORGCJ[1]  + AOLGBJ[1]  + AOLGAJ[1]            \
+                            +ALVOO1J[1] + ALVOO2J[1] + ASVOO1J[1]           \
+                            +ASVOO2J[1] + ASVOO3J[1] + APCSOJ[1]            \
+                            +AAVB1J[1]  + AAVB2J[1]  + AAVB3J[1]            \
+                            +AAVB4J[1]
+ASOMIJ          ,ug m-3    ,ASOMI[0] + ASOMJ[0]
+ 
+AOCI            ,ugC m-3    ,APOCI[0]  + ASOCI[0]
+AOCJ            ,ugC m-3    ,APOCJ[0]  + ASOCJ[0]
+
+AOCIJ           ,ugC m-3    ,APOCIJ[0] + ASOCIJ[0]
+
+
+AOMI            ,ug m-3     ,APOMI[0]  + ASOMI[0]
+AOMJ            ,ug m-3     ,APOMJ[0]  + ASOMJ[0]
+
+AOMIJ           ,ug m-3     ,APOMIJ[0] + ASOMIJ[0]
+
+!!! Anthropogenic-VOC Derived Organic Aerosol
+AORGAI          ,ug m-3    ,ALVOO1I[1] + ALVOO2I[1] + ASVOO1I[1]       \ 
+                           +ASVOO2I[1]
+AORGAJ          ,ug m-3    ,ALVOO1J[1] + ALVOO2J[1]                    \
+                           +ASVOO1J[1] + ASVOO2J[1] + ASVOO3J[1]       \
+                           +AAVB1J[1] + AAVB2J[1] + AAVB3J[1]          \
+                           +AAVB4J[1] + AOLGAJ[1] + APCSOJ[1]   
+AORGAIJ         ,ug m-3    ,AORGAI[0] + AORGAJ[0]                           
+
+!!! Biogenic-VOC Derived Organic Aerosol
+AORGBIJ         ,ug m-3    ,AMT1J[1] + AMT2J[1] + AMT3J[1] + AMT4J[1]  \
+                           +AMT5J[1] + AMT6J[1] + AMTNO3J[1]           \
+                           +AMTHYDJ[1] + AISO1J[1] + AISO2J[1]         \
+                           +AISO3J[1] + ASQTJ[1] + AOLGBJ[1] 
+
+!!! Cloud-Processed  SOA
+AORGCJ          ,ug m-3    ,AORGCJ[1]
+!!! Remaining SOA
+AGLYJ           ,ug m-3    ,AGLYJ[1]
+
+!!! OM/OC ratios
+AOMOCRAT_TOT    ,           ,AOMIJ[0]/AOCIJ[0]
+
+!! Total PM Aggregates
+ATOTI           ,ug m-3    ,ASO4I[1] + ANH4I[1] + ANO3I[1] + ANAI[1]   \
+                           +ACLI[1] + AECI[1] + AOMI[0] + AOTHRI[1] 
+ATOTJ           ,ug m-3    ,ASO4J[1] + ANH4J[1] + ANO3J[1] + ANAJ[1]   \
+                           +ACLJ[1] + AECJ[1] + AOMJ[0] + AOTHRJ[1]    \
+                           +AFEJ[1] + AALJ[1] + ASIJ[1] + ATIJ[1]      \
+                           +ACAJ[1] + AMGJ[1] + AKJ[1] + AMNJ[1]        
+                            
+ATOTK           ,ug m-3    ,ASO4K[1] + ANH4K[1] + ANO3K[1] + ACLK[1]   \
+                           +ACORS[1] + ASOIL[1] + ASEACAT[1]   
+ATOTIJ          ,ug m-3    ,ATOTI[0] + ATOTJ[0] 
+ATOTIJK         ,ug m-3    ,ATOTI[0] + ATOTJ[0] + ATOTK[0]
+
+!! Unspeciated PM including non-carbon organic mass
+AUNSPEC1IJ      ,ug m-3    ,ATOTIJ[0] - (ASO4IJ[0] + ANO3IJ[0]         \
+                                         +ANH4IJ[0] + ACLIJ[0]         \
+                                         +ANAIJ[0] + AECIJ[0]          \
+                                         +AOCIJ[0] + ASOILJ[0])       
+!! Non-Carbon Organic Mass
+ANCOMIJ         ,ug m-3    ,AOMIJ[0] - AOCIJ[0]
+
+!! Unspeciated PM excluding non-carbon organic mass
+AUNSPEC2IJ      ,ug m-3     ,AUNSPEC1IJ[0] - ANCOMIJ[0]
+
+!! AMS Projection of Output Concentrations
+PMAMS_CL        ,ug m-3    ,ACLI[1] *FAMSAIT[3] +ACLJ[1]*FAMSACC[3]+ACLK[1] *FAMSCOR[3]
+PMAMS_NH4       ,ug m-3    ,ANH4I[1]*FAMSAIT[3]+ANH4J[1]*FAMSACC[3]+ANH4K[1]*FAMSCOR[3]
+PMAMS_NO3       ,ug m-3    ,ANO3I[1]*FAMSAIT[3]+ANO3J[1]*FAMSACC[3]+ANO3K[1]*FAMSCOR[3]
+PMAMS_OA        ,ug m-3    ,AOMI[0] *FAMSAIT[3]+AOMJ[0] *FAMSACC[3]
+PMAMS_SO4       ,ug m-3    ,ASO4I[1]*FAMSAIT[3]+ASO4J[1]*FAMSACC[3]+ASO4K[1]*FAMSCOR[3]
+
+!! PM1 Cutoff Output
+PM1_TOT         ,ug m-3    ,ATOTI[0]*FPM1AIT[3]+ATOTJ[0]*FPM1ACC[3]+ATOTK[0]*FPM1COR[3]
+
+!! Unused PM1 Species. Included Here for demonstration
+!PM1_EC         ,ug m-3    ,AECI[1] *FPM1AIT[3] +AECJ[1] *FPM1ACC[3]
+!PM1_OC         ,ugC m-3   ,AOCI[0] *FPM1AIT[3] +AOCJ[0] *FPM1ACC[3]
+!PM1_OM         ,ug m-3    ,AOMI[0] *FPM1AIT[3] +AOMJ[0] *FPM1ACC[3]
+!PM1_SO4        ,ug m-3    ,ASO4I[1]*FPM1AIT[3] +ASO4J[1]*FPM1ACC[3] +ASO4K[1]*FPM1COR[3]
+!PM1_CL         ,ug m-3    ,ACLI[1] *FPM1AIT[3] +ACLJ[1] *FPM1ACC[3] +ACLK[1] *FPM1COR[3]
+!PM1_NA         ,ug m-3    ,ANAI[1] *FPM1AIT[3] +ANAJ[1] *FPM1ACC[3] +ANAK[0] *FPM1COR[3]
+!PM1_MG         ,ug m-3    ,                     AMGJ[1] *FPM1ACC[3] +AMGK[0] *FPM1COR[3]
+!PM1_K          ,ug m-3    ,                     AKJ[1]  *FPM1ACC[3] +AKK[0]  *FPM1COR[3]
+!PM1_CA         ,ug m-3    ,                     ACAJ[1] *FPM1ACC[3] +ACAK[0] *FPM1COR[3]
+!PM1_NH4        ,ug m-3    ,ANH4I[1] *FPM1AIT[3]+ANH4J[1]*FPM1ACC[3] +ANH4K[1]*FPM1COR[3]
+!PM1_NO3        ,ug m-3    ,ANO3I[1] *FPM1AIT[3]+ANO3J[1]*FPM1ACC[3] +ANO3K[1]*FPM1COR[3] 
+!PM1_SOIL       ,ug m-3    ,ASOILJ[0]*FPM1ACC[3]+(ASOIL[1]+ACORS[1])*FPM1COR[3]
+!PM1_UNSPEC1    ,ug m-3    ,PM1_TOT[0] - (PM1_CL[0] + PM1_EC[0]+ PM1_NA[0]  + PM1_NH4[0] +  \
+!                                         PM1_NO3[0]+ PM1_OC[0]+ PM1_SOIL[0]+ PM1_SO4[0] ) 
+!PM1_UNSPCRS    ,ug m-3    ,ATOTK[0] *FPM1COR[3] - (ASO4K[1]*FPM1COR[3] \
+!                                                  +ACLK[1]*FPM1COR[3]  \
+!                                                  +ANAK[0]*FPM1COR[3]  \
+!                                                  +AMGK[0]*FPM1COR[3]  \
+!                                                  +AKK[0]*FPM1COR[3]   \
+!                                                  +ACAK[0]*FPM1COR[3]  \
+!                                                  +ANH4K[1]*FPM1COR[3] \
+!                                                  +ANO3K[1]*FPM1COR[3]) 
+ 
+!! PM2.5 species computed using modeled size distribution
+PM25_HP         ,ug m-3    ,(AH3OPI[1]*FPM25AIT[3]+AH3OPJ[1]*FPM25ACC[3]+AH3OPK[1]*FPM25COR[3])*1.0/19.0
+PM25_CL         ,ug m-3    ,ACLI[1]*FPM25AIT[3]+ACLJ[1]*FPM25ACC[3]+ACLK[1]*FPM25COR[3]
+PM25_EC         ,ug m-3    ,AECI[1]*FPM25AIT[3]+AECJ[1]*FPM25ACC[3]
+PM25_NA         ,ug m-3    ,ANAI[1]*FPM25AIT[3]+ANAJ[1]*FPM25ACC[3]+ANAK[0]*FPM25COR[3]
+PM25_MG         ,ug m-3    ,                    AMGJ[1]*FPM25ACC[3]+AMGK[0]*FPM25COR[3]
+PM25_K          ,ug m-3    ,                    AKJ[1] *FPM25ACC[3]+AKK[0] *FPM25COR[3]
+PM25_CA         ,ug m-3    ,                    ACAJ[1]*FPM25ACC[3]+ACAK[0]*FPM25COR[3]
+PM25_NH4        ,ug m-3    ,ANH4I[1]*FPM25AIT[3]+ANH4J[1]*FPM25ACC[3]+ANH4K[1]*FPM25COR[3]
+PM25_NO3        ,ug m-3    ,ANO3I[1]*FPM25AIT[3]+ANO3J[1]*FPM25ACC[3]+ANO3K[1]*FPM25COR[3]
+PM25_OC         ,ugC m-3   ,AOCI[0] *FPM25AIT[3]+AOCJ[0]*FPM25ACC[3]
+PM25_OM         ,ug m-3    ,AOMI[0] *FPM25AIT[3]+AOMJ[0]*FPM25ACC[3]
+PM25_SOIL       ,ug m-3    ,ASOILJ[0]*FPM25ACC[3]+ASOIL[1]*FPM25COR[3]
+PM25_SO4        ,ug m-3    ,ASO4I[1]*FPM25AIT[3]+ASO4J[1]*FPM25ACC[3]+ASO4K[1]*FPM25COR[3]
+PM25_TOT        ,ug m-3    ,ATOTI[0]*FPM25AIT[3]+ATOTJ[0]*FPM25ACC[3]+ATOTK[0]*FPM25COR[3]
+PM25_UNSPEC1    ,ug m-3    ,PM25_TOT[0]-(PM25_CL[0]+PM25_EC[0]+PM25_NA[0]+PM25_NH4[0] \
+                           +PM25_NO3[0]+PM25_OC[0]+PM25_SOIL[0]+PM25_SO4[0])
+PM25_UNSPCRS    ,ug m-3    ,ATOTK[0]*FPM25COR[3] - (ASO4K[1]*FPM25COR[3] \
+                                                  +ACLK[1]*FPM25COR[3]  \
+                                                  +ANAK[0]*FPM25COR[3]  \
+                                                  +AMGK[0]*FPM25COR[3]  \
+                                                  +AKK[0]*FPM25COR[3]   \
+                                                  +ACAK[0]*FPM25COR[3]  \
+                                                  +ANH4K[1]*FPM25COR[3] \
+                                                  +ANO3K[1]*FPM25COR[3]) 
+
+
+!! Fine particle acidity (pH). pH is undefined if there is no aerosol water. 
+!Do not trust predictions when hourly water is <0.01 ug m-3. FINEPHF will 
+!have large negative value (-9.999E36) when pH is not to be trusted.
+!AH2OIJ         ,ug m-3     ,AH2OI[1]+AH2OJ[1]
+!HPMOLAL        ,mol kg-1   ,AHPLUSIJ[0]/AH2OIJ[0]*1000.0
+!ACIDITYTEMP    ,           ,-1*LOG10(HPMOLAL[0])
+!FINEPHF        ,           ,AH2OIJ[0]>0.01 ? ACIDITYTEMP[0] : -9.999E36
+
+!! PM10.0 and Coarse-Sized Species
+PM10            ,ug m-3    ,ATOTI[0]*FPM10AIT[3]+ATOTJ[0]*FPM10ACC[3]+ATOTK[0]*FPM10COR[3]
+
+PMC_CL          ,ug m-3    ,ACLI[1]*FPM10AIT[3] +ACLJ[1]*FPM10ACC[3] +ACLK[1]*FPM10COR[3] -PM25_CL[0]
+PMC_NA          ,ug m-3    ,ANAI[1]*FPM10AIT[3] +ANAJ[1]*FPM10ACC[3] +ANAK[0]*FPM10COR[3] -PM25_NA[0]
+PMC_NH4         ,ug m-3    ,ANH4I[1]*FPM10AIT[3]+ANH4J[1]*FPM10ACC[3]+ANH4K[1]*FPM10COR[3]-PM25_NH4[0]
+PMC_NO3         ,ug m-3    ,ANO3I[1]*FPM10AIT[3]+ANO3J[1]*FPM10ACC[3]+ANO3K[1]*FPM10COR[3]-PM25_NO3[0]
+PMC_SO4         ,ug m-3    ,ASO4I[1]*FPM10AIT[3]+ASO4J[1]*FPM10ACC[3]+ASO4K[1]*FPM10COR[3]-PM25_SO4[0]
+PMC_TOT         ,ug m-3    ,PM10[0]-PM25_TOT[0]
+
+!! Deisel PM Species
+DIESEL_PM10     ,ug m-3    ,ADE_OTHRI[1]*FPM10AIT[3] + ADE_OTHRJ[1]*FPM10ACC[3] \
+                           +ADE_ECI[1]  *FPM10AIT[3] + ADE_ECJ[1]  *FPM10ACC[3] \
+                           +ADE_OCI[1]  *FPM10AIT[3] + ADE_OCJ[1]  *FPM10ACC[3] \
+                                                     + ADE_SO4J[1] *FPM10ACC[3] \
+                                                     + ADE_NO3J[1] *FPM10ACC[3] \
+                                                     + ADE_CORS[1] *FPM10COR[3] 
+DIESEL_PM25     ,ug m-3    ,ADE_OTHRI[1]*FPM25AIT[3] + ADE_OTHRJ[1]*FPM25ACC[3] \
+                           +ADE_ECI[1]  *FPM25AIT[3] + ADE_ECJ[1]  *FPM25ACC[3] \
+                           +ADE_OCI[1]  *FPM25AIT[3] + ADE_OCJ[1]  *FPM25ACC[3] \
+                                                     + ADE_SO4J[1] *FPM25ACC[3] \
+                                                     + ADE_NO3J[1] *FPM25ACC[3] \
+                                                     + ADE_CORS[1] *FPM25COR[3] 
+ 
+!!Benzo-A-Pyrene, gas and aerosol species
+BAP_GAS         ,ng/m3     ,1.0e6*8.7017*BENAPY[1]*DENS[2]      , gas phase benzo-a-pyrene
+BAP_AERO        ,ng/m3     ,1000.0*(ABENAPYI[1]+ABENAPYJ[1])    , fine aerosol phase benzo-a-pyrene
+BAP_FAERO       ,          ,BAP_AERO[0]/(BAP_AERO[0]+BAP_GAS[0]), aerosol fraction benzo-a-pyrene
+BAP_PM10        ,ng/m3     ,1000.0*(ABENAPYI[1]*FPM10AIT[3] + ABENAPYJ[1]*FPM10ACC[3])
+BAP_PM25        ,ng/m3     ,1000.0*(ABENAPYI[1]*FPM25AIT[3] + ABENAPYJ[1]*FPM25ACC[3])
+ 
+!Toxic Metallic PM species
+BERYLLIUM_PM10  ,ng m-3    ,1000.0*(ABEI[1]*FPM10AIT[3] + ABEJ[1]*FPM10ACC[3])
+BERYLLIUM_PM25  ,ng m-3    ,1000.0*(ABEI[1]*FPM25AIT[3] + ABEJ[1]*FPM25ACC[3])
+CADMIUM_PM10    ,ng m-3    ,1000.0*(ACDI[1]*FPM10AIT[3] + ACDJ[1]*FPM10ACC[3])
+CADMIUM_PM25    ,ng m-3    ,1000.0*(ACDI[1]*FPM25AIT[3] + ACDJ[1]*FPM25ACC[3])
+CR_III_PM10     ,ng m-3    ,1000.0*(ACR_IIII[1]*FPM10AIT[3] + ACR_IIIJ[1]*FPM10ACC[3])
+CR_III_PM25     ,ng m-3    ,1000.0*(ACR_IIII[1]*FPM25AIT[3] + ACR_IIIJ[1]*FPM25ACC[3])
+CR_VI_PM10      ,ng m-3    ,1000.0*(ACR_VII[1]*FPM10AIT[3] + ACR_VIJ[1]*FPM10ACC[3])
+CR_VI_PM25      ,ng m-3    ,1000.0*(ACR_VII[1]*FPM25AIT[3] + ACR_VIJ[1]*FPM25ACC[3])
+CHROMIUM_PM10   ,ng m-3    ,CR_III_PM10[0] + CR_VI_PM10[0]
+CHROMIUM_PM25   ,ng m-3    ,CR_III_PM25[0] + CR_VI_PM25[0]
+LEAD_PM10       ,ng m-3    ,1000.0*(APBI[1]*FPM10AIT[3] + APBJ[1]*FPM10ACC[3])
+LEAD_PM25       ,ng m-3    ,1000.0*(APBI[1]*FPM25AIT[3] + APBJ[1]*FPM25ACC[3])
+MANGANESE_PM10  ,ng m-3    ,1000.0*(AMN_HAPSI[1]*FPM10AIT[3] + AMN_HAPSJ[1]*FPM10ACC[3])
+MANGANESE_PM25  ,ng m-3    ,1000.0*(AMN_HAPSI[1]*FPM25AIT[3] + AMN_HAPSJ[1]*FPM25ACC[3])
+NICKEL_PM10     ,ng m-3    ,1000.0*(ANII[1]*FPM10AIT[3] + ANIJ[1]*FPM10ACC[3])
+NICKEL_PM25     ,ng m-3    ,1000.0*(ANII[1]*FPM25AIT[3] + ANIJ[1]*FPM25ACC[3])
+ARSENIC_PM10    ,ng m-3    ,1000.0*(AASI[1]*FPM10AIT[3] + AASJ[1]*FPM10ACC[3])
+ARSENIC_PM25    ,ng m-3    ,1000.0*(AASI[1]*FPM25AIT[3] + AASJ[1]*FPM25ACC[3])
+
+!Mercuric PM species
+HG_PM10         ,ng m-3    ,1000.0*(APHGI[1]*FPM10AIT[3] + APHGJ[1]*FPM10ACC[3])
+HG_PM25         ,ng m-3    ,1000.0*(APHGI[1]*FPM25AIT[3] + APHGJ[1]*FPM25ACC[3])
+  
+!! FRM PM Equivalent Calculation
+!! This section calculates the FRM applicable PM species, PMIJ_FRM and
+!! PM25_FRM. The intermediate variablse K...ANH4IJ_loss are needed to 
+!! calculate the final quantities.
+K               ,ppb2      ,exp(118.87-24084/TEMP2[4]-6.025*log(TEMP2[4]))
+P1              ,          ,exp(8763/TEMP2[4]+19.12*log(TEMP2[4])-135.94)
+P2              ,          ,exp(9969/TEMP2[4]+16.22*log(TEMP2[4])-122.65)
+P3              ,          ,exp(13875/TEMP2[4]+24.46*log(TEMP2[4])-182.61)
+a               ,          ,1-RH[0]/100
+K_prime         ,ppb2      ,(P1[0]-P2[0]*a[0]+(P3[0]*a[0]*a[0]))*(a[0]^1.75)*K[0]
+sqrt_Ki         ,ppb       ,sqrt(RH[0]<=61 ? K[0] : K_prime[0])
+max_NO3_loss    ,ug m-3     ,745.7/TEMP2[4]*sqrt_Ki[0]
+PM25_NO3_loss   ,ug m-3     ,max_NO3_loss[0]<=PM25_NO3[0] ? max_NO3_loss[0] : PM25_NO3[0]
+ANO3IJ_loss     ,ug m-3     ,max_NO3_loss[0]<=ANO3IJ[0] ? max_NO3_loss[0] : ANO3IJ[0]
+PM25_NH4_loss   ,ug m-3     ,PM25_NO3_loss[0]*(18/62)
+ANH4IJ_loss     ,ug m-3     ,ANO3IJ_loss[0]*(18/62)
+PMIJ_FRM        ,ug m-3     ,ATOTIJ[0]-(ANO3IJ_loss[0]+ANH4IJ_loss[0]) \
+                            +0.24*(ASO4IJ[0]+ANH4IJ[0]-ANH4IJ_loss[0])+0.5
+PM25_FRM        ,ug m-3     ,PM25_TOT[0]-(PM25_NO3_loss[0]+PM25_NH4_loss[0]) \
+                            +0.24*(PM25_SO4[0]+PM25_NH4[0]-PM25_NH4_loss[0])+0.5

--- a/CCTM/src/MECHS/cb6r5hap_ae7_aq/SpecDef_cb6r5hap_ae7_aq.txt
+++ b/CCTM/src/MECHS/cb6r5hap_ae7_aq/SpecDef_cb6r5hap_ae7_aq.txt
@@ -198,10 +198,10 @@ AOCIJ           ,ugC m-3   ,PMF_OC[3]
 AOMIJ           ,ug m-3    ,PMF_OA[3]
 
 !!! Anthropogenic-VOC Derived Organic Aerosol
-AORGAJ          ,ug m-3    ,PMF_ASOA[3]
+AORGAIJ         ,ug m-3    ,PMF_ASOA[3]
 
 !!! Biogenic-VOC Derived Organic Aerosol
-AORGBJ          ,ug m-3    ,PMF_BSOA[3]
+AORGBIJ         ,ug m-3    ,PMF_BSOA[3]
 
 !!! Cloud-Processed  SOA
 AORGCJ          ,ug m-3    ,AORGCJ[1]

--- a/CCTM/src/MECHS/cb6r5m_ae7_aq/SpecDef_Conc_cb6r5m_ae7_aq.txt
+++ b/CCTM/src/MECHS/cb6r5m_ae7_aq/SpecDef_Conc_cb6r5m_ae7_aq.txt
@@ -1,0 +1,347 @@
+!#start   YYYYJJJ  010000
+!#end     YYYYJJJ  000000
+#layer         1
+
+/
+! This Species Definition File is for Use with the COMBINE tool built for 
+! post-processing CMAQ output. It is compatible with CMAQv5.4.
+! Date: May 12 2017
+
+! Output variables that begin with 'PM' represent those in which a size cut was 
+! applied based on modeled aerosol mode parameters.  For example, PM25_NA is all 
+! sodium that falls below 2.5 um diameter. These 'PM' variables are used for 
+! comparisons at IMPROVE and CSN sites.
+
+! Output variables that begin with 'PMAMS' represent the mass that would have
+! been detected  by an Aerosol Mass Spectrometer.
+
+! Output variables beginning with 'A' (aside from AIR_DENS) represent a 
+! combination of aerosol species in which no size cut was applied.  For example, 
+! ASO4IJ is the sum of i-mode and j-mode sulfate.  These 'A' variables are used 
+! for comparisons at CASTNet sites.
+
+! Output variables beginning with 'PMC' refer to the coarse fraction of total PM,
+! computed by summing all modes and subtracting the PM2.5 fraction.  These 'PMC'
+! variables are used for comparisons at SEARCH sites.
+
+! This Species Definition File is just for use with the uncoupled, offline CMAQ,
+! model. If you are processing WRF-CMAQ results, a different Species Definition
+! file is required.
+
+/ File [1]: CMAQ conc/aconc file
+/ File [2]: METCRO3D file
+/ File [3]: ELMO/AELMO file
+/ File [4]: METCRO2D file
+/
+/new species    ,units     ,expression
+                                         
+!-------------------------------------------!
+!------------- Meteorology -----------------!
+!-------------------------------------------!
+AIR_DENS        ,kg m-3    ,DENS[2]
+RH              ,%         ,100.00*RH[3]
+SFC_TMP         ,C         ,(TEMP2[4]-273.15)
+PBLH            ,m         ,PBL[4]
+SOL_RAD         ,W m-2     ,RGRND[4]
+precip          ,cm        ,RC[4]>=0 ? RN[4]+RC[4] : RN[4]
+WSPD10          ,m s-1     ,WSPD10[4]
+WDIR10          ,deg       ,WDIR10[4]
+
+!-------------------------------------------!
+!--------------- Gases ---------------------!
+!-------------------------------------------!
+ALD2            ,ppbV      ,1000.0*ALD2[1]
+BENZENE         ,ppbV      ,1000.0*BENZENE[1]
+CO              ,ppbV      ,1000.0*CO[1]
+ETH             ,ppbV      ,1000.0*ETH[1]
+ETHA            ,ppbV      ,1000.0*ETHA[1]
+FORM            ,ppbV      ,1000.0*FORM[1]
+H2O2            ,ppbV      ,1000.0*H2O2[1]
+HNO3            ,ppbV      ,1000.0*HNO3[1]
+HNO3_UGM3       ,ug m-3    ,1000.0*(HNO3[1]*2.1756*DENS[2])
+HONO            ,ppbV      ,1000.0*HONO[1]
+HOX             ,ppbV      ,1000.0*(OH[1]+HO2[1])
+OH              ,ppbV      ,1000.0*(OH[1])
+ISOP            ,ppbV      ,1000.0*ISOP[1]
+N2O5            ,ppbV      ,1000.0*N2O5[1]
+NH3             ,ppbV      ,1000.0*NH3[1]
+NH3_UGM3        ,ug m-3    ,1000.0*(NH3[1]*0.5880*DENS[2])
+NHX             ,ug m-3    ,1000.0*(NH3[1]*0.5880*DENS[2])+ANH4I[1]+ANH4J[1]+ANH4K[1]
+NO              ,ppbV      ,1000.0*NO[1]
+NO2             ,ppbV      ,1000.0*NO2[1]
+NOX             ,ppbV      ,1000.0*(NO[1] + NO2[1])
+ANO3_PPB        ,ppbV      ,(ANO3I[1]+ANO3J[1]+ANO3K[1])/(DENS[2]*(62.0/28.97))
+NTR             ,ppbV      ,1000.0*(NTR1[1]+NTR2[1]+INTR[1])
+PANS            ,ppbV      ,1000.0*(PAN[1]+PANX[1]+OPAN[1])
+NOY             ,ppbV      ,1000.0* (NO[1]+NO2[1]+NO3[1]+2*N2O5[1]+HONO[1]+HNO3[1]+PNA[1] \
+                                     +CRON[1]+CLNO2[1]+CLNO3[1] \
+                                     +BRNO2[1]+BRNO3[1]+INO[1]+INO2[1]+INO3[1]) \                                    
+                                     +PANS[0]+NTR[0]+ANO3_PPB[0]
+O3              ,ppbV      ,1000.0*O3[1]
+SO2             ,ppbV      ,1000.0*SO2[1]
+SO2_UGM3        ,ug m-3    ,1000.0*(SO2[1]*2.2118*DENS[2])
+TERP            ,ppbV      ,1000.0*TERP[1]
+TOL             ,ppbV      ,1000.0*TOL[1]
+XYL             ,ppbV      ,1000.0*XYLMN[1]
+
+!Additional Toxic gases
+!ACROLEIN        ,ug m-3    ,1000.0*(ACROLEIN[1]*1.9365*DENS[2])
+!ACRO_PRIMARY    ,ug m-3    ,1000.0*(ACRO_PRIMARY*1.9365*DENS[2])
+!ALD2_PRIMARY    ,ug m-3    ,1000.0*(ALD2_PRIMARY[1]*1.5188*DENS[2])
+!FORM_PRIMARY    ,ug m-3    ,1000.0*(FORM_PRIMARY[1]*1.0356*DENS[2])
+!BUTADIENE13     ,ug m-3    ,1000.0*(BUTADIENE13[1]*1.8674*DENS[2])
+!HCL             ,ppbV      ,1000.0*HCL[1]
+!TOLUENE         ,ppbV      ,1000.0*TOLU[1]
+
+!Mercuric gas species
+!HG_0            ,ng/m3     ,1000.0*(HG[1]*8.3330*DENS[2]*1000.0)       
+!HG_II           ,ng/m3     ,1000.0*(HGIIGAS[1]*8.3330*DENS[2]*1000.0) 
+
+!! Unused Gases. Presented Here for illustration. Users can uncomment
+!! them if they choose.
+!ALDX            ,ppbV      ,1000.0*ALDX[1]
+!IOLE            ,ppbV      ,1000.0*IOLE[1]
+!OLE             ,ppbV      ,1000.0*OLE[1]
+!PAR             ,ppbV      ,1000.0*PAR[1]
+!PAN             ,ppbV      ,1000.0*PAN[1]
+!SULF            ,ppbV      ,1000.0*SULF[1]
+! emitted VOCs
+!VOC             ,ppbC      ,1000.0* (PAR[1] +2.0*ETHA[1] +3.0*PRPA[1] +MEOH[1]\
+!                            +2.0*ETH[1] +2.0*ETOH[1] +2.0*OLE[1] +3.0*ACET[1] \
+!                            +7.0*TOL[1] +8.0*XYLMN[1] +6.0*BENZENE[1] \
+!                            +FORM[1] +3.0*GLY[1] +4.0*KET[1] +2.0*ETHY[1] \
+!                           +2.0*ALD2[1] + 2.0*ETHA[1] + 4.0*IOLE[1] + 2.0*ALDX[1]  \
+!                           +5.0*ISOP[1] + 10.0*TERP[1]+ 10.0*NAPH[1] +10.*APIN[1])
+
+!! DMS and MSA. Users can uncomment them if they choose.
+DMS            ,ppbV      ,1000.0*DMS[1]
+MSA            ,ppbV      ,1000.0*MSA[1]
+
+!-------------------------------------------!
+!--------------- Particles -----------------!
+!-------------------------------------------!
+!! Crustal Elements
+AFEJ            ,ug m-3    ,AFEJ[1]
+AALJ            ,ug m-3    ,AALJ[1]
+ASIJ            ,ug m-3    ,ASIJ[1]
+ATIJ            ,ug m-3    ,ATIJ[1]
+ACAJ            ,ug m-3    ,ACAJ[1]
+AMGJ            ,ug m-3    ,AMGJ[1]
+AKJ             ,ug m-3    ,AKJ[1]
+AMNJ            ,ug m-3    ,AMNJ[1]
+ASOILJ          ,ug m-3    ,2.20*AALJ[1]+2.49*ASIJ[1]+1.63*ACAJ[1]+2.42*AFEJ[1]+1.94*ATIJ[1]
+
+!! Non-Crustal Inorganic Particle Species
+AHPLUSIJ        ,umol m-3  ,(AH3OPI[1]+AH3OPJ[1])*1.0/19.0
+ANAK            ,ug m-3    ,0.8373*ASEACAT[1]+0.0626*ASOIL[1]+0.0023*ACORS[1]
+AMGK            ,ug m-3    ,0.0997*ASEACAT[1]+0.0170*ASOIL[1]+0.0032*ACORS[1]
+AKK             ,ug m-3    ,0.0310*ASEACAT[1]+0.0242*ASOIL[1]+0.0176*ACORS[1]
+ACAK            ,ug m-3    ,0.0320*ASEACAT[1]+0.0838*ASOIL[1]+0.0562*ACORS[1]
+ACLIJ           ,ug m-3    ,ACLI[1]+ACLJ[1]
+AECIJ           ,ug m-3    ,AECI[1]+AECJ[1]
+ANAIJ           ,ug m-3    ,ANAJ[1]+ANAI[1]
+ANO3IJ          ,ug m-3    ,ANO3I[1]+ANO3J[1]
+ANO3K           ,ug m-3    ,ANO3K[1]
+TNO3            ,ug m-3    ,2175.6*(HNO3[1]*DENS[2])+ANO3I[1]+ANO3J[1]+ANO3K[1]
+ANH4IJ          ,ug m-3    ,ANH4I[1]+ANH4J[1]
+ANH4K           ,ug m-3    ,ANH4K[1]
+ASO4IJ          ,ug m-3    ,ASO4I[1]+ASO4J[1]
+ASO4K           ,ug m-3    ,ASO4K[1]
+
+!! Organic Particle Species
+APOCI           ,ugC m-3   ,ALVPO1I[1]/1.39 + ASVPO1I[1]/1.32 + ASVPO2I[1]/1.26 \
+                            +APOCI[1]
+APOCJ           ,ugC m-3   ,ALVPO1J[1]/1.39 + ASVPO1J[1]/1.32 + ASVPO2J[1]/1.26 \
+                           +ASVPO3J[1]/1.21 + AIVPO1J[1]/1.17  + APOCJ[1]
+APOCIJ          ,ugC m-3   ,APOCI[0] + APOCJ[0]
+
+APOMI           ,ug m-3    ,ALVPO1I[1] + ASVPO1I[1] + ASVPO2I[1] + APOCI[1]    \
+                            +APNCOMI[1]
+APOMJ           ,ug m-3    ,ALVPO1J[1] + ASVPO1J[1] + ASVPO2J[1] + APOCJ[1]    \
+                           +ASVPO3J[1] + AIVPO1J[1]  + APNCOMJ[1]
+APOMIJ          ,ug m-3    ,APOMI[0] + APOMJ[0]
+
+ASOCI           ,ugC m-3   ,ALVOO1I[1]/2.27 + ALVOO2I[1]/2.06  \
+                           +ASVOO1I[1]/1.88 + ASVOO2I[1]/1.73
+ASOCJ           ,ugC m-3   ,AISO1J[1]/2.20  + AISO2J[1]/2.23  + AISO3J[1]/2.80  \
+                           +AMT1J[1]/1.67   + AMT2J[1]/1.67   + AMT3J[1]/1.72   \
+                           +AMT4J[1]/1.53   + AMT5J[1]/1.57   + AMT6J[1]/1.40   \
+                           +AMTNO3J[1]/1.90 + AMTHYDJ[1]/1.54                   \
+                           +AGLYJ[1]/2.13   + ASQTJ[1]/1.52                     \
+                           +AORGCJ[1]/2.00  + AOLGBJ[1]/2.10  + AOLGAJ[1]/2.50  \
+                           +ALVOO1J[1]/2.27 + ALVOO2J[1]/2.06 + ASVOO1J[1]/1.88 \
+                           +ASVOO2J[1]/1.73 + ASVOO3J[1]/1.60                   \
+                           +AAVB1J[1]/2.70  + AAVB2J[1]/2.35  + AAVB3J[1]/2.17  \
+                           +AAVB4J[1]/1.99 + APCSOJ[1]/2.00
+ASOCIJ          ,ugC m-3   ,ASOCI[0] + ASOCJ[0]
+
+ASOMI           ,ug m-3    ,ALVOO1I[1] + ALVOO2I[1] + ASVOO1I[1] + ASVOO2I[1] 
+ASOMJ           ,ug m-3    ,+AISO1J[1]+ AISO2J[1]  + AISO3J[1]              \
+                            +AMT1J[1]   + AMT2J[1]   + AMT3J[1]             \
+                            +AMT4J[1]   + AMT5J[1]   + AMT6J[1]             \
+                            +AMTNO3J[1] + AMTHYDJ[1]                        \
+                            +AGLYJ[1]   + ASQTJ[1]                          \
+                            +AORGCJ[1]  + AOLGBJ[1]  + AOLGAJ[1]            \
+                            +ALVOO1J[1] + ALVOO2J[1] + ASVOO1J[1]           \
+                            +ASVOO2J[1] + ASVOO3J[1] + APCSOJ[1]            \
+                            +AAVB1J[1]  + AAVB2J[1]  + AAVB3J[1]            \
+                            +AAVB4J[1]
+ASOMIJ          ,ug m-3    ,ASOMI[0] + ASOMJ[0]
+ 
+AOCI            ,ugC m-3    ,APOCI[0]  + ASOCI[0]
+AOCJ            ,ugC m-3    ,APOCJ[0]  + ASOCJ[0]
+
+AOCIJ           ,ugC m-3    ,APOCIJ[0] + ASOCIJ[0]
+
+
+AOMI            ,ug m-3     ,APOMI[0]  + ASOMI[0]
+AOMJ            ,ug m-3     ,APOMJ[0]  + ASOMJ[0]
+
+AOMIJ           ,ug m-3     ,APOMIJ[0] + ASOMIJ[0]
+
+!!! Anthropogenic-VOC Derived Organic Aerosol
+AORGAI          ,ug m-3    ,ALVOO1I[1] + ALVOO2I[1] + ASVOO1I[1]       \ 
+                           +ASVOO2I[1]
+AORGAJ          ,ug m-3    ,ALVOO1J[1] + ALVOO2J[1]                    \
+                           +ASVOO1J[1] + ASVOO2J[1] + ASVOO3J[1]       \
+                           +AAVB1J[1] + AAVB2J[1] + AAVB3J[1]          \
+                           +AAVB4J[1] + AOLGAJ[1] + APCSOJ[1]   
+AORGAIJ         ,ug m-3    ,AORGAI[0] + AORGAJ[0]                           
+
+!!! Biogenic-VOC Derived Organic Aerosol
+AORGBIJ         ,ug m-3    ,AMT1J[1] + AMT2J[1] + AMT3J[1] + AMT4J[1]  \
+                           +AMT5J[1] + AMT6J[1] + AMTNO3J[1]           \
+                           +AMTHYDJ[1] + AISO1J[1] + AISO2J[1]         \
+                           +AISO3J[1] + ASQTJ[1] + AOLGBJ[1] 
+
+!!! Cloud-Processed  SOA
+AORGCJ          ,ug m-3    ,AORGCJ[1]
+!!! Remaining SOA
+AGLYJ           ,ug m-3    ,AGLYJ[1]
+
+!!! OM/OC ratios
+AOMOCRAT_TOT    ,           ,AOMIJ[0]/AOCIJ[0]
+
+!! Total PM Aggregates
+ATOTI           ,ug m-3    ,ASO4I[1] + ANH4I[1] + ANO3I[1] + ANAI[1]   \
+                           +ACLI[1] + AECI[1] + AOMI[0] + AOTHRI[1] 
+ATOTJ           ,ug m-3    ,ASO4J[1] + ANH4J[1] + ANO3J[1] + ANAJ[1]   \
+                           +ACLJ[1] + AECJ[1] + AOMJ[0] + AOTHRJ[1]    \
+                           +AFEJ[1] + AALJ[1] + ASIJ[1] + ATIJ[1]      \
+                           +ACAJ[1] + AMGJ[1] + AKJ[1] + AMNJ[1]        
+                            
+ATOTK           ,ug m-3    ,ASO4K[1] + ANH4K[1] + ANO3K[1] + ACLK[1]   \
+                           +ACORS[1] + ASOIL[1] + ASEACAT[1]   
+ATOTIJ          ,ug m-3    ,ATOTI[0] + ATOTJ[0] 
+ATOTIJK         ,ug m-3    ,ATOTI[0] + ATOTJ[0] + ATOTK[0]
+
+!! Unspeciated PM including non-carbon organic mass
+AUNSPEC1IJ      ,ug m-3    ,ATOTIJ[0] - (ASO4IJ[0] + ANO3IJ[0]         \
+                                         +ANH4IJ[0] + ACLIJ[0]         \
+                                         +ANAIJ[0] + AECIJ[0]          \
+                                         +AOCIJ[0] + ASOILJ[0])       
+!! Non-Carbon Organic Mass
+ANCOMIJ         ,ug m-3    ,AOMIJ[0] - AOCIJ[0]
+
+!! Unspeciated PM excluding non-carbon organic mass
+AUNSPEC2IJ      ,ug m-3     ,AUNSPEC1IJ[0] - ANCOMIJ[0]
+
+!! AMS Projection of Output Concentrations
+PMAMS_CL        ,ug m-3    ,ACLI[1] *FAMSAIT[3] +ACLJ[1]*FAMSACC[3]+ACLK[1] *FAMSCOR[3]
+PMAMS_NH4       ,ug m-3    ,ANH4I[1]*FAMSAIT[3]+ANH4J[1]*FAMSACC[3]+ANH4K[1]*FAMSCOR[3]
+PMAMS_NO3       ,ug m-3    ,ANO3I[1]*FAMSAIT[3]+ANO3J[1]*FAMSACC[3]+ANO3K[1]*FAMSCOR[3]
+PMAMS_OA        ,ug m-3    ,AOMI[0] *FAMSAIT[3]+AOMJ[0] *FAMSACC[3]
+PMAMS_SO4       ,ug m-3    ,ASO4I[1]*FAMSAIT[3]+ASO4J[1]*FAMSACC[3]+ASO4K[1]*FAMSCOR[3]
+
+!! PM1 Cutoff Output
+PM1_TOT         ,ug m-3    ,ATOTI[0]*FPM1AIT[3]+ATOTJ[0]*FPM1ACC[3]+ATOTK[0]*FPM1COR[3]
+
+!! Unused PM1 Species. Included Here for demonstration
+!PM1_EC         ,ug m-3    ,AECI[1] *FPM1AIT[3] +AECJ[1] *FPM1ACC[3]
+!PM1_OC         ,ugC m-3   ,AOCI[0] *FPM1AIT[3] +AOCJ[0] *FPM1ACC[3]
+!PM1_OM         ,ug m-3    ,AOMI[0] *FPM1AIT[3] +AOMJ[0] *FPM1ACC[3]
+!PM1_SO4        ,ug m-3    ,ASO4I[1]*FPM1AIT[3] +ASO4J[1]*FPM1ACC[3] +ASO4K[1]*FPM1COR[3]
+!PM1_CL         ,ug m-3    ,ACLI[1] *FPM1AIT[3] +ACLJ[1] *FPM1ACC[3] +ACLK[1] *FPM1COR[3]
+!PM1_NA         ,ug m-3    ,ANAI[1] *FPM1AIT[3] +ANAJ[1] *FPM1ACC[3] +ANAK[0] *FPM1COR[3]
+!PM1_MG         ,ug m-3    ,                     AMGJ[1] *FPM1ACC[3] +AMGK[0] *FPM1COR[3]
+!PM1_K          ,ug m-3    ,                     AKJ[1]  *FPM1ACC[3] +AKK[0]  *FPM1COR[3]
+!PM1_CA         ,ug m-3    ,                     ACAJ[1] *FPM1ACC[3] +ACAK[0] *FPM1COR[3]
+!PM1_NH4        ,ug m-3    ,ANH4I[1] *FPM1AIT[3]+ANH4J[1]*FPM1ACC[3] +ANH4K[1]*FPM1COR[3]
+!PM1_NO3        ,ug m-3    ,ANO3I[1] *FPM1AIT[3]+ANO3J[1]*FPM1ACC[3] +ANO3K[1]*FPM1COR[3] 
+!PM1_SOIL       ,ug m-3    ,ASOILJ[0]*FPM1ACC[3]+(ASOIL[1]+ACORS[1])*FPM1COR[3]
+!PM1_UNSPEC1    ,ug m-3    ,PM1_TOT[0] - (PM1_CL[0] + PM1_EC[0]+ PM1_NA[0]  + PM1_NH4[0] +  \
+!                                         PM1_NO3[0]+ PM1_OC[0]+ PM1_SOIL[0]+ PM1_SO4[0] ) 
+!PM1_UNSPCRS    ,ug m-3    ,ATOTK[0] *FPM1COR[3] - (ASO4K[1]*FPM1COR[3] \
+!                                                  +ACLK[1]*FPM1COR[3]  \
+!                                                  +ANAK[0]*FPM1COR[3]  \
+!                                                  +AMGK[0]*FPM1COR[3]  \
+!                                                  +AKK[0]*FPM1COR[3]   \
+!                                                  +ACAK[0]*FPM1COR[3]  \
+!                                                  +ANH4K[1]*FPM1COR[3] \
+!                                                  +ANO3K[1]*FPM1COR[3]) 
+ 
+!! PM2.5 species computed using modeled size distribution
+PM25_HP         ,ug m-3    ,(AH3OPI[1]*FPM25AIT[3]+AH3OPJ[1]*FPM25ACC[3]+AH3OPK[1]*FPM25COR[3])*1.0/19.0
+PM25_CL         ,ug m-3    ,ACLI[1]*FPM25AIT[3]+ACLJ[1]*FPM25ACC[3]+ACLK[1]*FPM25COR[3]
+PM25_EC         ,ug m-3    ,AECI[1]*FPM25AIT[3]+AECJ[1]*FPM25ACC[3]
+PM25_NA         ,ug m-3    ,ANAI[1]*FPM25AIT[3]+ANAJ[1]*FPM25ACC[3]+ANAK[0]*FPM25COR[3]
+PM25_MG         ,ug m-3    ,                    AMGJ[1]*FPM25ACC[3]+AMGK[0]*FPM25COR[3]
+PM25_K          ,ug m-3    ,                    AKJ[1] *FPM25ACC[3]+AKK[0] *FPM25COR[3]
+PM25_CA         ,ug m-3    ,                    ACAJ[1]*FPM25ACC[3]+ACAK[0]*FPM25COR[3]
+PM25_NH4        ,ug m-3    ,ANH4I[1]*FPM25AIT[3]+ANH4J[1]*FPM25ACC[3]+ANH4K[1]*FPM25COR[3]
+PM25_NO3        ,ug m-3    ,ANO3I[1]*FPM25AIT[3]+ANO3J[1]*FPM25ACC[3]+ANO3K[1]*FPM25COR[3]
+PM25_OC         ,ugC m-3   ,AOCI[0] *FPM25AIT[3]+AOCJ[0]*FPM25ACC[3]
+PM25_OM         ,ug m-3    ,AOMI[0] *FPM25AIT[3]+AOMJ[0]*FPM25ACC[3]
+PM25_SOIL       ,ug m-3    ,ASOILJ[0]*FPM25ACC[3]+ASOIL[1]*FPM25COR[3]
+PM25_SO4        ,ug m-3    ,ASO4I[1]*FPM25AIT[3]+ASO4J[1]*FPM25ACC[3]+ASO4K[1]*FPM25COR[3]
+PM25_TOT        ,ug m-3    ,ATOTI[0]*FPM25AIT[3]+ATOTJ[0]*FPM25ACC[3]+ATOTK[0]*FPM25COR[3]
+PM25_UNSPEC1    ,ug m-3    ,PM25_TOT[0]-(PM25_CL[0]+PM25_EC[0]+PM25_NA[0]+PM25_NH4[0] \
+                           +PM25_NO3[0]+PM25_OC[0]+PM25_SOIL[0]+PM25_SO4[0])
+PM25_UNSPCRS    ,ug m-3    ,ATOTK[0]*FPM25COR[3] - (ASO4K[1]*FPM25COR[3] \
+                                                  +ACLK[1]*FPM25COR[3]  \
+                                                  +ANAK[0]*FPM25COR[3]  \
+                                                  +AMGK[0]*FPM25COR[3]  \
+                                                  +AKK[0]*FPM25COR[3]   \
+                                                  +ACAK[0]*FPM25COR[3]  \
+                                                  +ANH4K[1]*FPM25COR[3] \
+                                                  +ANO3K[1]*FPM25COR[3]) 
+
+
+!! Fine particle acidity (pH). pH is undefined if there is no aerosol water. 
+!Do not trust predictions when hourly water is <0.01 ug m-3. FINEPHF will 
+!have large negative value (-9.999E36) when pH is not to be trusted.
+!AH2OIJ         ,ug m-3     ,AH2OI[1]+AH2OJ[1]
+!HPMOLAL        ,mol kg-1   ,AHPLUSIJ[0]/AH2OIJ[0]*1000.0
+!ACIDITYTEMP    ,           ,-1*LOG10(HPMOLAL[0])
+!FINEPHF        ,           ,AH2OIJ[0]>0.01 ? ACIDITYTEMP[0] : -9.999E36
+
+!! PM10.0 and Coarse-Sized Species
+PM10            ,ug m-3    ,ATOTI[0]*FPM10AIT[3]+ATOTJ[0]*FPM10ACC[3]+ATOTK[0]*FPM10COR[3]
+
+PMC_CL          ,ug m-3    ,ACLI[1]*FPM10AIT[3] +ACLJ[1]*FPM10ACC[3] +ACLK[1]*FPM10COR[3] -PM25_CL[0]
+PMC_NA          ,ug m-3    ,ANAI[1]*FPM10AIT[3] +ANAJ[1]*FPM10ACC[3] +ANAK[0]*FPM10COR[3] -PM25_NA[0]
+PMC_NH4         ,ug m-3    ,ANH4I[1]*FPM10AIT[3]+ANH4J[1]*FPM10ACC[3]+ANH4K[1]*FPM10COR[3]-PM25_NH4[0]
+PMC_NO3         ,ug m-3    ,ANO3I[1]*FPM10AIT[3]+ANO3J[1]*FPM10ACC[3]+ANO3K[1]*FPM10COR[3]-PM25_NO3[0]
+PMC_SO4         ,ug m-3    ,ASO4I[1]*FPM10AIT[3]+ASO4J[1]*FPM10ACC[3]+ASO4K[1]*FPM10COR[3]-PM25_SO4[0]
+PMC_TOT         ,ug m-3    ,PM10[0]-PM25_TOT[0]
+
+!! FRM PM Equivalent Calculation
+!! This section calculates the FRM applicable PM species, PMIJ_FRM and
+!! PM25_FRM. The intermediate variablse K...ANH4IJ_loss are needed to 
+!! calculate the final quantities.
+K               ,ppb2      ,exp(118.87-24084/TEMP2[4]-6.025*log(TEMP2[4]))
+P1              ,          ,exp(8763/TEMP2[4]+19.12*log(TEMP2[4])-135.94)
+P2              ,          ,exp(9969/TEMP2[4]+16.22*log(TEMP2[4])-122.65)
+P3              ,          ,exp(13875/TEMP2[4]+24.46*log(TEMP2[4])-182.61)
+a               ,          ,1-RH[0]/100
+K_prime         ,ppb2      ,(P1[0]-P2[0]*a[0]+(P3[0]*a[0]*a[0]))*(a[0]^1.75)*K[0]
+sqrt_Ki         ,ppb       ,sqrt(RH[0]<=61 ? K[0] : K_prime[0])
+max_NO3_loss    ,ug m-3     ,745.7/TEMP2[4]*sqrt_Ki[0]
+PM25_NO3_loss   ,ug m-3     ,max_NO3_loss[0]<=PM25_NO3[0] ? max_NO3_loss[0] : PM25_NO3[0]
+ANO3IJ_loss     ,ug m-3     ,max_NO3_loss[0]<=ANO3IJ[0] ? max_NO3_loss[0] : ANO3IJ[0]
+PM25_NH4_loss   ,ug m-3     ,PM25_NO3_loss[0]*(18/62)
+ANH4IJ_loss     ,ug m-3     ,ANO3IJ_loss[0]*(18/62)
+PMIJ_FRM        ,ug m-3     ,ATOTIJ[0]-(ANO3IJ_loss[0]+ANH4IJ_loss[0]) \
+                            +0.24*(ASO4IJ[0]+ANH4IJ[0]-ANH4IJ_loss[0])+0.5
+PM25_FRM        ,ug m-3     ,PM25_TOT[0]-(PM25_NO3_loss[0]+PM25_NH4_loss[0]) \
+                            +0.24*(PM25_SO4[0]+PM25_NH4[0]-PM25_NH4_loss[0])+0.5

--- a/CCTM/src/MECHS/cb6r5m_ae7_aq/SpecDef_cb6r5m_ae7_aq.txt
+++ b/CCTM/src/MECHS/cb6r5m_ae7_aq/SpecDef_cb6r5m_ae7_aq.txt
@@ -113,7 +113,9 @@ XYL             ,ppbV      ,1000.0*XYLMN[1]
 !                           +2.0*ALD2[1] + 2.0*ETHA[1] + 4.0*IOLE[1] + 2.0*ALDX[1]  \
 !                           +5.0*ISOP[1] + 10.0*TERP[1]+ 10.0*NAPH[1] +10.*APIN[1])
 
-
+!! DMS and MSA. Users can uncomment them if they choose.
+DMS            ,ppbV      ,1000.0*DMS[1]
+MSA            ,ppbV      ,1000.0*MSA[1]
 
 !-------------------------------------------!
 !--------------- Particles -----------------!
@@ -155,10 +157,10 @@ AOCIJ           ,ugC m-3   ,PMF_OC[3]
 AOMIJ           ,ug m-3    ,PMF_OA[3]
 
 !!! Anthropogenic-VOC Derived Organic Aerosol
-AORGAJ          ,ug m-3    ,PMF_ASOA[3]
+AORGAIJ         ,ug m-3    ,PMF_ASOA[3]
 
 !!! Biogenic-VOC Derived Organic Aerosol
-AORGBJ          ,ug m-3    ,PMF_BSOA[3]
+AORGBIJ         ,ug m-3    ,PMF_BSOA[3]
 
 !!! Cloud-Processed  SOA
 AORGCJ          ,ug m-3    ,AORGCJ[1]

--- a/CCTM/src/MECHS/cracmm1_aq/SpecDef_Conc_cracmm1_aq.txt
+++ b/CCTM/src/MECHS/cracmm1_aq/SpecDef_Conc_cracmm1_aq.txt
@@ -1,0 +1,382 @@
+!#start   YYYYJJJ  010000
+!#end     YYYYJJJ  000000
+#layer         1
+
+/
+! This Species Definition File is for Use with the COMBINE tool built for 
+! post-processing CMAQ output. It is compatible with CMAQv5.2.
+! Date: May 12 2017
+
+! Output variables that begin with 'PM' represent those in which a size cut was 
+! applied based on modeled aerosol mode parameters.  For example, PM25_NA is all 
+! sodium that falls below 2.5 um diameter. These 'PM' variables are used for 
+! comparisons at IMPROVE and CSN sites.
+
+! Output variables that begin with 'PMAMS' represent the mass that would have
+! been detected  by an Aerosol Mass Spectrometer.
+
+! Output variables beginning with 'A' (aside from AIR_DENS) represent a 
+! combination of aerosol species in which no size cut was applied.  For example, 
+! ASO4IJ is the sum of i-mode and j-mode sulfate.  These 'A' variables are used 
+! for comparisons at CASTNet sites.
+
+! Output variables beginning with 'PMC' refer to the coarse fraction of total PM,
+! computed by summing all modes and subtracting the PM2.5 fraction.  These 'PMC'
+! variables are used for comparisons at SEARCH sites.
+
+! This Species Definition File is just for use with the uncoupled, offline CMAQ,
+! model. If you are processing WRF-CMAQ results, a different Species Definition
+! file is required.
+
+/ File [1]: CMAQ conc/aconc file
+/ File [2]: METCRO3D file
+/ File [3]: ELMO/AELMO file
+/ File [4]: METCRO2D file
+/
+/new species    ,units     ,expression
+                                         
+!-------------------------------------------!
+!------------- Meteorology -----------------!
+!-------------------------------------------!
+AIR_DENS        ,kg m-3    ,DENS[2]
+RH              ,%         ,100.00*RH[3]
+SFC_TMP         ,C         ,(TEMP2[4]-273.15)
+PBLH            ,m         ,PBL[4]
+SOL_RAD         ,W m-2     ,RGRND[4]
+precip          ,cm        ,RC[4]>=0 ? RN[4]+RC[4] : RN[4]
+WSPD10          ,m s-1     ,WSPD10[4]
+WDIR10          ,deg       ,WDIR10[4]
+
+!-------------------------------------------!
+!--------------- Gases ---------------------!
+!-------------------------------------------!
+CO              ,ppbV      ,1000.0*CO[1]
+H2O2            ,ppbV      ,1000.0*H2O2[1]
+HNO3            ,ppbV      ,1000.0*HNO3[1]
+HNO3_UGM3       ,ug m-3    ,1000.0*(HNO3[1]*2.1756*DENS[2])  
+HONO            ,ppbV      ,1000.0*HONO[1]
+HOX             ,ppbV      ,1000.0*(HO[1]+HO2[1])
+OH              ,ppbV      ,1000.0*HO[1]
+N2O5            ,ppbV      ,1000.0*N2O5[1]
+NH3             ,ppbV      ,1000.0*NH3[1]
+NH3_UGM3        ,ug m-3    ,1000.0*(NH3[1]*0.5880*DENS[2])
+NHX             ,ug m-3    ,1000.0*(NH3[1]*0.5880*DENS[2])+ANH4I[1]+ANH4J[1]+ANH4K[1]
+NO              ,ppbV      ,1000.0*NO[1]
+NO2             ,ppbV      ,1000.0*NO2[1]
+NOX             ,ppbV      ,1000.0*(NO[1] + NO2[1])
+ANO3_PPB        ,ppbV      ,(ANO3I[1]+ANO3J[1]+ANO3K[1])/(DENS[2]*(62.0/28.97))
+NTR             ,ppbV      ,1000.0*(ONIT[1]+ISON[1]+TRPN[1]+NALD[1]), organic nitrates in RACM2
+PANS            ,ppbV      ,1000.0*(PAN[1]+PPN[1]+MPAN[1])
+NOY             ,ppbV      ,1000.0*(NO[1]+NO2[1]+NO3[1]+2*N2O5[1]+HONO[1] \
+                                   +HNO3[1]+HNO4[1]+PAN[1]+PPN[1]+MPAN[1] \
+                                   +ISON[1]+TRPN[1]+ONIT[1]+NALD[1])+ANO3_PPB[0]
+O3              ,ppbV      ,1000.0*O3[1]
+SO2             ,ppbV      ,1000.0*SO2[1]
+SO2_UGM3        ,ug m-3    ,1000.0*(SO2[1]*2.2118*DENS[2])
+TERP            ,ppbV      ,1000.0*(API[1]+LIM[1]),  a-pinene and limonene monoterpenes in RACM2
+
+! Deprecate these names in future
+ETH             ,ppbV      ,1000.0*ETE[1],            ethene is ETE in RACM2
+ETHA            ,ppbV      ,1000.0*ETH[1],            ethane is ETH in RACM2
+ALD2            ,ppbV      ,1000.0*ACD[1],            acetaldehyde is ACD in RACM2
+FORM            ,ppbV      ,1000.0*HCHO[1],           formaldehyde is HCHO RACM2
+ISOP            ,ppbV      ,1000.0*ISO[1],            isoprene is ISO in RACM2
+TOL             ,ppbV      ,1000.0*TOL[1]
+
+! Hydrocarbons for evaluation. Note an "s" on the end indicates a collection of species from AQS
+ACETALDEHYDE    ,ppbV      ,1000.0*ACD[1]
+ACETYLENE       ,ppbV      ,1000.0*ACE[1]
+ACROLEIN        ,ppbV      ,1000.0*ACRO[1]
+ACETONE         ,ppbV      ,1000.0*ACT[1]
+BUTADIENE13     ,ppbV      ,1000.0*BDE13[1]
+BENZENE         ,ppbV      ,1000.0*BEN[1]
+ETHYLENE        ,ppbV      ,1000.0*ETE[1],            ethene is ETE in RACM2
+ETHANE          ,ppbV      ,1000.0*ETH[1],            ethane is ETH in RACM2
+ISOPRENE        ,ppbV      ,1000.0*ISO[1],            isoprene is ISO in RACM2
+FORMALDEHYDE    ,ppbV      ,1000.0*HCHO[1],           formaldehyde is HCHO RACM2
+MEKETONE        ,ppbV      ,1000.0*MEK[1]
+TOLUENE         ,ppbV      ,1000.0*TOL[1]
+XYLENES         ,ppbV      ,1000.0*(XYE[1]+XYM[1])
+HCPROPANES      ,ppbV      ,1000.0*(HC3[1])
+HCPENTANES      ,ppbV      ,1000.0*(HC5[1])
+HCDECANES       ,ppbV      ,1000.0*(HC10[1]), formerly HC8
+OLEFINS         ,ppbV      ,1000.0*(OLI[1]+OLT[1])
+ABPINENES       ,ppbV      ,1000.0*(API[1])
+
+!! Unused Gases. Presented Here for illustration. Users can uncomment
+!! them if they choose.
+ALDX            ,ppbV      ,1000.0*ALD[1],            C3 and higher aldehydes is ALD in RACM2
+!NOZ             ,ppbV      ,NOY[0]-NOX[0]
+!SULF            ,ppbV      ,1000.0*SULF[1]
+! SIGROC: S/IVOC alk and oxy gas species
+LSIVROC         ,ppbC      ,1000.0* (9.5*VROCIOXY[1] \
+                                    +14.0*VROCP5ARO[1]+13.0*VROCP6ARO[1] \
+                                    +30.0*VROCN2ALK[1]+29.0*VROCN1ALK[1] \
+                                    +28.0*VROCP0ALK[1]+27.0*VROCP1ALK[1] \
+                                    +24.0*VROCP2ALK[1]+21.0*VROCP3ALK[1] \
+                                    +18.0*VROCP4ALK[1]+14.0*VROCP5ALK[1] \
+                                    +13.0*VROCP6ALK[1]\
+                                    +17.0*VROCN2OXY2[1]+11.0*VROCN2OXY4[1] \ 
+                                    +7.0*VROCN2OXY8[1]+20.0*VROCN1OXY1[1] \ 
+                                    +12.0*VROCN1OXY3[1]+8.0*VROCN1OXY6[1] \ 
+                                    +14.0*VROCP0OXY2[1]+10.0*VROCP0OXY4[1] \ 
+                                    +17.0*VROCP1OXY1[1]+11.0*VROCP1OXY3[1] \ 
+                                    +12.0*VROCP2OXY2[1]+11.0*VROCP3OXY2[1] \ 
+                                    +9.0*VROCP4OXY2[1]+11.0*VROCP5OXY1[1] \ 
+                                    +9.0*VROCP6OXY1[1] ),                  
+! VROC: Total gas-phase (vapor) reactive organic carbon (stable species only) 
+VROC             ,ppbC      ,1000.0*(2.0*ACD[1]+2.0*ACE[1] \
+                                    +3.0*ACRO[1]+3.0*ACT[1]+3.0*ALD[1]+10*API[1] \
+                                    +7.0*BALD[1]+4.0*BDE13[1]+6.0*BEN[1] \
+                                    +9.0*CSL[1]+5.0*DCB1[1]+6.0*DCB2[1]+4.0*DCB3[1] \
+                                    +20.0*ELHOM[1] \
+                                    +2.0*EOH[1]+2.0*ETE[1]+2.0*ETEG[1]+2.0*ETH[1] \
+                                    +5.0*FURAN[1]+4.0*FURANONE[1]+2.0*GLY[1]+10.0*HOM[1] \
+                                    +3.0*HC3[1]+5.0*HC5[1]+10.0*HC10[1]  \
+                                    +1.0*HCHO[1]+3.0*HKET[1] \
+                                    +5.0*IEPOX[1]+5.0*ISHP[1]+5.0*ISO[1]+5.0*KET[1] \
+                                    +10.0*LIM[1]+10.0*LIMAL[1]+4.0*MACR[1]+4*MAHP[1] \
+                                    +7.0*MCT[1]  \
+                                    +4.0*MEK[1]+3.0*MGLY[1]+1.0*MOH[1]+4.0*MVK[1] \
+                                    +10.0*NAPH[1]+5.0*OLI[1]+3.0*OLT[1] \
+                                    +1.0*OP1[1]+2.0*OP2[1]+8.0*OP3[1]+10.0*OPB[1]   \
+                                    +1.0*ORA1[1]+2.0*ORA2[1] \
+                                    +10.0*PINAL[1]   \
+                                    +6.0*PHEN[1]+3.0*PROG[1]  \
+                                    +3.0*ROH[1]+15.0*SESQ[1]+2.1*SLOWROC[1] \
+                                    +7.0*TOL[1]+5.0*UALD[1] \
+                                    +8.0*XYM[1]+8.0*XYE[1] \
+                                    +2.0*PAA[1]+2.0*PAN[1]+3.0*PPN[1]+4.0*MPAN[1] \  
+                                    +4.0*ONIT[1]+2.0*NALD[1]+5.0*ISON[1]+10.0*TRPN[1] ) \ 
+                                    +LSIVROC[0] ,
+
+!-------------------------------------------!
+!--------------- Particles -----------------!
+!-------------------------------------------!
+!! Crustal Elements
+AFEJ            ,ug m-3    ,AFEJ[1]
+AALJ            ,ug m-3    ,AALJ[1]
+ASIJ            ,ug m-3    ,ASIJ[1]
+ATIJ            ,ug m-3    ,ATIJ[1]
+ACAJ            ,ug m-3    ,ACAJ[1]
+AMGJ            ,ug m-3    ,AMGJ[1]
+AKJ             ,ug m-3    ,AKJ[1]
+AMNJ            ,ug m-3    ,AMNJ[1]
+ASOILJ          ,ug m-3    ,2.20*AALJ[1]+2.49*ASIJ[1]+1.63*ACAJ[1]+2.42*AFEJ[1]+1.94*ATIJ[1]
+
+!! Non-Crustal Inorganic Particle Species
+AHPLUSIJ        ,umol m-3  ,(AH3OPI[1]+AH3OPJ[1])*1.0/19.0
+ANAK            ,ug m-3    ,0.8373*ASEACAT[1]+0.0626*ASOIL[1]+0.0023*ACORS[1]
+AMGK            ,ug m-3    ,0.0997*ASEACAT[1]+0.0170*ASOIL[1]+0.0032*ACORS[1]
+AKK             ,ug m-3    ,0.0310*ASEACAT[1]+0.0242*ASOIL[1]+0.0176*ACORS[1]
+ACAK            ,ug m-3    ,0.0320*ASEACAT[1]+0.0838*ASOIL[1]+0.0562*ACORS[1]
+ACLIJ           ,ug m-3    ,ACLI[1]+ACLJ[1]
+AECIJ           ,ug m-3    ,AECI[1]+AECJ[1]
+ANAIJ           ,ug m-3    ,ANAJ[1]+ANAI[1]
+ANO3IJ          ,ug m-3    ,ANO3I[1]+ANO3J[1]
+ANO3K           ,ug m-3    ,ANO3K[1]
+TNO3            ,ug m-3    ,2175.6*(HNO3[1]*DENS[2])+ANO3I[1]+ANO3J[1]+ANO3K[1]
+ANH4IJ          ,ug m-3    ,ANH4I[1]+ANH4J[1]
+ANH4K           ,ug m-3    ,ANH4K[1]
+ASO4IJ          ,ug m-3    ,ASO4I[1]+ASO4J[1]
+ASO4K           ,ug m-3    ,ASO4K[1]
+
+!! Organic Particle Species
+! Why is there an APOCI and APOCJ in the output? It doesn't match below 
+APOCI     ,ugC m-3,  AROCN2ALKI[1]/1.39 + AROCN1ALKI[1]/1.32 \
+                    + AROCP0ALKI[1]/1.17 + AROCP1ALKI[1]/1.17
+APOCJ     ,ugC m-3,  AROCN2ALKJ[1]/1.39  + AROCN1ALKJ[1]/1.32 \
+                    + AROCP0ALKJ[1]/1.17 + AROCP1ALKJ[1]/1.17 \
+                     + AROCP2ALKJ[1]/1.17  + AROCP3ALKJ[1]/1.17
+APOCIJ    ,ugC m-3,  APOCI[0] + APOCJ[0]
+
+APOMI     ,ug m-3,   AROCN2ALKI[1] + AROCN1ALKI[1]  \
+                    + AROCP0ALKI[1] + AROCP1ALKI[1] + APNCOMI[1]
+APOMJ     ,ug m-3,   AROCN2ALKJ[1] + AROCN1ALKJ[1] + AROCP0ALKJ[1] \
+                    + AROCP1ALKJ[1] + AROCP2ALKJ[1]  + AROCP3ALKJ[1] + APNCOMJ[1]
+APOMIJ    ,ug m-3,   APOMI[0] + APOMJ[0]
+ASOCI     ,ugC m-3,  AROCN2OXY2I[1]/1.42  + AROCN2OXY4I[1]/1.67  \
+                    + AROCN2OXY8I[1]/2.17 + AROCN1OXY1I[1]/1.29 \
+                    + AROCN1OXY3I[1]/1.54 + AROCN1OXY6I[1]/1.92 \
+                    + AROCP0OXY2I[1]/1.42 + AROCP0OXY4I[1]/1.67 \
+                    + AROCP1OXY1I[1]/1.29 + AROCP1OXY3I[1]/1.54
+ASOCJ     ,ugC m-3,  AHOMJ[1]/2.08 + AELHOMJ[1]/1.67 + AISO3NOSJ[1]/2.27 \
+                   + AISO3OSJ[1]/3.6 + AGLYJ[1]/2.13 + AORGCJ[1]/2  \
+                   + AOP3J[1]/1.92 + ASOATJ[1]/2.31 + AROCN2OXY2J[1]/1.42 \
+                   + AROCN2OXY4J[1]/1.67 + AROCN2OXY8J[1]/2.17 + AROCN1OXY1J[1]/1.29 \
+                   + AROCN1OXY3J[1]/1.54 + AROCN1OXY6J[1]/1.92 + AROCP0OXY2J[1]/1.42 \
+                   + AROCP0OXY4J[1]/1.67 + AROCP1OXY1J[1]/1.29 + AROCP1OXY3J[1]/1.54 \
+                   + AROCP2OXY2J[1]/1.42 + AROCP3OXY2J[1]/1.42 
+ASOCIJ   ,ugC m-3,  ASOCI[0] + ASOCJ[0]
+
+ASOMI    ,ug m-3, AROCN2OXY2I[1]  + AROCN2OXY4I[1]  \
+                    + AROCN2OXY8I[1] + AROCN1OXY1I[1] \
+                    + AROCN1OXY3I[1] + AROCN1OXY6I[1] \
+                    + AROCP0OXY2I[1] + AROCP0OXY4I[1] \
+                    + AROCP1OXY1I[1] + AROCP1OXY3I[1]
+ASOMJ    ,ug m-3,  AHOMJ[1] + AELHOMJ[1] + AISO3NOSJ[1] \
+                   + AISO3OSJ[1] + AGLYJ[1] + AORGCJ[1]  \
+                   + AOP3J[1] + ASOATJ[1] + AROCN2OXY2J[1] \
+                   + AROCN2OXY4J[1] + AROCN2OXY8J[1] + AROCN1OXY1J[1] \
+                   + AROCN1OXY3J[1] + AROCN1OXY6J[1] + AROCP0OXY2J[1] \
+                   + AROCP0OXY4J[1] + AROCP1OXY1J[1] + AROCP1OXY3J[1] \
+                   + AROCP2OXY2J[1] + AROCP3OXY2J[1]
+
+ASOMIJ   ,ug m-3     ,ASOMI[0] + ASOMJ[0]
+ 
+AOCI            ,ugC m-3    ,APOCI[0]  + ASOCI[0]
+AOCJ            ,ugC m-3    ,APOCJ[0]  + ASOCJ[0]
+
+AOCIJ           ,ugC m-3    ,APOCIJ[0] + ASOCIJ[0]
+
+
+AOMI            ,ug m-3     ,APOMI[0]  + ASOMI[0]
+AOMJ            ,ug m-3     ,APOMJ[0]  + ASOMJ[0]
+
+AOMIJ           ,ug m-3     ,APOMIJ[0] + ASOMIJ[0]
+
+!!! Anthropogenic-VOC Derived Organic Aerosol
+AORGAI          ,ug m-3     ,AROCN2OXY2I[1]+AROCN2OXY4I[1]+AROCN2OXY8I[1]+AROCN1OXY1I[1]   \
+                            +AROCN1OXY3I[1]+AROCN1OXY6I[1]+AROCP0OXY2I[1]+AROCP0OXY4I[1]   \
+                            +AROCP1OXY1I[1]+AROCP1OXY3I[1]
+                            
+AORGAJ          ,ug m-3     ,AROCN2OXY2J[1]+AROCN2OXY4J[1]+AROCN2OXY8J[1]+AROCN1OXY1J[1]   \
+                            +AROCN1OXY3J[1]+AROCN1OXY6J[1]+AROCP0OXY2J[1]+AROCP0OXY4J[1]   \
+                            +AROCP1OXY1J[1]+AROCP1OXY3J[1]+AROCP2OXY2J[1]+AROCP3OXY2J[1]   \
+                            +AOP3J[1] +ASOATJ[1]
+AORGAIJ         ,ug m-3     ,AORGAI[0] + AORGAJ[0]
+
+!!! Biogenic-VOC Derived Organic Aerosol
+AORGBIJ         ,ug m-3    ,AISO3NOSJ[1] +AISO3OSJ[1] +AHOMJ[1] + AELHOMJ[1]
+
+!!! Cloud-Processed  SOA
+AORGCJ          ,ug m-3    ,AORGCJ[1]
+!!! Remaining SOA
+AGLYJ           ,ug m-3    ,AGLYJ[1]
+
+!!! OM/OC ratios
+AOMOCRAT_TOT    ,           ,AOMIJ[0]/AOCIJ[0]
+
+!! Total PM Aggregates
+ATOTI           ,ug m-3    ,ASO4I[1] + ANH4I[1] + ANO3I[1] + ANAI[1]   \
+                           +ACLI[1] + AECI[1] + AOMI[0] + AOTHRI[1] 
+ATOTJ           ,ug m-3    ,ASO4J[1] + ANH4J[1] + ANO3J[1] + ANAJ[1]   \
+                           +ACLJ[1] + AECJ[1] + AOMJ[0] + AOTHRJ[1]    \
+                           +AFEJ[1] + AALJ[1] + ASIJ[1] + ATIJ[1]      \
+                           +ACAJ[1] + AMGJ[1] + AKJ[1] + AMNJ[1]        
+                            
+ATOTK           ,ug m-3    ,ASO4K[1] + ANH4K[1] + ANO3K[1] + ACLK[1]   \
+                           +ACORS[1] + ASOIL[1] + ASEACAT[1]   
+ATOTIJ          ,ug m-3    ,ATOTI[0] + ATOTJ[0] 
+ATOTIJK         ,ug m-3    ,ATOTI[0] + ATOTJ[0] + ATOTK[0]
+
+!! Unspeciated PM including non-carbon organic mass
+AUNSPEC1IJ      ,ug m-3    ,ATOTIJ[0] - (ASO4IJ[0] + ANO3IJ[0]         \
+                                         +ANH4IJ[0] + ACLIJ[0]         \
+                                         +ANAIJ[0] + AECIJ[0]          \
+                                         +AOCIJ[0] + ASOILJ[0])       
+!! Non-Carbon Organic Mass
+ANCOMIJ         ,ug m-3    ,AOMIJ[0] - AOCIJ[0]
+
+!! Unspeciated PM excluding non-carbon organic mass
+AUNSPEC2IJ      ,ug m-3     ,AUNSPEC1IJ[0] - ANCOMIJ[0]
+
+!! AMS Projection of Output Concentrations
+PMAMS_CL        ,ug m-3    ,ACLI[1] *FAMSAIT[3] +ACLJ[1]*FAMSACC[3]+ACLK[1] *FAMSCOR[3]
+PMAMS_NH4       ,ug m-3    ,ANH4I[1]*FAMSAIT[3]+ANH4J[1]*FAMSACC[3]+ANH4K[1]*FAMSCOR[3]
+PMAMS_NO3       ,ug m-3    ,ANO3I[1]*FAMSAIT[3]+ANO3J[1]*FAMSACC[3]+ANO3K[1]*FAMSCOR[3]
+PMAMS_OA        ,ug m-3    ,AOMI[0] *FAMSAIT[3]+AOMJ[0] *FAMSACC[3]
+PMAMS_SO4       ,ug m-3    ,ASO4I[1]*FAMSAIT[3]+ASO4J[1]*FAMSACC[3]+ASO4K[1]*FAMSCOR[3]
+
+!! PM1 Cutoff Output
+PM1_TOT         ,ug m-3    ,ATOTI[0]*FPM1AIT[3]+ATOTJ[0]*FPM1ACC[3]+ATOTK[0]*FPM1COR[3]
+
+!! Unused PM1 Species. Included Here for demonstration
+!PM1_EC         ,ug m-3    ,AECI[1] *FPM1AIT[3] +AECJ[1] *FPM1ACC[3]
+!PM1_OC         ,ugC m-3   ,AOCI[0] *FPM1AIT[3] +AOCJ[0] *FPM1ACC[3]
+!PM1_OM         ,ug m-3    ,AOMI[0] *FPM1AIT[3] +AOMJ[0] *FPM1ACC[3]
+!PM1_SO4        ,ug m-3    ,ASO4I[1]*FPM1AIT[3] +ASO4J[1]*FPM1ACC[3] +ASO4K[1]*FPM1COR[3]
+!PM1_CL         ,ug m-3    ,ACLI[1] *FPM1AIT[3] +ACLJ[1] *FPM1ACC[3] +ACLK[1] *FPM1COR[3]
+!PM1_NA         ,ug m-3    ,ANAI[1] *FPM1AIT[3] +ANAJ[1] *FPM1ACC[3] +ANAK[0] *FPM1COR[3]
+!PM1_MG         ,ug m-3    ,                     AMGJ[1] *FPM1ACC[3] +AMGK[0] *FPM1COR[3]
+!PM1_K          ,ug m-3    ,                     AKJ[1]  *FPM1ACC[3] +AKK[0]  *FPM1COR[3]
+!PM1_CA         ,ug m-3    ,                     ACAJ[1] *FPM1ACC[3] +ACAK[0] *FPM1COR[3]
+!PM1_NH4        ,ug m-3    ,ANH4I[1] *FPM1AIT[3]+ANH4J[1]*FPM1ACC[3] +ANH4K[1]*FPM1COR[3]
+!PM1_NO3        ,ug m-3    ,ANO3I[1] *FPM1AIT[3]+ANO3J[1]*FPM1ACC[3] +ANO3K[1]*FPM1COR[3] 
+!PM1_SOIL       ,ug m-3    ,ASOILJ[0]*FPM1ACC[3]+(ASOIL[1]+ACORS[1])*FPM1COR[3]
+!PM1_UNSPEC1    ,ug m-3    ,PM1_TOT[0] - (PM1_CL[0] + PM1_EC[0]+ PM1_NA[0]  + PM1_NH4[0] +  \
+!                                         PM1_NO3[0]+ PM1_OC[0]+ PM1_SOIL[0]+ PM1_SO4[0] ) 
+!PM1_UNSPCRS    ,ug m-3    ,ATOTK[0] *FPM1COR[3] - (ASO4K[1]*FPM1COR[3] \
+!                                                  +ACLK[1]*FPM1COR[3]  \
+!                                                  +ANAK[0]*FPM1COR[3]  \
+!                                                  +AMGK[0]*FPM1COR[3]  \
+!                                                  +AKK[0]*FPM1COR[3]   \
+!                                                  +ACAK[0]*FPM1COR[3]  \
+!                                                  +ANH4K[1]*FPM1COR[3] \
+!                                                  +ANO3K[1]*FPM1COR[3]) 
+ 
+!! PM2.5 species computed using modeled size distribution
+PM25_HP         ,ug m-3    ,(AH3OPI[1]*FPM25AIT[3]+AH3OPJ[1]*FPM25ACC[3]+AH3OPK[1]*FPM25COR[3])*1.0/19.0
+PM25_CL         ,ug m-3    ,ACLI[1]*FPM25AIT[3]+ACLJ[1]*FPM25ACC[3]+ACLK[1]*FPM25COR[3]
+PM25_EC         ,ug m-3    ,AECI[1]*FPM25AIT[3]+AECJ[1]*FPM25ACC[3]
+PM25_NA         ,ug m-3    ,ANAI[1]*FPM25AIT[3]+ANAJ[1]*FPM25ACC[3]+ANAK[0]*FPM25COR[3]
+PM25_MG         ,ug m-3    ,                    AMGJ[1]*FPM25ACC[3]+AMGK[0]*FPM25COR[3]
+PM25_K          ,ug m-3    ,                    AKJ[1] *FPM25ACC[3]+AKK[0] *FPM25COR[3]
+PM25_CA         ,ug m-3    ,                    ACAJ[1]*FPM25ACC[3]+ACAK[0]*FPM25COR[3]
+PM25_NH4        ,ug m-3    ,ANH4I[1]*FPM25AIT[3]+ANH4J[1]*FPM25ACC[3]+ANH4K[1]*FPM25COR[3]
+PM25_NO3        ,ug m-3    ,ANO3I[1]*FPM25AIT[3]+ANO3J[1]*FPM25ACC[3]+ANO3K[1]*FPM25COR[3]
+PM25_OC         ,ugC m-3   ,AOCI[0] *FPM25AIT[3]+AOCJ[0]*FPM25ACC[3]
+PM25_OM         ,ug m-3    ,AOMI[0] *FPM25AIT[3]+AOMJ[0]*FPM25ACC[3]
+PM25_SOIL       ,ug m-3    ,ASOILJ[0]*FPM25ACC[3]+ASOIL[1]*FPM25COR[3]
+PM25_SO4        ,ug m-3    ,ASO4I[1]*FPM25AIT[3]+ASO4J[1]*FPM25ACC[3]+ASO4K[1]*FPM25COR[3]
+PM25_TOT        ,ug m-3    ,ATOTI[0]*FPM25AIT[3]+ATOTJ[0]*FPM25ACC[3]+ATOTK[0]*FPM25COR[3]
+PM25_UNSPEC1    ,ug m-3    ,PM25_TOT[0]-(PM25_CL[0]+PM25_EC[0]+PM25_NA[0]+PM25_NH4[0] \
+                           +PM25_NO3[0]+PM25_OC[0]+PM25_SOIL[0]+PM25_SO4[0])
+PM25_UNSPCRS    ,ug m-3    ,ATOTK[0]*FPM25COR[3] - (ASO4K[1]*FPM25COR[3] \
+                                                  +ACLK[1]*FPM25COR[3]  \
+                                                  +ANAK[0]*FPM25COR[3]  \
+                                                  +AMGK[0]*FPM25COR[3]  \
+                                                  +AKK[0]*FPM25COR[3]   \
+                                                  +ACAK[0]*FPM25COR[3]  \
+                                                  +ANH4K[1]*FPM25COR[3] \
+                                                  +ANO3K[1]*FPM25COR[3]) 
+
+
+!! Fine particle acidity (pH). pH is undefined if there is no aerosol water. 
+!Do not trust predictions when hourly water is <0.01 ug m-3. FINEPHF will 
+!have large negative value (-9.999E36) when pH is not to be trusted.
+!AH2OIJ         ,ug m-3     ,AH2OI[1]+AH2OJ[1]
+!HPMOLAL        ,mol kg-1   ,AHPLUSIJ[0]/AH2OIJ[0]*1000.0
+!ACIDITYTEMP    ,           ,-1*LOG10(HPMOLAL[0])
+!FINEPHF        ,           ,AH2OIJ[0]>0.01 ? ACIDITYTEMP[0] : -9.999E36
+
+!! PM10.0 and Coarse-Sized Species
+PM10            ,ug m-3    ,ATOTI[0]*FPM10AIT[3]+ATOTJ[0]*FPM10ACC[3]+ATOTK[0]*FPM10COR[3]
+
+PMC_CL          ,ug m-3    ,ACLI[1]*FPM10AIT[3] +ACLJ[1]*FPM10ACC[3] +ACLK[1]*FPM10COR[3] -PM25_CL[0]
+PMC_NA          ,ug m-3    ,ANAI[1]*FPM10AIT[3] +ANAJ[1]*FPM10ACC[3] +ANAK[0]*FPM10COR[3] -PM25_NA[0]
+PMC_NH4         ,ug m-3    ,ANH4I[1]*FPM10AIT[3]+ANH4J[1]*FPM10ACC[3]+ANH4K[1]*FPM10COR[3]-PM25_NH4[0]
+PMC_NO3         ,ug m-3    ,ANO3I[1]*FPM10AIT[3]+ANO3J[1]*FPM10ACC[3]+ANO3K[1]*FPM10COR[3]-PM25_NO3[0]
+PMC_SO4         ,ug m-3    ,ASO4I[1]*FPM10AIT[3]+ASO4J[1]*FPM10ACC[3]+ASO4K[1]*FPM10COR[3]-PM25_SO4[0]
+PMC_TOT         ,ug m-3    ,PM10[0]-PM25_TOT[0]
+
+!! FRM PM Equivalent Calculation
+!! This section calculates the FRM applicable PM species, PMIJ_FRM and
+!! PM25_FRM. The intermediate variablse K...ANH4IJ_loss are needed to 
+!! calculate the final quantities.
+K               ,ppb2      ,exp(118.87-24084/TEMP2[4]-6.025*log(TEMP2[4]))
+P1              ,          ,exp(8763/TEMP2[4]+19.12*log(TEMP2[4])-135.94)
+P2              ,          ,exp(9969/TEMP2[4]+16.22*log(TEMP2[4])-122.65)
+P3              ,          ,exp(13875/TEMP2[4]+24.46*log(TEMP2[4])-182.61)
+a               ,          ,1-RH[0]/100
+K_prime         ,ppb2      ,(P1[0]-P2[0]*a[0]+(P3[0]*a[0]*a[0]))*(a[0]^1.75)*K[0]
+sqrt_Ki         ,ppb       ,sqrt(RH[0]<=61 ? K[0] : K_prime[0])
+max_NO3_loss    ,ug m-3     ,745.7/TEMP2[4]*sqrt_Ki[0]
+PM25_NO3_loss   ,ug m-3     ,max_NO3_loss[0]<=PM25_NO3[0] ? max_NO3_loss[0] : PM25_NO3[0]
+ANO3IJ_loss     ,ug m-3     ,max_NO3_loss[0]<=ANO3IJ[0] ? max_NO3_loss[0] : ANO3IJ[0]
+PM25_NH4_loss   ,ug m-3     ,PM25_NO3_loss[0]*(18/62)
+ANH4IJ_loss     ,ug m-3     ,ANO3IJ_loss[0]*(18/62)
+PMIJ_FRM        ,ug m-3     ,ATOTIJ[0]-(ANO3IJ_loss[0]+ANH4IJ_loss[0]) \
+                            +0.24*(ASO4IJ[0]+ANH4IJ[0]-ANH4IJ_loss[0])+0.5
+PM25_FRM        ,ug m-3     ,PM25_TOT[0]-(PM25_NO3_loss[0]+PM25_NH4_loss[0]) \
+                            +0.24*(PM25_SO4[0]+PM25_NH4[0]-PM25_NH4_loss[0])+0.5

--- a/CCTM/src/MECHS/cracmm1_aq/SpecDef_cracmm1_aq.txt
+++ b/CCTM/src/MECHS/cracmm1_aq/SpecDef_cracmm1_aq.txt
@@ -145,7 +145,7 @@ VROC             ,ppbC      ,1000.0*(2.0*ACD[1]+2.0*ACE[1] \
                                     +6.0*PHEN[1]+3.0*PROG[1]  \
                                     +3.0*ROH[1]+15.0*SESQ[1]+2.1*SLOWROC[1] \
                                     +7.0*TOL[1]+5.0*UALD[1] \
-                                    +8.0*XYM[1]+8.0*XYE[1] \         \
+                                    +8.0*XYM[1]+8.0*XYE[1] \
                                     +2.0*PAA[1]+2.0*PAN[1]+3.0*PPN[1]+4.0*MPAN[1] \  
                                     +4.0*ONIT[1]+2.0*NALD[1]+5.0*ISON[1]+10.0*TRPN[1] ) \ 
                                     +LSIVROC[0] ,
@@ -188,10 +188,10 @@ AOCIJ           ,ugC m-3   ,PMF_OC[3]
 AOMIJ           ,ug m-3    ,PMF_OA[3]
 
 !!! Anthropogenic-VOC Derived Organic Aerosol
-AORGAJ          ,ug m-3    ,PMF_ASOA[3]
+AORGAIJ         ,ug m-3    ,PMF_ASOA[3]
 
 !!! Biogenic-VOC Derived Organic Aerosol
-AORGBJ          ,ug m-3    ,PMF_BSOA[3]
+AORGBIJ         ,ug m-3    ,PMF_BSOA[3]
 
 !!! Cloud-Processed  SOA
 AORGCJ          ,ug m-3    ,AORGCJ[1]

--- a/CCTM/src/MECHS/cracmm1amore_aq/SpecDef_Conc_cracmm1amore_aq.txt
+++ b/CCTM/src/MECHS/cracmm1amore_aq/SpecDef_Conc_cracmm1amore_aq.txt
@@ -1,0 +1,384 @@
+!#start   YYYYJJJ  010000
+!#end     YYYYJJJ  000000
+#layer         1
+
+/
+! This Species Definition File is for Use with the COMBINE tool built for 
+! post-processing CMAQ output. It is compatible with CMAQv5.2.
+! Date: May 12 2017
+
+! Output variables that begin with 'PM' represent those in which a size cut was 
+! applied based on modeled aerosol mode parameters.  For example, PM25_NA is all 
+! sodium that falls below 2.5 um diameter. These 'PM' variables are used for 
+! comparisons at IMPROVE and CSN sites.
+
+! Output variables that begin with 'PMAMS' represent the mass that would have
+! been detected  by an Aerosol Mass Spectrometer.
+
+! Output variables beginning with 'A' (aside from AIR_DENS) represent a 
+! combination of aerosol species in which no size cut was applied.  For example, 
+! ASO4IJ is the sum of i-mode and j-mode sulfate.  These 'A' variables are used 
+! for comparisons at CASTNet sites.
+
+! Output variables beginning with 'PMC' refer to the coarse fraction of total PM,
+! computed by summing all modes and subtracting the PM2.5 fraction.  These 'PMC'
+! variables are used for comparisons at SEARCH sites.
+
+! This Species Definition File is just for use with the uncoupled, offline CMAQ,
+! model. If you are processing WRF-CMAQ results, a different Species Definition
+! file is required.
+
+/ File [1]: CMAQ conc/aconc file
+/ File [2]: METCRO3D file
+/ File [3]: ELMO/AELMO file
+/ File [4]: METCRO2D file
+/
+/new species    ,units     ,expression
+                                         
+!-------------------------------------------!
+!------------- Meteorology -----------------!
+!-------------------------------------------!
+AIR_DENS        ,kg m-3    ,DENS[2]
+RH              ,%         ,100.00*RH[3]
+SFC_TMP         ,C         ,(TEMP2[4]-273.15)
+PBLH            ,m         ,PBL[4]
+SOL_RAD         ,W m-2     ,RGRND[4]
+precip          ,cm        ,RC[4]>=0 ? RN[4]+RC[4] : RN[4]
+WSPD10          ,m s-1     ,WSPD10[4]
+WDIR10          ,deg       ,WDIR10[4]
+
+!-------------------------------------------!
+!--------------- Gases ---------------------!
+!-------------------------------------------!
+CO              ,ppbV      ,1000.0*CO[1]
+H2O2            ,ppbV      ,1000.0*H2O2[1]
+HNO3            ,ppbV      ,1000.0*HNO3[1]
+HNO3_UGM3       ,ug m-3    ,1000.0*(HNO3[1]*2.1756*DENS[2])  
+HONO            ,ppbV      ,1000.0*HONO[1]
+HOX             ,ppbV      ,1000.0*(HO[1]+HO2[1])
+OH              ,ppbV      ,1000.0*HO[1]
+N2O5            ,ppbV      ,1000.0*N2O5[1]
+NH3             ,ppbV      ,1000.0*NH3[1]
+NH3_UGM3        ,ug m-3    ,1000.0*(NH3[1]*0.5880*DENS[2])
+NHX             ,ug m-3    ,1000.0*(NH3[1]*0.5880*DENS[2])+ANH4I[1]+ANH4J[1]+ANH4K[1]
+NO              ,ppbV      ,1000.0*NO[1]
+NO2             ,ppbV      ,1000.0*NO2[1]
+NOX             ,ppbV      ,1000.0*(NO[1] + NO2[1])
+ANO3_PPB        ,ppbV      ,(ANO3I[1]+ANO3J[1]+ANO3K[1])/(DENS[2]*(62.0/28.97))
+NTR             ,ppbV      ,1000.0*(ONIT[1]+ISON[1]+NALD[1]+IPN[1]+IPC[1]+TRPN[1]), organic nitrates in RACM2
+PANS            ,ppbV      ,1000.0*(PAN[1]+PPN[1]+MPAN[1])
+NOY             ,ppbV      ,1000.0*(NO[1]+NO2[1]+NO3[1]+2*N2O5[1]+HONO[1] \
+                                   +HNO3[1]+HNO4[1]+PAN[1]+PPN[1]+MPAN[1] \
+                                   +ISON[1]+NALD[1]+IPN[1]+IPC[1]+TRPN[1]+ONIT[1])+ANO3_PPB[0]
+O3              ,ppbV      ,1000.0*O3[1]
+SO2             ,ppbV      ,1000.0*SO2[1]
+SO2_UGM3        ,ug m-3    ,1000.0*(SO2[1]*2.2118*DENS[2])
+TERP            ,ppbV      ,1000.0*(API[1]+LIM[1]),  a-pinene and limonene monoterpenes in RACM2
+
+! Deprecate these names in future
+ETH             ,ppbV      ,1000.0*ETE[1],            ethene is ETE in RACM2
+ETHA            ,ppbV      ,1000.0*ETH[1],            ethane is ETH in RACM2
+ALD2            ,ppbV      ,1000.0*ACD[1],            acetaldehyde is ACD in RACM2
+FORM            ,ppbV      ,1000.0*HCHO[1],           formaldehyde is HCHO RACM2
+ISOP            ,ppbV      ,1000.0*ISO[1],            isoprene is ISO in RACM2
+TOL             ,ppbV      ,1000.0*TOL[1]
+
+! Hydrocarbons for evaluation. Note an "s" on the end indicates a collection of species from AQS
+ACETALDEHYDE    ,ppbV      ,1000.0*ACD[1]
+ACETYLENE       ,ppbV      ,1000.0*ACE[1]
+ACROLEIN        ,ppbV      ,1000.0*ACRO[1]
+ACETONE         ,ppbV      ,1000.0*ACT[1]
+BUTADIENE13     ,ppbV      ,1000.0*BDE13[1]
+BENZENE         ,ppbV      ,1000.0*BEN[1]
+ETHYLENE        ,ppbV      ,1000.0*ETE[1],            ethene is ETE in RACM2
+ETHANE          ,ppbV      ,1000.0*ETH[1],            ethane is ETH in RACM2
+ISOPRENE        ,ppbV      ,1000.0*ISO[1],            isoprene is ISO in RACM2
+FORMALDEHYDE    ,ppbV      ,1000.0*HCHO[1],           formaldehyde is HCHO RACM2
+MEKETONE        ,ppbV      ,1000.0*MEK[1]
+TOLUENE         ,ppbV      ,1000.0*TOL[1]
+XYLENES         ,ppbV      ,1000.0*(XYE[1]+XYM[1])
+HCPROPANES      ,ppbV      ,1000.0*(HC3[1])
+HCPENTANES      ,ppbV      ,1000.0*(HC5[1])
+HCDECANES       ,ppbV      ,1000.0*(HC10[1]), formerly HC8
+OLEFINS         ,ppbV      ,1000.0*(OLI[1]+OLT[1])
+ABPINENES       ,ppbV      ,1000.0*(API[1])
+
+!! Unused Gases. Presented Here for illustration. Users can uncomment
+!! them if they choose.
+ALDX            ,ppbV      ,1000.0*ALD[1],            C3 and higher aldehydes is ALD in RACM2
+!NOZ             ,ppbV      ,NOY[0]-NOX[0]
+!SULF            ,ppbV      ,1000.0*SULF[1]
+! SIGROC: L/S/IVOC alk and oxy gas species
+LSIVROC         ,ppbC      ,1000.0* (9.5*VROCIOXY[1] \
+                                    +14.0*VROCP5ARO[1]+13.0*VROCP6ARO[1] \
+                                    +30.0*VROCN2ALK[1]+29.0*VROCN1ALK[1] \
+                                    +28.0*VROCP0ALK[1]+27.0*VROCP1ALK[1] \
+                                    +24.0*VROCP2ALK[1]+21.0*VROCP3ALK[1] \
+                                    +18.0*VROCP4ALK[1]+14.0*VROCP5ALK[1] \
+                                    +13.0*VROCP6ALK[1]\
+                                    +17.0*VROCN2OXY2[1]+11.0*VROCN2OXY4[1] \ 
+                                    +7.0*VROCN2OXY8[1]+20.0*VROCN1OXY1[1] \ 
+                                    +12.0*VROCN1OXY3[1]+8.0*VROCN1OXY6[1] \ 
+                                    +14.0*VROCP0OXY2[1]+10.0*VROCP0OXY4[1] \ 
+                                    +17.0*VROCP1OXY1[1]+11.0*VROCP1OXY3[1] \ 
+                                    +12.0*VROCP2OXY2[1]+11.0*VROCP3OXY2[1] \ 
+                                    +9.0*VROCP4OXY2[1]+11.0*VROCP5OXY1[1] \ 
+                                    +9.0*VROCP6OXY1[1] ),                  
+! VROC: Total gas-phase (vapor) reactive organic carbon (stable species only) 
+VROC             ,ppbC      ,1000.0*(2.0*ACD[1]+2.0*ACE[1] \
+                                    +3.0*ACRO[1]+3.0*ACT[1]+3.0*ALD[1]+10*API[1] \
+                                    +7.0*BALD[1]+4.0*BDE13[1]+6.0*BEN[1] \
+                                    +9.0*CSL[1]+5.0*DCB1[1]+6.0*DCB2[1]+4.0*DCB3[1] \
+                                    +20.0*ELHOM[1] \
+                                    +2.0*EOH[1]+2.0*ETE[1]+2.0*ETEG[1]+2.0*ETH[1] \
+                                    +5.0*FURAN[1]+4.0*FURANONE[1]+2.0*GLY[1]+10.0*HOM[1] \
+                                    +3.0*HC3[1]+5.0*HC5[1]+10.0*HC10[1]  \
+                                    +1.0*HCHO[1]+3.0*HKET[1] \
+                                    +5.0*IEPOX[1]+5.0*ISHP[1]\
+                                    +5.0*ISO[1]+5.0*KET[1] \
+                                    +10.0*LIM[1]+10.0*LIMAL[1]+4.0*MACR[1]+4*MAHP[1] \
+                                    +7.0*MCT[1]  \
+                                    +4.0*MEK[1]+3.0*MGLY[1]+1.0*MOH[1]+4.0*MVK[1] \
+                                    +10.0*NAPH[1]+5.0*OLI[1]+3.0*OLT[1] \
+                                    +1.0*OP1[1]+2.0*OP2[1]+8.0*OP3[1]+10.0*OPB[1]   \
+                                    +1.0*ORA1[1]+2.0*ORA2[1] \
+                                    +10.0*PINAL[1]   \
+                                    +6.0*PHEN[1]+3.0*PROG[1]  \
+                                    +3.0*ROH[1]+15.0*SESQ[1]+2.1*SLOWROC[1] \
+                                    +7.0*TOL[1]+5.0*UALD[1] \
+                                    +8.0*XYM[1]+8.0*XYE[1] \
+                                    +2.0*PAA[1]+2.0*PAN[1]+3.0*PPN[1]+4.0*MPAN[1] \  
+                                    +4.0*ONIT[1]+5.0*ISON[1] \
+                                    +5.0*NALD[1]+5.0*IPN[1]+5.0*IPC[1]+10.0*TRPN[1] ) \ 
+                                    +LSIVROC[0] ,
+
+!-------------------------------------------!
+!--------------- Particles -----------------!
+!-------------------------------------------!
+!! Crustal Elements
+AFEJ            ,ug m-3    ,AFEJ[1]
+AALJ            ,ug m-3    ,AALJ[1]
+ASIJ            ,ug m-3    ,ASIJ[1]
+ATIJ            ,ug m-3    ,ATIJ[1]
+ACAJ            ,ug m-3    ,ACAJ[1]
+AMGJ            ,ug m-3    ,AMGJ[1]
+AKJ             ,ug m-3    ,AKJ[1]
+AMNJ            ,ug m-3    ,AMNJ[1]
+ASOILJ          ,ug m-3    ,2.20*AALJ[1]+2.49*ASIJ[1]+1.63*ACAJ[1]+2.42*AFEJ[1]+1.94*ATIJ[1]
+
+!! Non-Crustal Inorganic Particle Species
+AHPLUSIJ        ,umol m-3  ,(AH3OPI[1]+AH3OPJ[1])*1.0/19.0
+ANAK            ,ug m-3    ,0.8373*ASEACAT[1]+0.0626*ASOIL[1]+0.0023*ACORS[1]
+AMGK            ,ug m-3    ,0.0997*ASEACAT[1]+0.0170*ASOIL[1]+0.0032*ACORS[1]
+AKK             ,ug m-3    ,0.0310*ASEACAT[1]+0.0242*ASOIL[1]+0.0176*ACORS[1]
+ACAK            ,ug m-3    ,0.0320*ASEACAT[1]+0.0838*ASOIL[1]+0.0562*ACORS[1]
+ACLIJ           ,ug m-3    ,ACLI[1]+ACLJ[1]
+AECIJ           ,ug m-3    ,AECI[1]+AECJ[1]
+ANAIJ           ,ug m-3    ,ANAJ[1]+ANAI[1]
+ANO3IJ          ,ug m-3    ,ANO3I[1]+ANO3J[1]
+ANO3K           ,ug m-3    ,ANO3K[1]
+TNO3            ,ug m-3    ,2175.6*(HNO3[1]*DENS[2])+ANO3I[1]+ANO3J[1]+ANO3K[1]
+ANH4IJ          ,ug m-3    ,ANH4I[1]+ANH4J[1]
+ANH4K           ,ug m-3    ,ANH4K[1]
+ASO4IJ          ,ug m-3    ,ASO4I[1]+ASO4J[1]
+ASO4K           ,ug m-3    ,ASO4K[1]
+
+!! Organic Particle Species
+! Why is there an APOCI and APOCJ in the output? It doesn't match below 
+APOCI     ,ugC m-3,  AROCN2ALKI[1]/1.39 + AROCN1ALKI[1]/1.32 \
+                    + AROCP0ALKI[1]/1.17 + AROCP1ALKI[1]/1.17
+APOCJ     ,ugC m-3,  AROCN2ALKJ[1]/1.39  + AROCN1ALKJ[1]/1.32 \
+                    + AROCP0ALKJ[1]/1.17 + AROCP1ALKJ[1]/1.17 \
+                     + AROCP2ALKJ[1]/1.17  + AROCP3ALKJ[1]/1.17
+APOCIJ    ,ugC m-3,  APOCI[0] + APOCJ[0]
+
+APOMI     ,ug m-3,   AROCN2ALKI[1] + AROCN1ALKI[1]  \
+                    + AROCP0ALKI[1] + AROCP1ALKI[1] + APNCOMI[1]
+APOMJ     ,ug m-3,   AROCN2ALKJ[1] + AROCN1ALKJ[1] + AROCP0ALKJ[1] \
+                    + AROCP1ALKJ[1] + AROCP2ALKJ[1]  + AROCP3ALKJ[1] + APNCOMJ[1]
+APOMIJ    ,ug m-3,   APOMI[0] + APOMJ[0]
+ASOCI     ,ugC m-3,  AROCN2OXY2I[1]/1.42  + AROCN2OXY4I[1]/1.67  \
+                    + AROCN2OXY8I[1]/2.17 + AROCN1OXY1I[1]/1.29 \
+                    + AROCN1OXY3I[1]/1.54 + AROCN1OXY6I[1]/1.92 \
+                    + AROCP0OXY2I[1]/1.42 + AROCP0OXY4I[1]/1.67 \
+                    + AROCP1OXY1I[1]/1.29 + AROCP1OXY3I[1]/1.54
+ASOCJ     ,ugC m-3,  AHOMJ[1]/2.08 + AELHOMJ[1]/1.67 + AISO3NOSJ[1]/2.27 \
+                   + AISO3OSJ[1]/3.6 + AGLYJ[1]/2.13 + AORGCJ[1]/2  \
+                   + AOP3J[1]/1.92 + ASOATJ[1]/2.31 + AROCN2OXY2J[1]/1.42 \
+                   + AROCN2OXY4J[1]/1.67 + AROCN2OXY8J[1]/2.17 + AROCN1OXY1J[1]/1.29 \
+                   + AROCN1OXY3J[1]/1.54 + AROCN1OXY6J[1]/1.92 + AROCP0OXY2J[1]/1.42 \
+                   + AROCP0OXY4J[1]/1.67 + AROCP1OXY1J[1]/1.29 + AROCP1OXY3J[1]/1.54 \
+                   + AROCP2OXY2J[1]/1.42 + AROCP3OXY2J[1]/1.42 
+ASOCIJ   ,ugC m-3,  ASOCI[0] + ASOCJ[0]
+
+ASOMI    ,ug m-3, AROCN2OXY2I[1]  + AROCN2OXY4I[1]  \
+                    + AROCN2OXY8I[1] + AROCN1OXY1I[1] \
+                    + AROCN1OXY3I[1] + AROCN1OXY6I[1] \
+                    + AROCP0OXY2I[1] + AROCP0OXY4I[1] \
+                    + AROCP1OXY1I[1] + AROCP1OXY3I[1]
+ASOMJ    ,ug m-3,  AHOMJ[1] + AELHOMJ[1] + AISO3NOSJ[1] \
+                   + AISO3OSJ[1] + AGLYJ[1] + AORGCJ[1]  \
+                   + AOP3J[1] + ASOATJ[1] + AROCN2OXY2J[1] \
+                   + AROCN2OXY4J[1] + AROCN2OXY8J[1] + AROCN1OXY1J[1] \
+                   + AROCN1OXY3J[1] + AROCN1OXY6J[1] + AROCP0OXY2J[1] \
+                   + AROCP0OXY4J[1] + AROCP1OXY1J[1] + AROCP1OXY3J[1] \
+                   + AROCP2OXY2J[1] + AROCP3OXY2J[1]
+
+ASOMIJ   ,ug m-3     ,ASOMI[0] + ASOMJ[0]
+ 
+AOCI            ,ugC m-3    ,APOCI[0]  + ASOCI[0]
+AOCJ            ,ugC m-3    ,APOCJ[0]  + ASOCJ[0]
+
+AOCIJ           ,ugC m-3    ,APOCIJ[0] + ASOCIJ[0]
+
+
+AOMI            ,ug m-3     ,APOMI[0]  + ASOMI[0]
+AOMJ            ,ug m-3     ,APOMJ[0]  + ASOMJ[0]
+
+AOMIJ           ,ug m-3     ,APOMIJ[0] + ASOMIJ[0]
+
+!!! Anthropogenic-VOC Derived Organic Aerosol
+AORGAI          ,ug m-3     ,AROCN2OXY2I[1]+AROCN2OXY4I[1]+AROCN2OXY8I[1]+AROCN1OXY1I[1]   \
+                            +AROCN1OXY3I[1]+AROCN1OXY6I[1]+AROCP0OXY2I[1]+AROCP0OXY4I[1]   \
+                            +AROCP1OXY1I[1]+AROCP1OXY3I[1]
+                            
+AORGAJ          ,ug m-3     ,AROCN2OXY2J[1]+AROCN2OXY4J[1]+AROCN2OXY8J[1]+AROCN1OXY1J[1]   \
+                            +AROCN1OXY3J[1]+AROCN1OXY6J[1]+AROCP0OXY2J[1]+AROCP0OXY4J[1]   \
+                            +AROCP1OXY1J[1]+AROCP1OXY3J[1]+AROCP2OXY2J[1]+AROCP3OXY2J[1]   \
+                            +AOP3J[1] +ASOATJ[1]
+AORGAIJ         ,ug m-3     ,AORGAI[0] + AORGAJ[0]
+
+!!! Biogenic-VOC Derived Organic Aerosol
+AORGBIJ         ,ug m-3    ,AISO3NOSJ[1] +AISO3OSJ[1] +AHOMJ[1] + AELHOMJ[1]
+
+!!! Cloud-Processed  SOA
+AORGCJ          ,ug m-3    ,AORGCJ[1]
+!!! Remaining SOA
+AGLYJ           ,ug m-3    ,AGLYJ[1]
+
+!!! OM/OC ratios
+AOMOCRAT_TOT    ,           ,AOMIJ[0]/AOCIJ[0]
+
+!! Total PM Aggregates
+ATOTI           ,ug m-3    ,ASO4I[1] + ANH4I[1] + ANO3I[1] + ANAI[1]   \
+                           +ACLI[1] + AECI[1] + AOMI[0] + AOTHRI[1] 
+ATOTJ           ,ug m-3    ,ASO4J[1] + ANH4J[1] + ANO3J[1] + ANAJ[1]   \
+                           +ACLJ[1] + AECJ[1] + AOMJ[0] + AOTHRJ[1]    \
+                           +AFEJ[1] + AALJ[1] + ASIJ[1] + ATIJ[1]      \
+                           +ACAJ[1] + AMGJ[1] + AKJ[1] + AMNJ[1]        
+                            
+ATOTK           ,ug m-3    ,ASO4K[1] + ANH4K[1] + ANO3K[1] + ACLK[1]   \
+                           +ACORS[1] + ASOIL[1] + ASEACAT[1]   
+ATOTIJ          ,ug m-3    ,ATOTI[0] + ATOTJ[0] 
+ATOTIJK         ,ug m-3    ,ATOTI[0] + ATOTJ[0] + ATOTK[0]
+
+!! Unspeciated PM including non-carbon organic mass
+AUNSPEC1IJ      ,ug m-3    ,ATOTIJ[0] - (ASO4IJ[0] + ANO3IJ[0]         \
+                                         +ANH4IJ[0] + ACLIJ[0]         \
+                                         +ANAIJ[0] + AECIJ[0]          \
+                                         +AOCIJ[0] + ASOILJ[0])       
+!! Non-Carbon Organic Mass
+ANCOMIJ         ,ug m-3    ,AOMIJ[0] - AOCIJ[0]
+
+!! Unspeciated PM excluding non-carbon organic mass
+AUNSPEC2IJ      ,ug m-3     ,AUNSPEC1IJ[0] - ANCOMIJ[0]
+
+!! AMS Projection of Output Concentrations
+PMAMS_CL        ,ug m-3    ,ACLI[1] *FAMSAIT[3] +ACLJ[1]*FAMSACC[3]+ACLK[1] *FAMSCOR[3]
+PMAMS_NH4       ,ug m-3    ,ANH4I[1]*FAMSAIT[3]+ANH4J[1]*FAMSACC[3]+ANH4K[1]*FAMSCOR[3]
+PMAMS_NO3       ,ug m-3    ,ANO3I[1]*FAMSAIT[3]+ANO3J[1]*FAMSACC[3]+ANO3K[1]*FAMSCOR[3]
+PMAMS_OA        ,ug m-3    ,AOMI[0] *FAMSAIT[3]+AOMJ[0] *FAMSACC[3]
+PMAMS_SO4       ,ug m-3    ,ASO4I[1]*FAMSAIT[3]+ASO4J[1]*FAMSACC[3]+ASO4K[1]*FAMSCOR[3]
+
+!! PM1 Cutoff Output
+PM1_TOT         ,ug m-3    ,ATOTI[0]*FPM1AIT[3]+ATOTJ[0]*FPM1ACC[3]+ATOTK[0]*FPM1COR[3]
+
+!! Unused PM1 Species. Included Here for demonstration
+!PM1_EC         ,ug m-3    ,AECI[1] *FPM1AIT[3] +AECJ[1] *FPM1ACC[3]
+!PM1_OC         ,ugC m-3   ,AOCI[0] *FPM1AIT[3] +AOCJ[0] *FPM1ACC[3]
+!PM1_OM         ,ug m-3    ,AOMI[0] *FPM1AIT[3] +AOMJ[0] *FPM1ACC[3]
+!PM1_SO4        ,ug m-3    ,ASO4I[1]*FPM1AIT[3] +ASO4J[1]*FPM1ACC[3] +ASO4K[1]*FPM1COR[3]
+!PM1_CL         ,ug m-3    ,ACLI[1] *FPM1AIT[3] +ACLJ[1] *FPM1ACC[3] +ACLK[1] *FPM1COR[3]
+!PM1_NA         ,ug m-3    ,ANAI[1] *FPM1AIT[3] +ANAJ[1] *FPM1ACC[3] +ANAK[0] *FPM1COR[3]
+!PM1_MG         ,ug m-3    ,                     AMGJ[1] *FPM1ACC[3] +AMGK[0] *FPM1COR[3]
+!PM1_K          ,ug m-3    ,                     AKJ[1]  *FPM1ACC[3] +AKK[0]  *FPM1COR[3]
+!PM1_CA         ,ug m-3    ,                     ACAJ[1] *FPM1ACC[3] +ACAK[0] *FPM1COR[3]
+!PM1_NH4        ,ug m-3    ,ANH4I[1] *FPM1AIT[3]+ANH4J[1]*FPM1ACC[3] +ANH4K[1]*FPM1COR[3]
+!PM1_NO3        ,ug m-3    ,ANO3I[1] *FPM1AIT[3]+ANO3J[1]*FPM1ACC[3] +ANO3K[1]*FPM1COR[3] 
+!PM1_SOIL       ,ug m-3    ,ASOILJ[0]*FPM1ACC[3]+(ASOIL[1]+ACORS[1])*FPM1COR[3]
+!PM1_UNSPEC1    ,ug m-3    ,PM1_TOT[0] - (PM1_CL[0] + PM1_EC[0]+ PM1_NA[0]  + PM1_NH4[0] +  \
+!                                         PM1_NO3[0]+ PM1_OC[0]+ PM1_SOIL[0]+ PM1_SO4[0] ) 
+!PM1_UNSPCRS    ,ug m-3    ,ATOTK[0] *FPM1COR[3] - (ASO4K[1]*FPM1COR[3] \
+!                                                  +ACLK[1]*FPM1COR[3]  \
+!                                                  +ANAK[0]*FPM1COR[3]  \
+!                                                  +AMGK[0]*FPM1COR[3]  \
+!                                                  +AKK[0]*FPM1COR[3]   \
+!                                                  +ACAK[0]*FPM1COR[3]  \
+!                                                  +ANH4K[1]*FPM1COR[3] \
+!                                                  +ANO3K[1]*FPM1COR[3]) 
+ 
+!! PM2.5 species computed using modeled size distribution
+PM25_HP         ,ug m-3    ,(AH3OPI[1]*FPM25AIT[3]+AH3OPJ[1]*FPM25ACC[3]+AH3OPK[1]*FPM25COR[3])*1.0/19.0
+PM25_CL         ,ug m-3    ,ACLI[1]*FPM25AIT[3]+ACLJ[1]*FPM25ACC[3]+ACLK[1]*FPM25COR[3]
+PM25_EC         ,ug m-3    ,AECI[1]*FPM25AIT[3]+AECJ[1]*FPM25ACC[3]
+PM25_NA         ,ug m-3    ,ANAI[1]*FPM25AIT[3]+ANAJ[1]*FPM25ACC[3]+ANAK[0]*FPM25COR[3]
+PM25_MG         ,ug m-3    ,                    AMGJ[1]*FPM25ACC[3]+AMGK[0]*FPM25COR[3]
+PM25_K          ,ug m-3    ,                    AKJ[1] *FPM25ACC[3]+AKK[0] *FPM25COR[3]
+PM25_CA         ,ug m-3    ,                    ACAJ[1]*FPM25ACC[3]+ACAK[0]*FPM25COR[3]
+PM25_NH4        ,ug m-3    ,ANH4I[1]*FPM25AIT[3]+ANH4J[1]*FPM25ACC[3]+ANH4K[1]*FPM25COR[3]
+PM25_NO3        ,ug m-3    ,ANO3I[1]*FPM25AIT[3]+ANO3J[1]*FPM25ACC[3]+ANO3K[1]*FPM25COR[3]
+PM25_OC         ,ugC m-3   ,AOCI[0] *FPM25AIT[3]+AOCJ[0]*FPM25ACC[3]
+PM25_OM         ,ug m-3    ,AOMI[0] *FPM25AIT[3]+AOMJ[0]*FPM25ACC[3]
+PM25_SOIL       ,ug m-3    ,ASOILJ[0]*FPM25ACC[3]+ASOIL[1]*FPM25COR[3]
+PM25_SO4        ,ug m-3    ,ASO4I[1]*FPM25AIT[3]+ASO4J[1]*FPM25ACC[3]+ASO4K[1]*FPM25COR[3]
+PM25_TOT        ,ug m-3    ,ATOTI[0]*FPM25AIT[3]+ATOTJ[0]*FPM25ACC[3]+ATOTK[0]*FPM25COR[3]
+PM25_UNSPEC1    ,ug m-3    ,PM25_TOT[0]-(PM25_CL[0]+PM25_EC[0]+PM25_NA[0]+PM25_NH4[0] \
+                           +PM25_NO3[0]+PM25_OC[0]+PM25_SOIL[0]+PM25_SO4[0])
+PM25_UNSPCRS    ,ug m-3    ,ATOTK[0]*FPM25COR[3] - (ASO4K[1]*FPM25COR[3] \
+                                                  +ACLK[1]*FPM25COR[3]  \
+                                                  +ANAK[0]*FPM25COR[3]  \
+                                                  +AMGK[0]*FPM25COR[3]  \
+                                                  +AKK[0]*FPM25COR[3]   \
+                                                  +ACAK[0]*FPM25COR[3]  \
+                                                  +ANH4K[1]*FPM25COR[3] \
+                                                  +ANO3K[1]*FPM25COR[3]) 
+
+
+!! Fine particle acidity (pH). pH is undefined if there is no aerosol water. 
+!Do not trust predictions when hourly water is <0.01 ug m-3. FINEPHF will 
+!have large negative value (-9.999E36) when pH is not to be trusted.
+!AH2OIJ         ,ug m-3     ,AH2OI[1]+AH2OJ[1]
+!HPMOLAL        ,mol kg-1   ,AHPLUSIJ[0]/AH2OIJ[0]*1000.0
+!ACIDITYTEMP    ,           ,-1*LOG10(HPMOLAL[0])
+!FINEPHF        ,           ,AH2OIJ[0]>0.01 ? ACIDITYTEMP[0] : -9.999E36
+
+!! PM10.0 and Coarse-Sized Species
+PM10            ,ug m-3    ,ATOTI[0]*FPM10AIT[3]+ATOTJ[0]*FPM10ACC[3]+ATOTK[0]*FPM10COR[3]
+
+PMC_CL          ,ug m-3    ,ACLI[1]*FPM10AIT[3] +ACLJ[1]*FPM10ACC[3] +ACLK[1]*FPM10COR[3] -PM25_CL[0]
+PMC_NA          ,ug m-3    ,ANAI[1]*FPM10AIT[3] +ANAJ[1]*FPM10ACC[3] +ANAK[0]*FPM10COR[3] -PM25_NA[0]
+PMC_NH4         ,ug m-3    ,ANH4I[1]*FPM10AIT[3]+ANH4J[1]*FPM10ACC[3]+ANH4K[1]*FPM10COR[3]-PM25_NH4[0]
+PMC_NO3         ,ug m-3    ,ANO3I[1]*FPM10AIT[3]+ANO3J[1]*FPM10ACC[3]+ANO3K[1]*FPM10COR[3]-PM25_NO3[0]
+PMC_SO4         ,ug m-3    ,ASO4I[1]*FPM10AIT[3]+ASO4J[1]*FPM10ACC[3]+ASO4K[1]*FPM10COR[3]-PM25_SO4[0]
+PMC_TOT         ,ug m-3    ,PM10[0]-PM25_TOT[0]
+
+!! FRM PM Equivalent Calculation
+!! This section calculates the FRM applicable PM species, PMIJ_FRM and
+!! PM25_FRM. The intermediate variablse K...ANH4IJ_loss are needed to 
+!! calculate the final quantities.
+K               ,ppb2      ,exp(118.87-24084/TEMP2[4]-6.025*log(TEMP2[4]))
+P1              ,          ,exp(8763/TEMP2[4]+19.12*log(TEMP2[4])-135.94)
+P2              ,          ,exp(9969/TEMP2[4]+16.22*log(TEMP2[4])-122.65)
+P3              ,          ,exp(13875/TEMP2[4]+24.46*log(TEMP2[4])-182.61)
+a               ,          ,1-RH[0]/100
+K_prime         ,ppb2      ,(P1[0]-P2[0]*a[0]+(P3[0]*a[0]*a[0]))*(a[0]^1.75)*K[0]
+sqrt_Ki         ,ppb       ,sqrt(RH[0]<=61 ? K[0] : K_prime[0])
+max_NO3_loss    ,ug m-3     ,745.7/TEMP2[4]*sqrt_Ki[0]
+PM25_NO3_loss   ,ug m-3     ,max_NO3_loss[0]<=PM25_NO3[0] ? max_NO3_loss[0] : PM25_NO3[0]
+ANO3IJ_loss     ,ug m-3     ,max_NO3_loss[0]<=ANO3IJ[0] ? max_NO3_loss[0] : ANO3IJ[0]
+PM25_NH4_loss   ,ug m-3     ,PM25_NO3_loss[0]*(18/62)
+ANH4IJ_loss     ,ug m-3     ,ANO3IJ_loss[0]*(18/62)
+PMIJ_FRM        ,ug m-3     ,ATOTIJ[0]-(ANO3IJ_loss[0]+ANH4IJ_loss[0]) \
+                            +0.24*(ASO4IJ[0]+ANH4IJ[0]-ANH4IJ_loss[0])+0.5
+PM25_FRM        ,ug m-3     ,PM25_TOT[0]-(PM25_NO3_loss[0]+PM25_NH4_loss[0]) \
+                            +0.24*(PM25_SO4[0]+PM25_NH4[0]-PM25_NH4_loss[0])+0.5

--- a/CCTM/src/MECHS/cracmm1amore_aq/SpecDef_cracmm1amore_aq.txt
+++ b/CCTM/src/MECHS/cracmm1amore_aq/SpecDef_cracmm1amore_aq.txt
@@ -146,7 +146,7 @@ VROC             ,ppbC      ,1000.0*(2.0*ACD[1]+2.0*ACE[1] \
                                     +6.0*PHEN[1]+3.0*PROG[1]  \
                                     +3.0*ROH[1]+15.0*SESQ[1]+2.1*SLOWROC[1] \
                                     +7.0*TOL[1]+5.0*UALD[1] \
-                                    +8.0*XYM[1]+8.0*XYE[1] \         \
+                                    +8.0*XYM[1]+8.0*XYE[1] \
                                     +2.0*PAA[1]+2.0*PAN[1]+3.0*PPN[1]+4.0*MPAN[1] \  
                                     +4.0*ONIT[1]+5.0*ISON[1] \
                                     +5.0*NALD[1]+5.0*IPN[1]+5.0*IPC[1]+10.0*TRPN[1] ) \ 
@@ -190,10 +190,10 @@ AOCIJ           ,ugC m-3   ,PMF_OC[3]
 AOMIJ           ,ug m-3    ,PMF_OA[3]
 
 !!! Anthropogenic-VOC Derived Organic Aerosol
-AORGAJ          ,ug m-3    ,PMF_ASOA[3]
+AORGAIJ         ,ug m-3    ,PMF_ASOA[3]
 
 !!! Biogenic-VOC Derived Organic Aerosol
-AORGBJ          ,ug m-3    ,PMF_BSOA[3]
+AORGBIJ         ,ug m-3    ,PMF_BSOA[3]
 
 !!! Cloud-Processed  SOA
 AORGCJ          ,ug m-3    ,AORGCJ[1]

--- a/CCTM/src/driver/ELMO_PROC.F
+++ b/CCTM/src/driver/ELMO_PROC.F
@@ -1082,6 +1082,12 @@
 !-------------------------------------------------------------------------
       USE CGRID_SPCS, ONLY : CGRID_NAME
       USE UTIL_FAMILY_MODULE, ONLY : CHEMFAMILYNUM, CHEMFAMILYMEMBERS
+      USE AERO_DATA, ONLY : ascat_na_fac, asoil_na_fac, acors_na_fac,
+     &                      ascat_mg_fac, asoil_mg_fac, acors_mg_fac,
+     &                      ascat_k_fac,  asoil_k_fac,  acors_k_fac,
+     &                      ascat_ca_fac, asoil_ca_fac, acors_ca_fac,
+     &                                    asoil_fe_fac, acors_fe_fac,
+     &                                    asoil_mn_fac, acors_mn_fac
 
       IMPLICIT NONE
 
@@ -1135,33 +1141,33 @@
              CASE ( ID_PMC_NA ) 
                N_VARS = 3
                CALL INIT_ELMO_COEFFS( IDG, N_VARS, 'COARSE' )
-               CALL SET_ELMO_COEFF_MAP( IDG, 1, 'AERO', 'ASEACAT', 0.8373 )
-               CALL SET_ELMO_COEFF_MAP( IDG, 2, 'AERO', 'ASOIL', 0.0626 )
-               CALL SET_ELMO_COEFF_MAP( IDG, 3, 'AERO', 'ACORS', 0.0023 )
+               CALL SET_ELMO_COEFF_MAP( IDG, 1, 'AERO', 'ASEACAT', real(ascat_na_fac) )
+               CALL SET_ELMO_COEFF_MAP( IDG, 2, 'AERO', 'ASOIL',   real(asoil_na_fac) )
+               CALL SET_ELMO_COEFF_MAP( IDG, 3, 'AERO', 'ACORS',   real(acors_na_fac) )
  
              ! Map PMC_MG - Coarse-Mode Magnesium
              CASE ( ID_PMC_MG ) 
                N_VARS = 3
                CALL INIT_ELMO_COEFFS( IDG, N_VARS, 'COARSE' )
-               CALL SET_ELMO_COEFF_MAP( IDG, 1, 'AERO', 'ASEACAT', 0.0997 )
-               CALL SET_ELMO_COEFF_MAP( IDG, 2, 'AERO', 'ASOIL', 0.0170 )
-               CALL SET_ELMO_COEFF_MAP( IDG, 3, 'AERO', 'ACORS', 0.0032 )
+               CALL SET_ELMO_COEFF_MAP( IDG, 1, 'AERO', 'ASEACAT', real(ascat_mg_fac) )
+               CALL SET_ELMO_COEFF_MAP( IDG, 2, 'AERO', 'ASOIL',   real(asoil_mg_fac) )
+               CALL SET_ELMO_COEFF_MAP( IDG, 3, 'AERO', 'ACORS',   real(acors_mg_fac) )
  
              ! Map PMC_K - Coarse-Mode Potassium
              CASE ( ID_PMC_K ) 
                N_VARS = 3
                CALL INIT_ELMO_COEFFS( IDG, N_VARS, 'COARSE' )
-               CALL SET_ELMO_COEFF_MAP( IDG, 1, 'AERO', 'ASEACAT', 0.0310 )
-               CALL SET_ELMO_COEFF_MAP( IDG, 2, 'AERO', 'ASOIL', 0.0242 )
-               CALL SET_ELMO_COEFF_MAP( IDG, 3, 'AERO', 'ACORS', 0.0176 )
+               CALL SET_ELMO_COEFF_MAP( IDG, 1, 'AERO', 'ASEACAT', real(ascat_k_fac) )
+               CALL SET_ELMO_COEFF_MAP( IDG, 2, 'AERO', 'ASOIL',   real(asoil_k_fac) )
+               CALL SET_ELMO_COEFF_MAP( IDG, 3, 'AERO', 'ACORS',   real(acors_k_fac) )
 
              ! Map PMC_CA - Coarse-Mode Calcium
              CASE ( ID_PMC_CA ) 
                N_VARS = 3
                CALL INIT_ELMO_COEFFS( IDG, N_VARS, 'COARSE' )
-               CALL SET_ELMO_COEFF_MAP( IDG, 1, 'AERO', 'ASEACAT', 0.0320 )
-               CALL SET_ELMO_COEFF_MAP( IDG, 2, 'AERO', 'ASOIL', 0.0838 )
-               CALL SET_ELMO_COEFF_MAP( IDG, 3, 'AERO', 'ACORS', 0.0562 )
+               CALL SET_ELMO_COEFF_MAP( IDG, 1, 'AERO', 'ASEACAT', real(ascat_ca_fac) )
+               CALL SET_ELMO_COEFF_MAP( IDG, 2, 'AERO', 'ASOIL',   real(asoil_ca_fac) )
+               CALL SET_ELMO_COEFF_MAP( IDG, 3, 'AERO', 'ACORS',   real(acors_ca_fac) )
 
              
              !!!! Fine-Mode Parameters !!!!  
@@ -1418,9 +1424,12 @@
  
              ! Map PM1_NA - PM1 Sodium
              CASE ( ID_PM1_NA ) 
-               N_VARS = 1
+               N_VARS = 4
                CALL INIT_ELMO_COEFFS( IDG, N_VARS, 'PM1' )
                CALL SET_ELMO_COEFF_MAP( IDG, 1, 'AERO', 'ANA', 1.0 )
+               CALL SET_ELMO_COEFF_MAP( IDG, 2, 'AERO', 'ASEACAT', real(ascat_na_fac) )
+               CALL SET_ELMO_COEFF_MAP( IDG, 3, 'AERO', 'ASOIL',   real(asoil_na_fac) )
+               CALL SET_ELMO_COEFF_MAP( IDG, 4, 'AERO', 'ACORS',   real(acors_na_fac) )
  
              ! Map PM1_EC - PM1 Elemental Carbon
              CASE ( ID_PM1_EC ) 
@@ -1430,21 +1439,30 @@
  
              ! Map PM1_MG - PM1 Magnesium
              CASE ( ID_PM1_MG ) 
-               N_VARS = 1
+               N_VARS = 4
                CALL INIT_ELMO_COEFFS( IDG, N_VARS, 'PM1' )
                CALL SET_ELMO_COEFF_MAP( IDG, 1, 'AERO', 'AMG', 1.0 )
+               CALL SET_ELMO_COEFF_MAP( IDG, 2, 'AERO', 'ASEACAT', real(ascat_mg_fac) )
+               CALL SET_ELMO_COEFF_MAP( IDG, 3, 'AERO', 'ASOIL',   real(asoil_mg_fac) )
+               CALL SET_ELMO_COEFF_MAP( IDG, 4, 'AERO', 'ACORS',   real(acors_mg_fac) )
  
              ! Map PM1_K - PM1 Potassium
              CASE ( ID_PM1_K ) 
-               N_VARS = 1
+               N_VARS = 4
                CALL INIT_ELMO_COEFFS( IDG, N_VARS, 'PM1' )
                CALL SET_ELMO_COEFF_MAP( IDG, 1, 'AERO', 'AK', 1.0 )
+               CALL SET_ELMO_COEFF_MAP( IDG, 2, 'AERO', 'ASEACAT', real(ascat_k_fac) )
+               CALL SET_ELMO_COEFF_MAP( IDG, 3, 'AERO', 'ASOIL',   real(asoil_k_fac) )
+               CALL SET_ELMO_COEFF_MAP( IDG, 4, 'AERO', 'ACORS',   real(acors_k_fac) )
  
              ! Map PM1_CA - PM1 Calcium
              CASE ( ID_PM1_CA ) 
-               N_VARS = 1
+               N_VARS = 4
                CALL INIT_ELMO_COEFFS( IDG, N_VARS, 'PM1' )
                CALL SET_ELMO_COEFF_MAP( IDG, 1, 'AERO', 'ACA', 1.0 )
+               CALL SET_ELMO_COEFF_MAP( IDG, 2, 'AERO', 'ASEACAT', real(ascat_ca_fac ))
+               CALL SET_ELMO_COEFF_MAP( IDG, 3, 'AERO', 'ASOIL',   real(asoil_ca_fac ))
+               CALL SET_ELMO_COEFF_MAP( IDG, 4, 'AERO', 'ACORS',   real(acors_ca_fac ))
  
              ! Map PM1_Other - PM1 Other 
              CASE ( ID_PM1_OT ) 
@@ -1454,9 +1472,11 @@
  
              ! Map PM1_FE - PM1 Iron
              CASE ( ID_PM1_FE ) 
-               N_VARS = 1
+               N_VARS = 3
                CALL INIT_ELMO_COEFFS( IDG, N_VARS, 'PM1' )
                CALL SET_ELMO_COEFF_MAP( IDG, 1, 'AERO', 'AFE', 1.0 )
+               CALL SET_ELMO_COEFF_MAP( IDG, 2, 'AERO', 'ASOIL',   real(asoil_fe_fac ))
+               CALL SET_ELMO_COEFF_MAP( IDG, 3, 'AERO', 'ACORS',   real(acors_fe_fac ))
  
              ! Map PM1_SI - PM1 Silicon
              CASE ( ID_PM1_SI ) 
@@ -1472,9 +1492,11 @@
  
              ! Map PM1_MN - PM1 Manganese
              CASE ( ID_PM1_MN ) 
-               N_VARS = 1
+               N_VARS = 3
                CALL INIT_ELMO_COEFFS( IDG, N_VARS, 'PM1' )
                CALL SET_ELMO_COEFF_MAP( IDG, 1, 'AERO', 'AMN', 1.0 )
+               CALL SET_ELMO_COEFF_MAP( IDG, 2, 'AERO', 'ASOIL',   real(asoil_mn_fac ))
+               CALL SET_ELMO_COEFF_MAP( IDG, 3, 'AERO', 'ACORS',   real(acors_mn_fac ))
  
              ! Map PM1_AL - PM1 Aluminum
              CASE ( ID_PM1_AL ) 
@@ -1514,10 +1536,14 @@
              CASE ( ID_PM1_UN ) 
                N_VARS = 3
                CALL INIT_ELMO_COEFFS( IDG, N_VARS, 'PM1' )
-               CALL SET_ELMO_COEFF_MAP( IDG, 1, 'AERO', 'ASEACAT', 0.0 ) ! All Seaspray Cation mass has been 
-                                                                           ! apportined to Na, Mg, K, and Ca
-               CALL SET_ELMO_COEFF_MAP( IDG, 2, 'AERO', 'ASOIL', 0.8124 )
-               CALL SET_ELMO_COEFF_MAP( IDG, 3, 'AERO', 'ACORS', 0.9207 )
+               CALL SET_ELMO_COEFF_MAP( IDG, 1, 'AERO', 'ASEACAT', 1.0 - real( ascat_na_fac + ascat_mg_fac +  
+     &                                                                         ascat_k_fac  + ascat_ca_fac  )) 
+               CALL SET_ELMO_COEFF_MAP( IDG, 2, 'AERO', 'ASOIL',   1.0 - real( asoil_na_fac + asoil_mg_fac +
+     &                                                                         asoil_k_fac  + asoil_ca_fac +
+     &                                                                         asoil_mn_fac + asoil_fe_fac  ))
+               CALL SET_ELMO_COEFF_MAP( IDG, 3, 'AERO', 'ACORS',   1.0 - real( acors_na_fac + acors_mg_fac +
+     &                                                                         acors_k_fac  + acors_ca_fac +
+     &                                                                         acors_mn_fac + acors_fe_fac  ))
               
              ! Map PM1_HP - PM1.0 Hydronium Ion
              CASE ( ID_PM1_HP ) 
@@ -1553,9 +1579,12 @@
  
              ! Map PM25_NA - PM2.5 Sodium
              CASE ( ID_PM25_NA ) 
-               N_VARS = 1
+               N_VARS = 4
                CALL INIT_ELMO_COEFFS( IDG, N_VARS, 'PM25' )
                CALL SET_ELMO_COEFF_MAP( IDG, 1, 'AERO', 'ANA', 1.0 )
+               CALL SET_ELMO_COEFF_MAP( IDG, 2, 'AERO', 'ASEACAT', real(ascat_na_fac ))
+               CALL SET_ELMO_COEFF_MAP( IDG, 3, 'AERO', 'ASOIL',   real(asoil_na_fac ))
+               CALL SET_ELMO_COEFF_MAP( IDG, 4, 'AERO', 'ACORS',   real(acors_na_fac ))
  
              ! Map PM25_EC - PM2.5 Elemental Carbon
              CASE ( ID_PM25_EC ) 
@@ -1565,21 +1594,30 @@
  
              ! Map PM25_MG - PM2.5 Magnesium
              CASE ( ID_PM25_MG ) 
-               N_VARS = 1
+               N_VARS = 4
                CALL INIT_ELMO_COEFFS( IDG, N_VARS, 'PM25' )
                CALL SET_ELMO_COEFF_MAP( IDG, 1, 'AERO', 'AMG', 1.0 )
+               CALL SET_ELMO_COEFF_MAP( IDG, 2, 'AERO', 'ASEACAT', real(ascat_mg_fac ))
+               CALL SET_ELMO_COEFF_MAP( IDG, 3, 'AERO', 'ASOIL',   real(asoil_mg_fac ))
+               CALL SET_ELMO_COEFF_MAP( IDG, 4, 'AERO', 'ACORS',   real(acors_mg_fac ))
  
              ! Map PM25_K - PM2.5 Potassium
              CASE ( ID_PM25_K ) 
-               N_VARS = 1
+               N_VARS = 4
                CALL INIT_ELMO_COEFFS( IDG, N_VARS, 'PM25' )
                CALL SET_ELMO_COEFF_MAP( IDG, 1, 'AERO', 'AK', 1.0 )
+               CALL SET_ELMO_COEFF_MAP( IDG, 2, 'AERO', 'ASEACAT', real(ascat_k_fac ))
+               CALL SET_ELMO_COEFF_MAP( IDG, 3, 'AERO', 'ASOIL',   real(asoil_k_fac ))
+               CALL SET_ELMO_COEFF_MAP( IDG, 4, 'AERO', 'ACORS',   real(acors_k_fac ))
  
              ! Map PM25_CA - PM2.5 Calcium
              CASE ( ID_PM25_CA ) 
-               N_VARS = 1
+               N_VARS = 4
                CALL INIT_ELMO_COEFFS( IDG, N_VARS, 'PM25' )
                CALL SET_ELMO_COEFF_MAP( IDG, 1, 'AERO', 'ACA', 1.0 )
+               CALL SET_ELMO_COEFF_MAP( IDG, 2, 'AERO', 'ASEACAT', real(ascat_ca_fac ))
+               CALL SET_ELMO_COEFF_MAP( IDG, 3, 'AERO', 'ASOIL',   real(asoil_ca_fac ))
+               CALL SET_ELMO_COEFF_MAP( IDG, 4, 'AERO', 'ACORS',   real(acors_ca_fac ))
  
              ! Map PM25_Other - PM25 Other 
              CASE ( ID_PM25_OT ) 
@@ -1589,9 +1627,11 @@
  
              ! Map PM25_FE - PM2.5 Iron
              CASE ( ID_PM25_FE ) 
-               N_VARS = 1
+               N_VARS = 3
                CALL INIT_ELMO_COEFFS( IDG, N_VARS, 'PM25' )
                CALL SET_ELMO_COEFF_MAP( IDG, 1, 'AERO', 'AFE', 1.0 )
+               CALL SET_ELMO_COEFF_MAP( IDG, 2, 'AERO', 'ASOIL',   real(asoil_fe_fac ))
+               CALL SET_ELMO_COEFF_MAP( IDG, 3, 'AERO', 'ACORS',   real(acors_fe_fac ))
  
              ! Map PM25_SI - PM2.5 Silicon
              CASE ( ID_PM25_SI ) 
@@ -1607,9 +1647,11 @@
  
              ! Map PM25_MN - PM2.5 Manganese
              CASE ( ID_PM25_MN ) 
-               N_VARS = 1
+               N_VARS = 3
                CALL INIT_ELMO_COEFFS( IDG, N_VARS, 'PM25' )
                CALL SET_ELMO_COEFF_MAP( IDG, 1, 'AERO', 'AMN', 1.0 )
+               CALL SET_ELMO_COEFF_MAP( IDG, 2, 'AERO', 'ASOIL',   real(asoil_mn_fac ))
+               CALL SET_ELMO_COEFF_MAP( IDG, 3, 'AERO', 'ACORS',   real(acors_mn_fac ))
  
              ! Map PM25_AL - PM2.5 Aluminum
              CASE ( ID_PM25_AL ) 
@@ -1649,10 +1691,14 @@
              CASE ( ID_PM25_UN ) 
                N_VARS = 3
                CALL INIT_ELMO_COEFFS( IDG, N_VARS, 'PM25' )
-               CALL SET_ELMO_COEFF_MAP( IDG, 1, 'AERO', 'ASEACAT', 0.0 ) ! All Seaspray Cation mass has been 
-                                                                           ! apportined to Na, Mg, K, and Ca
-               CALL SET_ELMO_COEFF_MAP( IDG, 2, 'AERO', 'ASOIL', 0.8124 )
-               CALL SET_ELMO_COEFF_MAP( IDG, 3, 'AERO', 'ACORS', 0.9207 )
+               CALL SET_ELMO_COEFF_MAP( IDG, 1, 'AERO', 'ASEACAT', 1.0 - real( ascat_na_fac + ascat_mg_fac +  
+     &                                                                         ascat_k_fac  + ascat_ca_fac  )) 
+               CALL SET_ELMO_COEFF_MAP( IDG, 2, 'AERO', 'ASOIL',   1.0 - real( asoil_na_fac + asoil_mg_fac +
+     &                                                                         asoil_k_fac  + asoil_ca_fac +
+     &                                                                         asoil_mn_fac + asoil_fe_fac  ))
+               CALL SET_ELMO_COEFF_MAP( IDG, 3, 'AERO', 'ACORS',   1.0 - real( acors_na_fac + acors_mg_fac +
+     &                                                                         acors_k_fac  + acors_ca_fac +
+     &                                                                         acors_mn_fac + acors_fe_fac  ))
  
              ! Map PM25_HP - PM2.5 Hydronium Ion
              CASE ( ID_PM25_HP ) 
@@ -1689,9 +1735,12 @@
  
              ! Map PM25to10_NA - PM2.5-10.0 Sodium
              CASE ( ID_PM25to10_NA ) 
-               N_VARS = 1
+               N_VARS = 4
                CALL INIT_ELMO_COEFFS( IDG, N_VARS, 'PM25TO10' )
                CALL SET_ELMO_COEFF_MAP( IDG, 1, 'AERO', 'ANA', 1.0 )
+               CALL SET_ELMO_COEFF_MAP( IDG, 2, 'AERO', 'ASEACAT', real(ascat_na_fac ))
+               CALL SET_ELMO_COEFF_MAP( IDG, 3, 'AERO', 'ASOIL',   real(asoil_na_fac ))
+               CALL SET_ELMO_COEFF_MAP( IDG, 4, 'AERO', 'ACORS',   real(acors_na_fac ))
  
              !!!! Toxics !!!!  
  
@@ -2041,6 +2090,7 @@
           IF ( ISPEC .GT. 0 ) THEN
              ! Found the Index. Save it!
              ELMO_COEFFS( IDG )%I_SPEC( IVAR ) = ISPEC
+             ELMO_COEFFS( IDG )%L_GAS( IVAR )  = .TRUE.
           ELSE
              ! Could not find the species in the CGRID Array. Print an
              ! Error and Warn
@@ -2577,8 +2627,8 @@
             ! just carbon mass
             VAL = 0.0
             DO IOA = 1,N_OA_NotTracers
-                ! Just Select Secondary Species
-                IF ( .NOT. OASPC( IOA )%PRIMARY ) THEN  
+                ! Skip primary species and those with negative OM:OC 
+                IF ( OASPC( IOA )%OMtoOC .GT. 0.0 .AND. .NOT. OASPC( IOA )%PRIMARY ) THEN  
                       VAL = VAL + SUM( AEROSPC_CONC( MAP_OAtoAERO(IOA),: ),
      &                            MASK = AEROMODE(:)%FINE_MASK ) 
      &                          / OASPC( IOA )%OMtoOC
@@ -2592,9 +2642,12 @@
             ! just carbon mass
             VAL = 0.0
             DO IOA = 1,N_OA_NotTracers
-               VAL = VAL + SUM( AEROSPC_CONC( MAP_OAtoAERO(IOA),: ),
-     &                     MASK = AEROMODE(:)%FINE_MASK ) 
-     &                   / OASPC( IOA )%OMtoOC
+               ! Skip species with negative OM:OC
+               IF ( OASPC( IOA )%OMtoOC .GT. 0.0 ) THEN
+                  VAL = VAL + SUM( AEROSPC_CONC( MAP_OAtoAERO(IOA),: ),
+     &                        MASK = AEROMODE(:)%FINE_MASK ) 
+     &                      / OASPC( IOA )%OMtoOC
+               END IF
             END DO
             OUTVAL = VAL  
 
@@ -2689,7 +2742,7 @@
          CASE ( ID_PM1_OC )
             ! Save PM1 Fraction for each mode
             DO IMODE = 1,N_MODE
-                CALL GET_AERO_INLET( IPM1, IM, IWET, FRAC( IMODE ) ) 
+                CALL GET_AERO_INLET( IPM1, IMODE, IWET, FRAC( IMODE ) ) 
             END DO
             ! Sum up primary organic aerosol species normalized to
             ! just carbon mass
@@ -2705,7 +2758,7 @@
          CASE ( ID_PM1_OA )
             ! Save PM1 Fraction for each mode
             DO IMODE = 1,N_MODE
-                CALL GET_AERO_INLET( IPM1, IM, IWET, FRAC( IMODE ) ) 
+                CALL GET_AERO_INLET( IPM1, IMODE, IWET, FRAC( IMODE ) ) 
             END DO
             ! Sum up primary organic aerosol species
             VAL = 0.0
@@ -2718,7 +2771,7 @@
          CASE ( ID_PM25_OC )
             ! Save PM2.5 Fraction for each mode
             DO IMODE = 1,N_MODE
-                CALL GET_AERO_INLET( IPM25, IM, IWET, FRAC( IMODE ) ) 
+                CALL GET_AERO_INLET( IPM25, IMODE, IWET, FRAC( IMODE ) ) 
             END DO
             ! Sum up primary organic aerosol species normalized to
             ! just carbon mass
@@ -2734,7 +2787,7 @@
          CASE ( ID_PM25_OA )
             ! Save PM2.5 Fraction for each mode
             DO IMODE = 1,N_MODE
-                CALL GET_AERO_INLET( IPM25, IM, IWET, FRAC( IMODE ) ) 
+                CALL GET_AERO_INLET( IPM25, IMODE, IWET, FRAC( IMODE ) ) 
             END DO
             ! Sum up primary organic aerosol species
             VAL = 0.0
@@ -3141,11 +3194,11 @@
          INIT_STEP = .TRUE.
       ELSE
          WSTEP = WSTEP + TIME2SEC( TSTEP( 2 ) )
-         IF ( WSTEP .GE. TIME2SEC( TSTEP( 1 ) ) ) 
+         IF ( WSTEP .GE. TIME2SEC( TSTEP( 1 ) ) )
      &        WRITE_STEP = .TRUE.
       END IF
       ELMO_NSTEP = ELMO_NSTEP + 1.0
-     
+
       ! Get Meteorological Variables
 
       ! pressure [Pa]
@@ -3409,19 +3462,19 @@ C *** Write data to the scalar output file.
 C *** Write data to the average aerosol diagnostic file.
          IF ( .NOT.INIT_TIME ) THEN
            IF ( AVRG_ACTIVE ) THEN
-              IF ( .NOT. END_TIME ) THEN   ! ending time timestamp
-                 CALL NEXTIME ( MDATE, MTIME, -TSTEP(1) )
-              END IF
+            IF ( .NOT. END_TIME ) THEN   ! ending time timestamp
+               CALL NEXTIME ( MDATE, MTIME, -TSTEP(1) )
+            END IF
           
-              IF ( .NOT. WRITE3( CTM_AELMO_1, 
+            IF ( .NOT. WRITE3( CTM_AELMO_1, 
      &             ALLVAR3, MDATE, MTIME, 
      &             ELMO_AVRG(:,:,:,:) / 2.0 / 
      &             (ELMO_NSTEP-1.0) ) ) THEN
-                 XMSG = 'Could not write ' // CTM_AELMO_1 // ' file'
-                 CALL M3EXIT ( PNAME, MDATE, MTIME, XMSG, XSTAT1 )
-              END IF
+               XMSG = 'Could not write ' // CTM_AELMO_1 // ' file'
+               CALL M3EXIT ( PNAME, MDATE, MTIME, XMSG, XSTAT1 )
+            END IF
           
-              WRITE( LOGDEV, '( /5X, 3( A, :, 1X ), I8, ":", I6.6 )' )
+            WRITE( LOGDEV, '( /5X, 3( A, :, 1X ), I8, ":", I6.6 )' )
      &                       'Timestep written to', CTM_AELMO_1,
      &                       'for date and time', MDATE, MTIME
           

--- a/CCTM/src/driver/ELMO_PROC.F
+++ b/CCTM/src/driver/ELMO_PROC.F
@@ -1682,7 +1682,7 @@
                CALL SET_ELMO_COEFF_MAP( IDG, 3, 'AERO', 'ANO3', -1.0 )
                CALL SET_ELMO_COEFF_MAP( IDG, 4, 'AERO', 'ANH4', -1.0 )
                CALL SET_ELMO_COEFF_MAP( IDG, 5, 'AERO', 'ACL', -1.0 )          
-               CALL SET_ELMO_COEFF_MAP( IDG, 6, 'AERO', 'ANA', -1.0 )          
+               CALL SET_ELMO_COEFF_MAP( IDG, 6, 'AGG',  'PM25_NA', -1.0 )          
                CALL SET_ELMO_COEFF_MAP( IDG, 7, 'AERO', 'AEC', -1.0 )          
                CALL SET_ELMO_COEFF_MAP( IDG, 8, 'AGG',  'PM25_OC', -1.0 )          
                CALL SET_ELMO_COEFF_MAP( IDG, 9, 'AGG',  'PM25_SOIL', -1.0 )          

--- a/CCTM/src/driver/ELMO_PROC.F
+++ b/CCTM/src/driver/ELMO_PROC.F
@@ -1527,7 +1527,7 @@
                CALL SET_ELMO_COEFF_MAP( IDG, 3, 'AERO', 'ANO3', -1.0 )
                CALL SET_ELMO_COEFF_MAP( IDG, 4, 'AERO', 'ANH4', -1.0 )
                CALL SET_ELMO_COEFF_MAP( IDG, 5, 'AERO', 'ACL', -1.0 )          
-               CALL SET_ELMO_COEFF_MAP( IDG, 6, 'AERO', 'ANA', -1.0 )          
+               CALL SET_ELMO_COEFF_MAP( IDG, 6, 'AGG',  'PM1_NA', -1.0 )          
                CALL SET_ELMO_COEFF_MAP( IDG, 7, 'AERO', 'AEC', -1.0 )          
                CALL SET_ELMO_COEFF_MAP( IDG, 8, 'AGG',  'PM1_OC', -1.0 )          
                CALL SET_ELMO_COEFF_MAP( IDG, 9, 'AGG',  'PM1_SOIL', -1.0 )          


### PR DESCRIPTION
**Contact:**  
Ben Murphy, US EPA 
murphy.ben@epa.gov

**Type of code change:**   
Bug Fixes

**Description of changes:**   
The Explicit and Lumped CMAQ Model Output (ELMO) module calculates post-processed variables online like total PM mass and mass of PM species in discrete size ranges.

CMAQ community members and EPA developers detected several coding errors in the ELMO algorithm. They are corrected with this PR.

Changes include:
- Using global coefficients from AERO_DATA to quantify the fraction of Na, Mg, K, Ca, Fe, and Mn in sea spray, soil, and coarse-mode species.
- Adding contributions from sea-spray, soil, and coarse-mode to PM1, PM2.5, and PM10 calculations of Na, Mg, K, Ca, Fe, and Mn.
- Updating unspeciated outputs with coarse-mode fraction calculations.
- Identify gases in the ELMO_COEFFS structure when they are determined.
- Repairing typo in GET_AERO_INLET calls: IM --> IMODE
- Adding SpecDef_Conc files which enable post-processing of raw CONC and ACONC aerosol mass into aggregated species. These tasks are done online within in the ELMO module, but making this alternative path available provides supports developers and users who work with their data this way, and makes possible a quality check on ELMO output.

**Issue:**  
Resolves issues #212 and #210 

**Summary of Impact:**  
Concentrations of the following species output by ELMO will change with this code fix:
PM1_NA
PM1_MG
PM1_K
PM1_CA
PM1_FE
PM1_MN
PM1_UNSP1

PM25_NA
PM25_MG
PM25_K
PM25_CA
PM25_FE
PM25_MN
PM25_UNSP1
PM25_UNSPCRS

PM25to10_NA
TNO3

PMF_OMOC
PM1_OC
PM1_OA
PM25_OC
PM25_OA

**Tests conducted:**  
The code has been tested on the 2016 southeastern US benchmark domain. These ELMO outputs have been compared to post-processing results from the ACONC file using combine and previous SpecDef versions. Most values agreed to within 6 significant figures. The output variables that correspond to specific size ranges (e.g. PM1, PM2.5 total and speciated variables) differed by ~1-10% due to order of operations differences in how modal fractions are applied (i.e. online every time step vs. offline every output time step).

The code compiles and runs after handling all merge conflicts.


