### PR TITLE
Corrected NLCD to BELD3 mapping for shrub/scrub and dwarf scrub

### DIFF
--- a/CCTM/src/emis/emis/lus_data_module.F
+++ b/CCTM/src/emis/emis/lus_data_module.F
@@ -27,6 +27,9 @@
 !                     to map dust categories from LUFRAC. **NOTE land use type
 !                     with no mapped index has a dummy -999 value.** 
 !  31 Mar 2022 J. Willison Removed BELD as wbdust input 
+!  18 Sep 2024 C. Hogrefe Corrected erroneous mapping of NLCD40 and NLCD50
+!                         shrub/scrub and dwarf scrub to BELD3 barren rather
+!                         than BELD3 shrubland 
 !------------------------------------------------------------------------!
 
           module lus_data_module
@@ -215,8 +218,8 @@
      &           (/ 0.50,    ! shrubland
      &              0.50,    ! shrubland
      &              0.75,    ! barrenland
-     &              0.75,    ! barrenland
-     &              0.75,    ! barrenland
+     &              0.50,    ! shrubland
+     &              0.50,    ! shrubland
      &              0.75,    ! barrenland
      &              0.75 /)  ! barrenland
 
@@ -224,8 +227,8 @@
      &           (/ 1,       ! shrubland
      &              1,       ! shrubland
      &              3,       ! barrenland
-     &              3,       ! barrenland
-     &              3,       ! barrenland
+     &              1,       ! shrubland
+     &              1,       ! shrubland
      &              3,       ! barrenland
      &              3,       ! barrenland
      &              3 /)     ! ag landuse surrogate
@@ -299,16 +302,16 @@
      &           (/ 0.50,    ! shrubland
      &              0.50,    ! shrubland
      &              0.75,    ! barrenland
-     &              0.75,    ! barrenland
-     &              0.75,    ! barrenland
+     &              0.50,    ! shrubland
+     &              0.50,    ! shrubland
      &              0.75 /)  ! barrenland
 
             integer :: dmap_nlcd40( n_dlcat_nlcd40+1 ) = ! land use type desert map to BELD3
      &           (/ 1,       ! shrubland
      &              1,       ! shrubland
      &              3,       ! barrenland
-     &              3,       ! barrenland
-     &              3,       ! barrenland
+     &              1,       ! shrubland
+     &              1,       ! shrubland
      &              3,       ! barrenland
      &              3 /)     ! ag landuse surrogate
 


### PR DESCRIPTION
**Description and/or issue being addressed**:  
Corrects the error in NLCD40 land use mapping for inline windblown dust calculations described in issue #220   

**Impact on results:**   
When enabling the inline WBD module and using WRF simulations with NLCD40 LU as input, 2018 annual domain total WBD emissions over the 12US1 domain were reduced by about factor of 3-4, with the exact reduction depending on the approach used to specify vegetation fraction in the WRF simulations and likely also depending on the domain and year being simulated.  

**Significance:**   
Without this fix, users enabling the inline WBD module and using WRF simulations with NLCD40 LU as input to their CCTM simulations will likely experience excessive “soil” PM2.5 and total PM2.5 mass concentrations. Over the 12US1 domain, the effect is most pronounced during springtime over the Southwestern U.S. NLCD40 LU is used in many WRF applications over North America. With the corrected NLCD40 mapping, WBD estimates become comparable to those generated when using MODIS LU in WRF, the standard configuration in hemispheric WRF simulations and also used in the EQUATES 12US1 WRF simulations.

**Tests conducted:**  
The following set of 2018 WRF simulations was used to quantify the impacts of the LU mapping fix and to also compare WBD estimates and resulting PM2.5 concentrations across different WRF configuration options (MODIS vs. LU; vegetation fraction (VEGF) obtained from MODIS satellite data vs. lookup-tables in the WRF PX LSM),:
•	WRFv4.1.1 with MODIS LU and lookup-table VEGF
•	WRFv4.3.3 with NLCD40 LU and satellite-derived VEGF
•	WRFv4.3.3 with NLCD40 LU and lookup-table VEGF  

The following CMAQ simulations were performed with these WRF inputs
1.	NO WBD: CMAQv5.4.0.3 with WRFv4.1.1 (MODIS LU, lookup-table VEGF), WBD switched off
2.	WBD_MODIS_TABLE: CMAQv5.4.0.3 with WRFv4.1.1 (MODIS LU, lookup-table VEGF), WBD switched on
3.	WBD_NLCD40_TABLE: CMAQv5.4.0.3 with WRFv4.3.3 (NLCD40 LU, lookup-table VEGF), WBD switched on
4.	WBD_NLCD40_TABLE_REMAP: CMAQv5.4.0.3 + LU mapping fix from this PR with WRFv4.3.3 (NLCD40 LU, lookup-table VEGF), WBD switched on
5.	WBD_NLCD40_SATELLITE: CMAQv5.4.0.3 with WRFv4.3.3 (NLCD40 LU, satellite-derived VEGF), WBD switched on
6.	WBD_NLCD40_SATELLITE_REMAP: CMAQv5.4.0.3 + LU mapping fix from this PR with WRFv4.3.3 (NLCD40 LU, satellite-derived VEGF), WBD switched on  
 
Comparing runs 3 vs 4 and 5 vs 6 provide clean comparisons of the effects of the LU mapping fix on WBD estimates and PM2.5 concentrations for a given WRF configuration. For other comparisons, the differences between the WRF meteorological fields (wind, soil moisture, rain, etc.) caused by differences in LU (and other differences between v411 and v433, e.g. lightning assimilation) can have secondary impacts on WBD estimates and potentially larger impacts on atmospheric concentrations, making such comparisons less quantitative.  

The time series below shows a comparison of the annual domain-total WBD emissions from runs 2 – 6 above.  
![dust_fig1](https://github.com/user-attachments/assets/93317c82-ecb1-4a77-9bac-243712db6a47)
Comparing the blue vs. purple and green vs. orange lines shows that the WBD emissions over the 12US1 domain were reduced by about factor of 3-4 by the mapping error fix, with the exact reduction depending on the approach used to specify vegetation fraction in the WRF simulations. The figure also shows that the totals from the WBD_NLCD40_TABLE_REMAP simulation are fairly close to the WBD_MODIS_TABLE simulation. The implication is that while prior to the mapping fix, the choice of LU (NLCD40 vs. MODIS) in WRF was more impactful than the choice of VEGF (satellite-based vs. lookup table), the reverse is true after the mapping fix.   

The maps below compare CMAQ PM2.5 “soil” (IMPROVE definition) concentrations for runs 3 – 6, i.e. the simulations directly testing the impact of the mapping fix for two different WRF NLCD40 configurations. They show seasonal mean concentrations (spring at the top, winter at the bottom) for WBD_NLCD40_TABLE (first column), WBD_NLCD40_TABLE_REMAP (second column), WBD_NLCD40_TABLE_REMAP - WBD_NLCD40_TABLE (third column), WBD_NLCD40_SATELLITE (fourth column), WBD_NLCD40_ SATELLITE_REMAP (fifth column), and WBD_NLCD40_SATELLITE _REMAP - WBD_NLCD40_SATELLITE (last column). Differences are largest during spring over the Southwestern US and can reach up to 5 ug/m3.


![dust_fig2](https://github.com/user-attachments/assets/a52b94d0-8fb1-48d7-b6d3-9d32ba7d6c85)
The corresponding plot for total PM2.5 mass is shown below, note that the color scale ranges are twice as large as for the “soil” maps above.


![dust_fig3](https://github.com/user-attachments/assets/38b69e98-3582-42de-ba43-e9decd458013)
Finally, the time series below show comparisons to “soil” observations over the Southwestern U.S. (AZ, NM, UT, CO) for February – May, 2018. The following colors are used in these Figures:
•	Observations - Black
•	NO WBD: Orange
•	WBD_MODIS_TABLE: Red
•	WBD_NLCD40_TABLE: Dark Blue
•	WBD_NLCD40_TABLE_REMAP: Light Blue
•	WBD_NLCD40_SATELLITE: Dark Green
•	WBD_NLCD40_SATELLITE_REMAP: Light Green


**Absolute Concentrations:**  
![dust_fig4](https://github.com/user-attachments/assets/b8a89d85-b6ae-4cad-a7f5-429bc00c5d31)

**Bias:**  
![dust_fig5](https://github.com/user-attachments/assets/6a46290b-cf3b-490f-bebf-dd82a1f70aca)

The Figures show that the significant overestimates present in the current code when using NLCD40 WRF inputs (dark blue and dark green) are greatly reduced. The simulation without WBD (orange) underestimates “soil” concentrations during apparent WBD events. The simulations with WBD on (and after correcting the NLCD40 mapping error) better capture these events, though there is a tendency for general overestimation.

Internal [PR1181](https://github.com/USEPA/CMAQ_Dev/pull/1181).
