### PR TITLE
CRACMM2 fixes for ISAM and post processing

### DIFF
--- a/CCTM/src/MECHS/cracmm2/SpecDef_Conc_cracmm2.txt
+++ b/CCTM/src/MECHS/cracmm2/SpecDef_Conc_cracmm2.txt
@@ -257,7 +257,7 @@ AORGAIJ         ,ug m-3     ,AORGAI[0] + AORGAJ[0]
 
 !!! Biogenic-VOC Derived Organic Aerosol
 AORGBIJ         ,ug m-3    ,AISO3NOSJ[1] +AISO3OSJ[1] +AHOMJ[1] + AELHOMJ[1] \
-                           +AISO4J[1]    +AISO5J[1]   +ATRNPJ[1]+AHONITJ[1]
+                           +AISO4J[1]    +AISO5J[1]   +ATRPNJ[1]+AHONITJ[1]
 
 !!! Cloud-Processed  SOA
 AORGCJ          ,ug m-3    ,AORGCJ[1]

--- a/CCTM/src/MECHS/cracmm2/SpecDef_Conc_cracmm2.txt
+++ b/CCTM/src/MECHS/cracmm2/SpecDef_Conc_cracmm2.txt
@@ -69,8 +69,8 @@ NTR             ,ppbV      ,1000.0*(ONIT[1]+ISON[1]+INALD[1]+TRPN[1]+HONIT[1]), 
 PANS            ,ppbV      ,1000.0*(PAN[1]+PPN[1]+MPAN[1])
 NOY             ,ppbV      ,1000.0*(NO[1]+NO2[1]+NO3[1]+2*N2O5[1]+HONO[1] \
                                    +HNO3[1]+HNO4[1]+PAN[1]+PPN[1]+MPAN[1] \
-                                   +ISON[1]+INALD[1]+IPX[1]+TRPN[1]+ONIT[1]) \
-                                   +HONIT[1]+ANO3_PPB[0]
+                                   +ISON[1]+INALD[1]+IPX[1]+TRPN[1]+ONIT[1] \
+                                   +HONIT[1])+ANO3_PPB[0]
 O3              ,ppbV      ,1000.0*O3[1]
 SO2             ,ppbV      ,1000.0*SO2[1]
 SO2_UGM3        ,ug m-3    ,1000.0*(SO2[1]*2.2118*DENS[2])
@@ -185,6 +185,7 @@ ANH4IJ          ,ug m-3    ,ANH4I[1]+ANH4J[1]
 ANH4K           ,ug m-3    ,ANH4K[1]
 ASO4IJ          ,ug m-3    ,ASO4I[1]+ASO4J[1]
 ASO4K           ,ug m-3    ,ASO4K[1]
+ACLK            ,ug m-3    ,ACLK[1]
 
 !! Organic Particle Species
 ! Why is there an APOCI and APOCJ in the output? It doesn't match below 
@@ -208,10 +209,13 @@ ASOCI     ,ugC m-3,  AROCN2OXY2I[1]/1.42  + AROCN2OXY4I[1]/1.67  \
 ASOCJ     ,ugC m-3,  AHOMJ[1]/2.08 + AELHOMJ[1]/1.67 + AISO3NOSJ[1]/2.27 \
                    + AISO3OSJ[1]/3.6 + AGLYJ[1]/2.13 + AORGCJ[1]/2  \
                    + AOP3J[1]/1.92 + ASOATJ[1]/2.31 + AROCN2OXY2J[1]/1.42 \
+                   + AISO4J[1]/2.80 + AISO5J[1]/2.50 + AHONITJ[1]/2.21 + ATRPNJ[1]/1.79 \
                    + AROCN2OXY4J[1]/1.67 + AROCN2OXY8J[1]/2.17 + AROCN1OXY1J[1]/1.29 \
                    + AROCN1OXY3J[1]/1.54 + AROCN1OXY6J[1]/1.92 + AROCP0OXY2J[1]/1.42 \
                    + AROCP0OXY4J[1]/1.67 + AROCP1OXY1J[1]/1.29 + AROCP1OXY3J[1]/1.54 \
                    + AROCP2OXY2J[1]/1.42 + AROCP3OXY2J[1]/1.42 
+ATERPJ   ,ugC m-3,  AHOMJ[1]/2.08 + AELHOMJ[1]/1.67  \
+                    + AHONITJ[1]/2.21 + ATRPNJ[1]/1.79 
 ASOCIJ   ,ugC m-3,  ASOCI[0] + ASOCJ[0]
 
 ASOMI    ,ug m-3, AROCN2OXY2I[1]  + AROCN2OXY4I[1]  \
@@ -252,7 +256,8 @@ AORGAJ          ,ug m-3     ,AROCN2OXY2J[1]+AROCN2OXY4J[1]+AROCN2OXY8J[1]+AROCN1
 AORGAIJ         ,ug m-3     ,AORGAI[0] + AORGAJ[0]
 
 !!! Biogenic-VOC Derived Organic Aerosol
-AORGBIJ         ,ug m-3    ,AISO3NOSJ[1] +AISO3OSJ[1] +AHOMJ[1] + AELHOMJ[1]
+AORGBIJ         ,ug m-3    ,AISO3NOSJ[1] +AISO3OSJ[1] +AHOMJ[1] + AELHOMJ[1] \
+                           +AISO4J[1]    +AISO5J[1]   +ATRNPJ[1]+AHONITJ[1]
 
 !!! Cloud-Processed  SOA
 AORGCJ          ,ug m-3    ,AORGCJ[1]

--- a/CCTM/src/MECHS/cracmm2/SpecDef_Conc_cracmm2.txt
+++ b/CCTM/src/MECHS/cracmm2/SpecDef_Conc_cracmm2.txt
@@ -226,6 +226,7 @@ ASOMI    ,ug m-3, AROCN2OXY2I[1]  + AROCN2OXY4I[1]  \
 ASOMJ    ,ug m-3,  AHOMJ[1] + AELHOMJ[1] + AISO3NOSJ[1] \
                    + AISO3OSJ[1] + AGLYJ[1] + AORGCJ[1]  \
                    + AOP3J[1] + ASOATJ[1] + AROCN2OXY2J[1] \
+                   + AISO4J[1] + AISO5J[1] + AHONITJ[1] + ATRPNJ[1] \
                    + AROCN2OXY4J[1] + AROCN2OXY8J[1] + AROCN1OXY1J[1] \
                    + AROCN1OXY3J[1] + AROCN1OXY6J[1] + AROCP0OXY2J[1] \
                    + AROCP0OXY4J[1] + AROCP1OXY1J[1] + AROCP1OXY3J[1] \

--- a/CCTM/src/MECHS/cracmm2/SpecDef_cracmm2.txt
+++ b/CCTM/src/MECHS/cracmm2/SpecDef_cracmm2.txt
@@ -184,6 +184,7 @@ ANH4IJ          ,ug m-3    ,PMF_NH4[3]
 ANH4K           ,ug m-3    ,PMC_NH4[3]
 ASO4IJ          ,ug m-3    ,PMF_SO4[3]
 ASO4K           ,ug m-3    ,PMC_SO4[3]
+ACLK            ,ug m-3    ,ACKL[1]
 
 !! Organic Particle Species
 APOCIJ          ,ugC m-3   ,PMF_POC[3]

--- a/CCTM/src/aero/aero6/AERO_DATA.F
+++ b/CCTM/src/aero/aero6/AERO_DATA.F
@@ -401,8 +401,8 @@ C                     ---------- - - - ------- ------- ---------- --------- ----
       ! The following species are associated with CRACMM2
      & spcs_list_type('AISO4   ',F,T,F, cm_set, 1400.0, '       ','       ',0.0  ,'NVL',F,F,  0,  2.8, 6.1,T, 'DUST  ', 0.21), ! from heterogeneous uptake of IPX
      & spcs_list_type('AISO5   ',F,T,F, cm_set, 1400.0, '       ','       ',0.0  ,'NVL',F,F,  0,  2.8, 6.1,T, 'DUST  ', 0.18), ! from heterogeneous uptake of INALD
-     & spcs_list_type('ATRPN   ',F,T,F, cm_set, 1400.0, '       ','       ',0.0  ,'REV',F,F,  0,  2.8, 6.1,T, 'DUST  ', 0.10), ! SOA from first generation monoterpene nitrate
-     & spcs_list_type('AHONIT  ',F,T,F, cm_set, 1400.0, '       ','       ',0.0  ,'REV',F,F,  0,  2.8, 6.1,T, 'DUST  ', 0.14)  ! SOA from second generation monoterpene nitrate
+     & spcs_list_type('ATRPN   ',F,T,F, cm_set, 1400.0, 'TRPN   ','       ',0.0  ,'REV',F,F,  0,  2.8, 6.1,T, 'DUST  ', 0.10), ! SOA from first generation monoterpene nitrate
+     & spcs_list_type('AHONIT  ',F,T,F, cm_set, 1400.0, 'HONT   ','       ',0.0  ,'REV',F,F,  0,  2.8, 6.1,T, 'DUST  ', 0.14)  ! SOA from second generation monoterpene nitrate
      & /)                                                 
  
 ! Define Reference Emissions Size Distributions

--- a/CCTM/src/isam/SA_DEFN.F
+++ b/CCTM/src/isam/SA_DEFN.F
@@ -583,7 +583,7 @@ c----------------------------------------------------------
      &          'DCB1   ','DCB2   ','DCB3   ','SOAALK ','CO     '/ )
 
         !CRACMM1_AQ
-        ALLOCATE( ISAM_SPEC_VOC( 8 )%LIST( 96 ) )
+        ALLOCATE( ISAM_SPEC_VOC( 8 )%LIST( 97 ) )
         ISAM_SPEC_VOC( 8 )%LIST = (/'ACD       ','ACE       ','ACRO      ',
      &    'ACT       ','ALD       ','API       ','BALD      ','BDE13     ',
      &    'BEN       ','CSL       ','DCB1      ','DCB2      ','DCB3      ',
@@ -603,10 +603,10 @@ c----------------------------------------------------------
      &    'VROCP4ALK ','VROCP5ALK ','VROCP6ALK ','VROCN2OXY2','VROCN2OXY4',
      &    'VROCN2OXY8','VROCN1OXY1','VROCN1OXY3','VROCN1OXY6','VROCP0OXY2',
      &    'VROCP0OXY4','VROCP1OXY1','VROCP1OXY3','VROCP2OXY2','VROCP3OXY2',
-     &    'VROCP4OXY2','VROCP5OXY1','VROCP6OXY1'/ )
+     &    'VROCP4OXY2','VROCP5OXY1','VROCP6OXY1','CO        '/ )
 
         !CRACMM2
-        ALLOCATE( ISAM_SPEC_VOC( 9 )%LIST( 97 ) )
+        ALLOCATE( ISAM_SPEC_VOC( 9 )%LIST( 98 ) )
         ISAM_SPEC_VOC( 9 )%LIST = (/'ACD       ','ACE       ','ACRO      ',
      &    'ACT       ','ALD       ','API       ','BALD      ','BDE13     ',
      &    'BEN       ','CSL       ','DCB1      ','DCB2      ','DCB3      ',
@@ -626,7 +626,7 @@ c----------------------------------------------------------
      &    'VROCP4ALK ','VROCP5ALK ','VROCP6ALK ','VROCN2OXY2','VROCN2OXY4',
      &    'VROCN2OXY8','VROCN1OXY1','VROCN1OXY3','VROCN1OXY6','VROCP0OXY2',
      &    'VROCP0OXY4','VROCP1OXY1','VROCP1OXY3','VROCP2OXY2','VROCP3OXY2',
-     &    'VROCP4OXY2','VROCP5OXY1','VROCP6OXY1','ECH4      '/ )
+     &    'VROCP4OXY2','VROCP5OXY1','VROCP6OXY1','ECH4      ','CO        '/)
 
         !PRESCRIBE NITRATE SPECIES
         !CB6R3_AE7_AQ

--- a/CCTM/src/isam/SA_DEFN.F
+++ b/CCTM/src/isam/SA_DEFN.F
@@ -690,18 +690,18 @@ c----------------------------------------------------------
      &         'BENP','ETEP'/ )
 
         !CRACMM1_AQ
-        ALLOCATE( ISAM_SPEC_NO3( 8 )%LIST( 27 ) )
+        ALLOCATE( ISAM_SPEC_NO3( 8 )%LIST( 26 ) )
         ISAM_SPEC_NO3( 8 )%LIST = (/   'HNO3 ','NO   ','NO2  ','NO3  ','HONO ',
      &         'N2O5 ','PAN  ','HNO4 ','ONIT ','MPAN ','PPN  ','ISON ','TRPN ',
      &         'NALD ','ACO3 ','MO2  ','HC3P ','HC5P ','HC10P','KETP ','ISOP ',
-     &         'ETHP ','RCO3 ','XYLP ','TR2  ','BENP ','ETEP '/ )
+     &         'ETHP ','RCO3 ','XYLP ','BENP ','ETEP '/ )
 
         !CRACMM2
         ALLOCATE( ISAM_SPEC_NO3( 9 )%LIST( 27 ) )
         ISAM_SPEC_NO3( 9 )%LIST = (/   'HNO3 ','NO   ','NO2  ','NO3  ','HONO ',
      &         'N2O5 ','PAN  ','HNO4 ','ONIT ','MPAN ','PPN  ','ISON ','TRPN ',
-     &         'INALD','ACO3 ','MO2  ','HC3P ','HC5P ','HC10P','KETP ','ISOP ',
-     &         'ETHP ','RCO3 ','XYLP ','TR2  ','BENP ','ETEP '/ )
+     &         'INALD','HONIT','ACO3 ','MO2  ','HC3P ','HC5P ','HC10P','KETP ',
+     &         'ISOP ','ETHP ','RCO3 ','XYLP ','BENP ','ETEP '/ )
         
         !PRESCRIBE SPECIES RELEVANT FOR ASSIGNING BIAS TO VOCs
         !CB6R3_AE7_AQ


### PR DESCRIPTION
-updates for ISAM applications
-minor corrections to SpecDef file for post processing
 On branch 20250213cmaq55plus
 Your branch is up to date with 'epapublic_repo/5.5+'.
 Changes to be committed:
	modified:   src/MECHS/cracmm2/SpecDef_Conc_cracmm2.txt
	modified:   src/aero/aero6/AERO_DATA.F
	modified:   src/isam/SA_DEFN.F

**Contact:**  
Havala Pye (pye.havala@epa.gov), US EPA

**Type of code change:**   
Bug fixes

**Description of changes:**   
Added ACLK to CRACMM SpecDef for AMET post processing. Added some missing SOA species in SpecDef definitions. Added 2 fixes for ISAM: SOA precursor names for TRPN and HONIT; 'CO' as member of VOC.

**Issue:**  
Resolves #221 

**Summary of Impact:**  
Small changes in post-processed concentrations due to missing species (minor).

**Tests conducted:**  
Merged in EPA internal CRACMM_Dev code. Tested on 2023 12US4 domain. Results for a project were similar to previous runs.
