### PR TITLE
Resolve merge conflict accidently commited to xc_qy_td_effect.F

### DIFF
--- a/UTIL/inline_phot_preproc/src/xc_qy_td_effect.F
+++ b/UTIL/inline_phot_preproc/src/xc_qy_td_effect.F
@@ -57,12 +57,7 @@
      &                         SPECTRA_TYPE,
      &                         WLL_AVE, WLU_AVE, NWL_AVE, 
      &                         CS_AVE, QY_AVE )
-<<<<<<< HEAD
-          USE CSQY_PARAMETERS
-          USE BIN_DATA
           IMPLICIT NONE      
-=======
->>>>>>> ddb97d77d2fbbdaacd82cf8c0353e4edecb81897
           CHARACTER(1), INTENT( IN ) :: SPECTRA_TYPE        ! spectra type
           INTEGER, INTENT( IN )      :: NWL_AVE             ! number of intervals average 
           INTEGER, INTENT( IN )      :: NWL_CS_IN           ! number of intervals CS_IN


### PR DESCRIPTION
**Contact:**  
Daniel Wesloh
Lynker Coporation, in support of NOAA/NWS/NCEP/EMC

**Type of code change:**   
Bug fix

**Description of changes:**   
Resolve a merge conflict that seems to have been committed a few years ago.

This version of `xc_qy_td_effect.F` seems to be only used by `old-dumb.makefile`: `old.Makefile` and `Makefile` both use `xc_qy_td_effect_v3.F`, and the last is probably what gets used.

**Issue:**  
<!-- If this resolves a known issue, include the link to the GitHub Issue number.  -->

**Summary of Impact:**  
This should prevent syntax errors when compiling an old configuration, and should not change any model predictions.
<!--
Please state whether this update changes the results of the core model predictions in terms of concentration, deposition, etc.  
Please state the approximate impact this update has on model runtime, if any.  -->

**Tests conducted:**  
<!-- Describe tests that were conducted including domain and time period (e.g. BLDCHECK; June 1-2 2016 SEBENCH; Jan 2017 12US1) and results of the tests.  Include plots of relevant results.  -->

This file no longer showed up on checks for merge conflict markers in a repository containing this one as a submodule.  I performed no further tests.