### PR TITLE
Add documenation that DDM is not compatible with STAGE in v5.4

### DIFF
--- a/CCTM/scripts/bldit_cctm.csh
+++ b/CCTM/scripts/bldit_cctm.csh
@@ -80,14 +80,17 @@ set make_options = "-j"                #> additional options for make command if
 
 #set DDM3D_CCTM                        #> uncomment to compile CCTM with DD3D activated
                                        #>   comment out to use standard process
-#> Two-way WRF-CMAQ 
-#set build_twoway                      #> uncomment to build WRF-CMAQ twoway; 
-                                       #>   comment out for off-line chemistry 
+                                       #> Note that DDM is not compatible with the 
+                                       #>   STAGE deposition model in v5.4
+#> Two-way WRF-CMAQ
+#set build_twoway                      #> uncomment to build WRF-CMAQ twoway;
+                                       #>   comment out for off-line chemistry      
 
 #> Potential vorticity free-troposphere O3 scaling
 #set potvortO3
 
 #> Working directory and Version IDs
+
  if ( $?ISAM_CCTM ) then
      set VRSN  = v54_ISAM             #> model configuration ID for CMAQ_ISAM
  else if ( $?DDM3D_CCTM ) then

--- a/DOCS/Users_Guide/CMAQ_UG_ch10_HDDM-3D.md
+++ b/DOCS/Users_Guide/CMAQ_UG_ch10_HDDM-3D.md
@@ -29,6 +29,10 @@ To use CMAQ-DDM-3D, follow the normal build process for CMAQ described in [Chapt
  set DDM3D_CCTM                        #> uncomment to compile CCTM with DD3D activated
 ```
 
+**Note that DDM-3D is not compatible with the STAGE deposition model in CMAQv5.4.**   
+Simulations with DDM-3D should use ``` set DepMod    = m3dry``` in bldit_cctm.csh.
+
+
 **A note about I/O API installation for DDM applications**
 
 I/O APIv3.2  supports up to MXFILE3=64 open files, each with up to MXVARS3=2048. DDM applications configured to calculate sensitivity to a large number of parameters may exceed this upper limit of model variables, leading to a model crash. To avoid this issue, users may use I/O API version 3.2 "large" that increases MXFILE3 to 512 and MXVARS3 to 16384. Instructions to build this version are found in [Chapter 3](https://github.com/USEPA/CMAQ/blob/main/DOCS/Users_Guide/CMAQ_UG_ch03_preparing_compute_environment.md#333-io-api-library).

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ particulates, toxics, and acid deposition.
 * Biogenic emissions algorithm options have been expanded
 * Revised algorithms for modeling the dry deposition of particles from the atmosphere (M3DRY and STAGE updates)
 * Streamlined building of the coupled WRF-CMAQ system compatible with WRFv4.4+ 
-* Improved efficiency, accuracy, and user experience for CMAQ instrumented model extensions CMAQ-DDM-3D and CMAQ-ISAM
+* Improved efficiency, accuracy, and user experience for CMAQ instrumented model extensions CMAQ-DDM-3D and CMAQ-ISAM. (*Note that DDM-3D is not compatible with the STAGE deposition model in CMAQv5.4.*)
 * Expansion of emissions diagnostic output features
 * Introduction of a domain-wide Budget Reporting tool 
 * Online integration of common pollutant post-processing tasks (i.e. output total PM2.5 mass and more directly!)


### PR DESCRIPTION
**Type of code change:**   
Documentation 

**Description of changes:**   
CMAQ DDM-3D is not compatible with the STAGE deposition module in CMAQv5.4 - CMAQv5.5 (including bugfix releases of those versions).   This PR adds documentation to the 5.4 branch to alert the user to this.  CMAQ has since been updated to allow DDM-3D to be used with the STAGE module.  This update will be included in the next CMAQ release (v6.0). 

**Issue:**  
Issue #254 

**Summary of Impact:**  
Changes are to .md documentation and shell script comments.  No impact on model results. 

**Tests conducted:**  
N/A