### PR TITLE
Update handling of CASTNET QA Flags for ozone, increase number of species allowed in expressions

### DIFF
--- a/POST/sitecmp/README.md
+++ b/POST/sitecmp/README.md
@@ -43,6 +43,10 @@ This Fortran program generates a csv (comma separated values) file that compares
  END_DATE    ending date of time period to process (YYYYJJJ)
  END_TIME    ending time of time period to process (HHMMSS)
  APPLY_DLS   apply daylight savings time (default N)
+ QA_FLAG_CHECK  does IN_TABLE include a QA flag for ozone values, and should it be used? 
+                (Default Y, but can be set to N for any network except CASTNET and SEARCH because flags are currently only present in the data files for these networks) 
+ QA_FLAG_VALUES if QA_FLAG_CHECK is Y, string composed of single-character QA flags that 
+                should be treated as missing values (default "#BCDFHIJKLMNPRTY" to capture known CASTNET data and SEARCH flags)
  TIME_SHIFT  number of hours to add when retrieving time steps from M3_FILE_n files 
              during processing. This should only be non-zero if the M3_FILE_n files
              were pre-processed with a utility like m3tshift (default 0)

--- a/POST/sitecmp/scripts/run_sitecmp_AQS_Daily.csh
+++ b/POST/sitecmp/scripts/run_sitecmp_AQS_Daily.csh
@@ -115,7 +115,7 @@
      setenv AERO_42 "OC_88370+EC_88380,ug/m3,AOCIJ+AECIJ,,PM25_TC_88370"  # Total Carbon
      setenv AERO_43 "OC_88320,ug/m3,PM25_OC,ug/m3,PM25_OC_88320"            # OC blank adjusted Mass
      setenv AERO_44 "EC_88321,ug/m3,PM25_EC,ug/m3,PM25_EC_88321"            # EC Mass
-     setenv AERO_45 "OC_88320+EC_88380,ug/m3,AOCIJ+AECIJ,,PM25_TC_88320"  # Total Carbon
+     setenv AERO_45 "OC_88320+EC_88321,ug/m3,AOCIJ+AECIJ,,PM25_TC_88320"  # Total Carbon
      setenv AERO_46 "PM10_81102,ug/m3,PM10,ug/m3,PM10"       # PM10 Total Mass 
  
  #> setenv AERO6 species

--- a/POST/sitecmp/scripts/run_sitecmp_AQS_Daily.csh
+++ b/POST/sitecmp/scripts/run_sitecmp_AQS_Daily.csh
@@ -22,7 +22,7 @@
 #> Set General Parameters for Configuring the Simulation
  set VRSN      = v55              #> Code Version
  set PROC      = mpi               #> serial or mpi
- set MECH      = cb6r3_ae7_aq      #> Mechanism ID
+ set MECH      = cb6r5_ae7_aq      #> Mechanism ID
  set APPL      = Bench_2016_12SE1        #> Application Name (e.g. Gridname)
                                                       
 #> Define RUNID as any combination of parameters above or others. By default,
@@ -68,51 +68,71 @@
 #>
 #> The expression is in the form:
 #>       [factor1]*Obs_name1 [+][-] [factor2]*Obs_name2 ...
- setenv AERO_1 "PM25,ug/m3,ATOTIJ,ug/m3,PM_TOT"              # PM2.5 Total Mass
- setenv AERO_2 "PM25,ug/m3,PMIJ_FRM,ug/m3,PM_FRM"          # PM2.5 Total Mass (I+J with FRM adjustment)
- setenv AERO_3 "PM10,ug/m3,ATOTIJK,ug/m3,PM10"       # PM10 Total Mass
- setenv AERO_4 "Isoprene,ppb,ISOP,ppb,Isoprene"            # Isoprene
- setenv AERO_5 "Ethylene,ppb,ETH,ppb,Ethylene"             # Ethene (Ethylene)
- setenv AERO_6 "Ethane,ppb,ETHA,ppb,Ethane"                # Ethane
- setenv AERO_7 "Toluene,ppb,TOL,ppb,Toluene"               # Toluene
- setenv AERO_8 "Acetaldehyde,ppb,ALD2,ppb,Acetaldehyde"    # Acetaldehyde
- setenv AERO_9 "Formaldehyde,ppb,FORM,ppb,Formaldehyde"    # Formaldehyde
- setenv AERO_10 "OC+OC_Blank,ug/m3,AOCIJ,ug/m3,OC"         # OC blank adjusted Mass
- setenv AERO_11 "EC,ug/m3,AECIJ,ug/m3,EC"                  # EC Mass
- setenv AERO_12 "OC+OC_Blank+EC,ug/m3,AOCIJ+AECIJ,,TC"     # Total Carbon
- setenv AERO_13 "Na,ug/m3, ANAIJ,,Na"                      # sodium
- setenv AERO_14 "Cl,ug/m3, ACLIJ,,Cl"                      # chlorine
- setenv AERO_15 "Na+Cl,ug/m3,ACLIJ+ANAIJ,,NaCl"            # sodium chloride
- setenv AERO_16 "SO4,ug/m3,ASO4IJ,ug/m3,SO4"               # PM2.5 Total Mass  
- setenv AERO_17 "NO3,ug/m3,ANO3IJ,ug/m3,NO3"               # PM2.5 Total Mass
- setenv AERO_18 "NH4,ug/m3,ANH4IJ,ug/m3,NH4"               # PM2.5 Total Mass
+     setenv AERO_1 "PM25,ug/m3,ATOTIJ,ug/m3,PM_TOT"              # PM2.5 Total Mass
+     setenv AERO_2 "PM25_88101,ug/m3,ATOTIJ,ug/m3,PM_TOT_88101"
+     setenv AERO_3 "PM25_88502,ug/m3,ATOTIJ,ug/m3,PM_TOT_88502"
+     setenv AERO_4 "PM10_81102,ug/m3,ATOTIJ+ATOTK,ug/m3,PM10_IJK"       # PM10 Total Mass
+     setenv AERO_5 "Isoprene,ppb,ISOP,ppb,Isoprene"            # Isoprene
+     setenv AERO_6 "Ethylene,ppb,ETH,ppb,Ethylene"             # Ethene (Ethylene)
+     setenv AERO_7 "Ethane,ppb,ETHA,ppb,Ethane"                # Ethane
+     setenv AERO_8 "Toluene,ppb,TOL,ppb,Toluene"               # Toluene
+     setenv AERO_9 "Acetaldehyde,ppb,ALD2,ppb,Acetaldehyde"    # Acetaldehyde
+     setenv AERO_10 "Formaldehyde,ppb,FORM,ppb,Formaldehyde"    # Formaldehyde
+     setenv AERO_11 "Benzene,ppb,BENZENE,ppb,Benzene"             # Benzene
+     setenv AERO_12 "OC,ug/m3,AOCIJ,ug/m3,OC"            # OC blank adjusted Mass
+     setenv AERO_13 "EC,ug/m3,AECIJ,ug/m3,EC"            # EC Mass
+     setenv AERO_14 "OC+EC,ug/m3,AOCIJ+AECIJ,,TC"  # Total Carbon
+     setenv AERO_15 "OC_88305,ug/m3,AOCIJ,ug/m3,OC_88305"            # OC blank adjusted Mass
+     setenv AERO_16 "EC_88307,ug/m3,AECIJ,ug/m3,EC_88307"            # EC Mass
+     setenv AERO_17 "OC_88305+EC_88307,ug/m3,AOCIJ+AECIJ,,TC_88305"  # Total Carbon
+     setenv AERO_18 "OC_88370,ug/m3,AOCIJ,ug/m3,OC_88370"            # OC blank adjusted Mass
+     setenv AERO_19 "EC_88380,ug/m3,AECIJ,ug/m3,EC_88380"            # EC Mass
+     setenv AERO_20 "OC_88370+EC_88380,ug/m3,AOCIJ+AECIJ,,TC_88370"  # Total Carbon
+     setenv AERO_21 "OC_88320,ug/m3,AOCIJ,ug/m3,OC_88320"            # OC blank adjusted Mass
+     setenv AERO_22 "EC_88321,ug/m3,AECIJ,ug/m3,EC_88321"            # EC Mass
+     setenv AERO_23 "OC_88320+EC_88321,ug/m3,AOCIJ+AECIJ,,TC_88320"  # Total Carbon 
+     setenv AERO_24 "Na,ug/m3, ANAIJ,,Na"                      # sodium
+     setenv AERO_25 "Cl,ug/m3, ACLIJ,,Cl"                      # chlorine
+     setenv AERO_26 "Na+Cl,ug/m3,ACLIJ+ANAIJ,,NaCl"            # sodium chloride
+     setenv AERO_27 "SO4,ug/m3,ASO4IJ,ug/m3,SO4"               # PM2.5 Total Mass  
+     setenv AERO_28 "NO3,ug/m3,ANO3IJ,ug/m3,NO3"               # PM2.5 Total Mass
+     setenv AERO_29 "NH4,ug/m3,ANH4IJ,ug/m3,NH4"               # PM2.5 Total Mass
  
 #> PM2.5 Sharp Cutoff Species
 #> Requires preprocessing using setenv CCTM_AELMO file
- setenv AERO_19 "PM25,ug/m3,PM25_TOT,ug/m3,PM25_TOT"       # PM2.5 Total Mass with sharp cutoff
- setenv AERO_20 "PM25,ug/m3,PM25_FRM,,PM25_FRM"            # PM2.5 Total Mass (cutoff with FRM adjustment)
- setenv AERO_21 "SO4,ug/m3, PM25_SO4,,PM25_SO4"            # sulfate (sharp cutoff)
- setenv AERO_22 "NO3,ug/m3, PM25_NO3,,PM25_NO3"            # nitrate (sharp cutoff)
- setenv AERO_23 "NH4,ug/m3, PM25_NH4,,PM25_NH4"            # ammonium (sharp cutoff)
- setenv AERO_24 "OC+OC_Blank,ug/m3, PM25_OC,,PM25_OC"               # Organic Carbon (sharp cutoff)
- setenv AERO_25 "EC,ug/m3, PM25_EC,,PM25_EC"               # Elemental Carbon (sharp cutoff)
- setenv AERO_26 "OC+OC_Blank+EC,ug/m3,PM25_OC+PM25_EC,,PM25_TC"     # Total Carbon (sharp cutoff)
+     setenv AERO_30 "PM25,ug/m3,PM25_TOT,ug/m3,PM25_TOT"       # PM2.5 Total Mass with sharp cutoff
+     setenv AERO_31 "SO4,ug/m3, PM25_SO4,,PM25_SO4"            # sulfate (sharp cutoff)
+     setenv AERO_32 "NO3,ug/m3, PM25_NO3,,PM25_NO3"            # nitrate (sharp cutoff)
+     setenv AERO_33 "NH4,ug/m3, PM25_NH4,,PM25_NH4"            # ammonium (sharp cutoff)
+     setenv AERO_34 "OC,ug/m3, PM25_OC,,PM25_OC"               # Organic Carbon (sharp cutoff)
+     setenv AERO_35 "EC,ug/m3, PM25_EC,,PM25_EC"               # Elemental Carbon (sharp cutoff)
+     setenv AERO_36 "OC+EC,ug/m3,PM25_OC+PM25_EC,,PM25_TC"     # Total Carbon (sharp cutoff)
+     setenv AERO_37 "OC_88305,ug/m3,PM25_OC,ug/m3,PM25_OC_88305"            # OC blank adjusted Mass
+     setenv AERO_38 "EC_88307,ug/m3,PM25_EC,ug/m3,PM25_EC_88307"            # EC Mass
+     setenv AERO_39 "OC_88305+EC_88307,ug/m3,AOCIJ+AECIJ,,PM25_TC_88305"  # Total Carbon
+     setenv AERO_40 "OC_88370,ug/m3,PM25_OC,ug/m3,PM25_OC_88370"            # OC blank adjusted Mass
+     setenv AERO_41 "EC_88380,ug/m3,PM25_EC,ug/m3,PM25_EC_88380"            # EC Mass
+     setenv AERO_42 "OC_88370+EC_88380,ug/m3,AOCIJ+AECIJ,,PM25_TC_88370"  # Total Carbon
+     setenv AERO_43 "OC_88320,ug/m3,PM25_OC,ug/m3,PM25_OC_88320"            # OC blank adjusted Mass
+     setenv AERO_44 "EC_88321,ug/m3,PM25_EC,ug/m3,PM25_EC_88321"            # EC Mass
+     setenv AERO_45 "OC_88320+EC_88380,ug/m3,AOCIJ+AECIJ,,PM25_TC_88320"  # Total Carbon
+     setenv AERO_46 "PM10_81102,ug/m3,PM10,ug/m3,PM10"       # PM10 Total Mass 
  
  #> setenv AERO6 species
  #> note we use Sodium Ion instead of sodium (XRF) becasue XRF is not reliable for sodium
  #> all other elemental concentrations (including Cl and K) come from XRF
-  setenv AERO_27 "Fe,ug/m3, AFEJ,,Fe"         # iron
-  setenv AERO_28 "Al,ug/m3,AALJ,,Al"          # aluminum 
-  setenv AERO_29 "Si,ug/m3, ASIJ,,Si"         # silicon
-  setenv AERO_30 "Ti,ug/m3, ATIJ,,Ti"         # titanium
-  setenv AERO_31 "Ca,ug/m3,ACAJ,,Ca"          # calcium
-  setenv AERO_32 "Mg,ug/m3,AMGJ,,Mg"          # magnesium
-  setenv AERO_33 "K,ug/m3,AKJ,,K"             # potassium
-  setenv AERO_34 "Mg,ug/m3,AMNJ,,Mn"          # manganese
-  setenv AERO_35 "2.2*Al+2.49*Si+1.63*Ca+2.42*Fe+1.94*Ti,ug/m3,ASOILJ,,soil" 
-  setenv AERO_36 "PM25-SO4-NO3-NH4-OC-EC-[Na]-[Cl]-2.2*Al-2.49*Si-1.63*Ca-2.42*Fe-1.94*Ti , ug/m3, AUNSPEC1IJ,,OTHER"        # PM Other
-  setenv AERO_37 "0.8*OC,ug/m3, ANCOMIJ,,NCOM"    # PM Other
-  setenv AERO_38 "PM25-SO4-NO3-NH4-OC-EC-[Na]-[Cl]-2.2*Al-2.49*Si-1.63*Ca-2.42*Fe-1.94*Ti-0.8*OC,ug/m3, AUNSPEC2IJ,,OTHER_REM"    # PM Other no NCOM
+     setenv AERO_47 "Fe,ug/m3, AFEJ,,Fe"         # iron
+     setenv AERO_48 "Al,ug/m3,AALJ,,Al"          # aluminum 
+     setenv AERO_49 "Si,ug/m3, ASIJ,,Si"         # silicon
+     setenv AERO_50 "Ti,ug/m3, ATIJ,,Ti"         # titanium
+     setenv AERO_51 "Ca,ug/m3,ACAJ,,Ca"          # calcium
+     setenv AERO_52 "Mg,ug/m3,AMGJ,,Mg"          # magnesium
+     setenv AERO_53 "K,ug/m3,AKJ,,K"             # potassium
+     setenv AERO_54 "Mg,ug/m3,AMNJ,,Mn"          # manganese
+     setenv AERO_55 "2.2*Al+2.49*Si+1.63*Ca+2.42*Fe+1.94*Ti,ug/m3,ASOILJ,,soil" 
+     setenv AERO_56 "PM25-SO4-NO3-NH4-OC-EC-[Na]-[Cl]-2.2*Al-2.49*Si-1.63*Ca-2.42*Fe-1.94*Ti , ug/m3, AUNSPEC1IJ,,OTHER"        # PM Other
+     setenv AERO_57 "0.8*OC,ug/m3, ANCOMIJ,,NCOM"    # PM Other
+     setenv AERO_58 "PM25-SO4-NO3-NH4-OC-EC-[Na]-[Cl]-2.2*Al-2.49*Si-1.63*Ca-2.42*Fe-1.94*Ti-0.8*OC,ug/m3, AUNSPEC2IJ,,OTHER_REM"    # PM Other no NCOM
 
 #>> End Species List <<#
 
@@ -145,13 +165,16 @@
 #> This should only be non-zero if the M3_FILE_n files were pre-processed with a utility like m3tshift (default 0).
  setenv TIME_SHIFT 0
 
+#> indicate whether or not to check QA flag (default Y)
+ setenv QA_FLAG_CHECK N 
+
 #############################################################
 #  Input files
 #############################################################
 
 #> ioapi input files containing VNAMES (max of 10)
- setenv M3_FILE_1 ${CMAQ_DATA}/POST/COMBINE_ACONC_${RUNID}_201607.nc
-         #[Add location of input file, e.g. COMBINE_ACONC file.]
+ setenv M3_FILE_1 ${CMAQ_DATA}/POST/COMBINE_AELMO_${RUNID}_201607.nc
+         #[Add location of input file, e.g. COMBINE_AELMO file.]
 
 #> SITE FILE containing site-id, longitude, latitude, and optionally 
 #> GMT offset, state, county, and elevation (csv format)

--- a/POST/sitecmp/scripts/run_sitecmp_AQS_Hourly.csh
+++ b/POST/sitecmp/scripts/run_sitecmp_AQS_Hourly.csh
@@ -22,7 +22,7 @@
 #> Set General Parameters for Configuring the Simulation
  set VRSN      = v55               #> Code Version
  set PROC      = mpi               #> serial or mpi
- set MECH      = cb6r3_ae7_aq      #> Mechanism ID
+ set MECH      = cb6r5_ae7_aq      #> Mechanism ID
  set APPL      = Bench_2016_12SE1        #> Application Name (e.g. Gridname)
                                                       
 #> Define RUNID as any combination of parameters above or others. By default,
@@ -69,31 +69,30 @@
 #>
 #> The expression is in the form:
 #>       [factor1]*Obs_name1 [+][-] [factor2]*Obs_name2 ...
- setenv GAS_1 "O3,ppb,O3,ppb,O3" 
- setenv GAS_2 "NO,ppb,NO,ppb,NO"              
- setenv GAS_3 "NOY,ppb,NOY,ppb,NOY"              
- setenv GAS_4 "NO2,ppb,NO2,ppb,NO2"              
- setenv GAS_5 "NOX,ppb,NO+NO2,ppb,NOX"           
- setenv GAS_6 "CO,ppb,CO,ppb,CO"                 
- setenv GAS_7 "SO2,ppb,SO2,ppb,SO2"              
- setenv GAS_8 "PM25,ug/m3,ATOTIJ,ug/m3,PM_TOT"     
- setenv GAS_9 "PM25,ug/m3,PMIJ_FRM,ug/m3,PM_FRM" 
- setenv GAS_10 "PM10,ug/m3,PM10,ug/m3,PM10"       
- setenv GAS_11 "Isoprene,ppb,ISOP,ppb,Isoprene"  
- setenv GAS_12 "Ethylene,ppb,ETH,ppb,Ethylene"   
- setenv GAS_13 "Ethane,ppb,ETHA,ppb,Ethane"      
- setenv GAS_14 "Toluene,ppb,TOL,ppb,Toluene"     
- setenv GAS_15 "Temperature,C,SFC_TMP,C,SFC_TMP" 
- setenv GAS_16 "RH,%,RH,%,RH"                    
- setenv GAS_17 "Wind_Speed,m/s,WSPD10,m/s,WSPD10"
- setenv GAS_18 ",,PBLH,m,PBLH"                   
- setenv GAS_19 ",,SOL_RAD,watts/m2,Solar_Rad"    
- setenv GAS_20 ",,10*precip,mm/hr,precip"       
+     setenv GAS_1 "O3,ppb,O3,ppb,O3"                           # O3
+     setenv GAS_2 "NO,ppb,NO,ppb,NO"                           # NO
+     setenv GAS_3 "NOY,ppb,NOY,ppb,NOY"                        # NOY
+     setenv GAS_4 "NO2,ppb,NO2,ppb,NO2"                        # NO2
+     setenv GAS_5 "NOX,ppb,NO+NO2,ppb,NOX"                     # NOX
+     setenv GAS_6 "CO,ppb,CO,ppb,CO"                           # CO
+     setenv GAS_7 "SO2,ppb,SO2,ppb,SO2"                        # SO2
+     setenv GAS_8 "PM25,ug/m3,ATOTIJ,ug/m3,PM_TOT"    # PM25
+     setenv GAS_9 "PM10_81102,ug/m3,ATOTIJ+ATOTK,ug/m3,PM10_IJK"       # PM10
+     setenv GAS_10 "Isoprene,ppb,ISOP,ppb,Isoprene"            # Isoprene
+     setenv GAS_11 "Ethylene,ppb,ETH,ppb,Ethylene"             # Ethene (Ethylene)
+     setenv GAS_12 "Ethane,ppb,ETHA,ppb,Ethane"                # Ethane
+     setenv GAS_13 "Toluene,ppb,TOL,ppb,Toluene"               # Toluene
+     setenv GAS_14 "Temperature,C,SFC_TMP,C,SFC_TMP"           # Surface Temperature
+     setenv GAS_15 "RH,%,RH,%,RH"                              # Relative Humidity
+     setenv GAS_16 "Wind_Speed,m/s,WSPD10,m/s,WSPD10"          # Wind Speed
+     setenv GAS_17 ",,PBLH,m,PBLH"                             # PBL Height
+     setenv GAS_18 ",,SOL_RAD,watts/m2,Solar_Rad"              # Solar Radiation
+     setenv GAS_19 ",,10*precip,mm/hr,precip"                  # Precipitation
    
 #> PM2.5 Sharp Cutoff Species
 #> Requires preprocessing using CCTM_AELMO file
- setenv GAS_21 "PM25,ug/m3,PM25_TOT,ug/m3,PM25_TOT"
- setenv GAS_22 "PM25,ug/m3,PM25_FRM,,PM25_FRM"     
+     setenv GAS_20 "PM25,ug/m3,PM25_TOT,ug/m3,PM25_TOT"       # PM2.5 Total Mass with sharp cutoff
+     setenv GAS_21 "PM10_81102,ug/m3,PM10,ug/m3,PM10"       # PM10
 #>> End Species List <<#
 
 # ~~~~~~~~~~~~ END NETWORK SPECIFIC SECTION ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -125,13 +124,16 @@
 #> This should only be non-zero if the M3_FILE_n files were pre-processed with a utility like m3tshift (default 0).
  setenv TIME_SHIFT 0
 
+#> indicate whether or not to check QA flag (default Y)
+ setenv QA_FLAG_CHECK N 
+
 #############################################################
 #  Input files
 #############################################################
 
 #> ioapi input files containing VNAMES (max of 10)
- setenv M3_FILE_1 ${CMAQ_DATA}/POST/COMBINE_ACONC_${RUNID}_201607.nc
-         #[Add location of input file, e.g. COMBINE_ACONC file.]
+ setenv M3_FILE_1 ${CMAQ_DATA}/POST/COMBINE_AELMO_${RUNID}_201607.nc
+         #[Add location of input file, e.g. COMBINE_AELMO file.]
 
 #> SITE FILE containing site-id, longitude, latitude, and optionally 
 #> GMT offset, state, county, and elevation (csv format)

--- a/POST/sitecmp/scripts/run_sitecmp_CASTNET_Hourly.csh
+++ b/POST/sitecmp/scripts/run_sitecmp_CASTNET_Hourly.csh
@@ -1,7 +1,7 @@
 #! /bin/csh -f
 
 # ===================== SITECMP_v5.5.X Run Script =====================
-# Usage: run_sitecmp_CSN.csh >&! sitecmp_CSN.log &
+# Usage: run_sitecmp_CASTNET_Hourly.csh >&! sitecmp_CASTNET_Hourly.log &
 #
 # To report problems or request help with this script/program:
 #             http://www.epa.gov/cmaq    (EPA CMAQ Website)
@@ -53,12 +53,13 @@
 # ~~~~~~~~~~~~ START NETWORK SPECIFIC SECTION ~~~~~~~~~~~~~~~~~~~~~~~~~
 #> The following environment variables will change depending on what 
 #> observation network is being matched with CMAQ output.
+#> This sample run script is set up for hourly data from CASTNET.
 #> See the README.md file in this folder for the settings to use for 
 #> the following networks: IMPROVE, CASTNET, CSN (formally STN), NADP
 #> SEARCH, AIRMON
 
 #> Set TABLE TYPE
- setenv TABLE_TYPE CASTNET
+  setenv TABLE_TYPE MET
 
 #> Specify the variable names used in your observation inputs
 #> and model output files for each of the species you are analyzing below.
@@ -68,56 +69,12 @@
 #>
 #> The expression is in the form:
 #>       [factor1]*Obs_name1 [+][-] [factor2]*Obs_name2 ...
-  setenv AERO_1 "SO4,ug/m3, ASO4IJ,,SO4"                     		     # sulfate
-  setenv AERO_2 "NO3,ug/m3, ANO3IJ,,NO3"                     		     # nitrate
-  setenv AERO_3 "NH4,ug/m3, ANH4IJ,,NH4"                     		     # ammonium
-  setenv AERO_4 "PM25,ug/m3,ATOTIJ,,PM_TOT"        # PM2.5 (88101 and 88502)
-  setenv AERO_5 "PM25_88101,ug/m3,ATOTIJ,,PM_TOT_88101"  	     # PM2.5 (88101 only)
-  setenv AERO_6 "PM25_88502,ug/m3,ATOTIJ,,PM_TOT_88502"	     # PM2.5 (88502 only)
-  setenv AERO_7 "PM10_81102,ug/m3,ATOTIJ+ATOTK,,PM10_IJK"         # PM10 (81102 vs ATOTIJK)
-  setenv AERO_8 "OC,ug/m3, AOCIJ,,OC"      				     # Organic Carbon (best available)
-  setenv AERO_9 "EC,ug/m3, AECIJ,,EC"                        		     # Elemental Carbon (best available)
-  setenv AERO_10 "OC+EC,ug/m3,AOCIJ+AECIJ,,TC"     			     # Total Carbon (best available)
-  setenv AERO_11 "OC_88305,ug/m3, AOCIJ,,OC_88305"                          # Organic Carbon (88305 raw)
-  setenv AERO_12 "OC_88305_adj,ug/m3,AOCIJ,,OC_88305_adj"                  # Organic Carbon (88305 adjusted)
-  setenv AERO_13 "OC_88370,ug/m3, AOCIJ,,OC_88370"                         # Organic Carbon (88370 raw)
-  setenv AERO_14 "OC_88370_adj,ug/m3,AOCIJ,,OC_88370_adj"                  # Organic Carbon (88370 adjusted)
-  setenv AERO_15 "OC_88320,ug/m3,AOCIJ,,OC_88320"                          # Organic Carbon (88320)
-  setenv AERO_16 "EC_88307,ug/m3, AECIJ,,EC_88307"                         # Elemental Carbon (88307 raw)
-  setenv AERO_17 "EC_88307_adj,ug/m3,AECIJ,,EC_88307_adj"                  # Elemental Carbon (88307 adjusted)
-  setenv AERO_18 "EC_88380,ug/m3, AECIJ,,EC_88380"                         # Elemental Carbon (88380)
-  setenv AERO_19 "EC_88321,ug/m3,AECIJ,,EC_88321"                          # Elemental Carbon (88321)
-     
- #> PM2.5 Sharp Cutoff Species
- #> Requires preprocessing using setenv CCTM_AELMO file
-  setenv AERO_20 "SO4,ug/m3, PM25_SO4,,PM25_SO4"                   	     # sulfate (sharp cutoff)
-  setenv AERO_21 "NO3,ug/m3, PM25_NO3,,PM25_NO3"                  	     # nitrate (sharp cutoff)
-  setenv AERO_22 "NH4,ug/m3, PM25_NH4,,PM25_NH4"                  	     # ammonium (sharp cutoff)
-  setenv AERO_23 "OC,ug/m3, PM25_OC,,PM25_OC"                    	     # Organic Carbon (sharp cutoff)
-  setenv AERO_24 "EC,ug/m3, PM25_EC,,PM25_EC"                 # Elemental Carbon (sharp cutoff)
-  setenv AERO_25 "OC+EC,ug/m3,PM25_OC+PM25_EC,,PM25_TC"       # Total Carbon (sharp cutoff)
-  setenv AERO_26 "PM25,ug/m3,PM25_TOT,ug/m3,PM25_TOT"       # Total PM2.5 (sharp cutoff)
-  setenv AERO_27 "PM10_81102,ug/m3,PM10,ug/m3,PM10"      # PM10 (sharp cutoff)
-
-#> setenv AERO6 species
-#> note we use Sodium Ion instead of sodium (XRF) becasue XRF is not reliable for sodium
-#> all other elemental concentrations (including Cl and K) come from XRF
-  setenv AERO_28 "Na,ug/m3, ANAIJ,,Na"        # sodium
-  setenv AERO_29 "Cl,ug/m3, ACLIJ,,Cl"        # chlorine
-  setenv AERO_30 "Fe,ug/m3, AFEJ,,Fe"         # iron
-  setenv AERO_31 "Al,ug/m3,AALJ,,Al"          # aluminum
-  setenv AERO_32 "Si,ug/m3, ASIJ,,Si"         # silicon
-  setenv AERO_33 "Ti,ug/m3, ATIJ,,Ti"         # titanium
-  setenv AERO_34 "Ca,ug/m3,ACAJ,,Ca"          # calcium
-  setenv AERO_35 "Mg,ug/m3,AMGJ,,Mg"          # magnesium
-  setenv AERO_36 "K,ug/m3,AKJ,,K"             # potassium
-  setenv AERO_37 "Mn,ug/m3,AMNJ,,Mn"          # manganese
-  setenv AERO_38 "2.2*Al+2.49*Si+1.63*Ca+2.42*Fe+1.94*Ti,ug/m3,ASOILJ,,soil" # SOIL_OLD
-  setenv AERO_39 "Na + Cl, ug/m3, ANAIJ+ACLIJ,,NaCl"                                   # NaCl
-  setenv AERO_40 "PM25-SO4-NO3-NH4-OC-EC-[Na]-[Cl]-2.2*Al-2.49*Si-1.63*Ca-2.42*Fe-1.94*Ti , ug/m3, AUNSPEC1IJ,,OTHER"        # PM Other
-  setenv AERO_41 "0.8*OC,ug/m3, ANCOMIJ,,NCOM"    # PM Other
-  setenv AERO_42 "PM25-SO4-NO3-NH4-OC-EC-[Na]-[Cl]-2.2*Al-2.49*Si-1.63*Ca-2.42*Fe-1.94*Ti-0.8*OC,ug/m3, AUNSPEC2IJ,,OTHER_REM"    # PM Other no NCOM
-  
+  setenv GAS_1 "ozone,ppb,O3,ppb,O3"				 # ozone
+  setenv GAS_2 "temperature,C,SFC_TMP,C,SFC_TMP"			 # 2 meter temperature
+  setenv GAS_3 "relative_humidity,%,RH,%,RH"			 # Relative Humidity
+  setenv GAS_4 "solar_radiation,watts/m2,SOL_RAD,watts/m2,Solar_Rad" # Solar Radiation
+  setenv GAS_5 "precipitation,mm/hr,precip,mm/hr,precip"		 # Precipitation
+  setenv GAS_6 "windspeed,m/s,WSPD10,m/s,WSPD10"			 # Wind Speed
 #>> End Species List <<#
 
 # ~~~~~~~~~~~~ END NETWORK SPECIFIC SECTION ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -150,7 +107,8 @@
  setenv TIME_SHIFT 0
 
 #> indicate whether or not to check QA flag (default Y)
- setenv QA_FLAG_CHECK N 
+ setenv QA_FLAG_CHECK Y 
+ setenv QA_FLAG_VALUES "#BCDFHIJKLMNPRTY" 
 
 #############################################################
 #  Input files
@@ -168,24 +126,25 @@
 #> gmt_offset, state, county, and elevation (case insensitive)
 #> See the README.md file in this folder for the information on 
 #> where to download this file.
- setenv SITE_FILE AQS_full_site_list.csv
+ setenv SITE_FILE CASTNET_full_site_list.csv
 #> On EPA system:
-#  setenv SITE_FILE /work/MOD3EVAL/aq_obs/routine/site_metadata_files/AQS_full_site_list.csv
+#  setenv SITE_FILE /work/MOD3EVAL/aq_obs/routine/site_metadata_files/CASTNET_full_site_list.csv
 
 #> input table containing site-id, time-period, and data fields
-#> AQS obs data in the format needed for sitecmp are available online.
+#> CASTNET obs data in the format needed for sitecmp are available online.
 #> See the README.md file in this folder for the information on 
 #> where to download this file.
- setenv IN_TABLE AQS_CSN_data_2016.csv
+ setenv IN_TABLE CASTNET_hourly_data_2016.csv
 #> One EPA system:
-#  setenv IN_TABLE /work/MOD3EVAL/aq_obs/routine/2016/AQS_CSN_data_2016.csv
+#  setenv IN_TABLE /work/MOD3EVAL/aq_obs/routine/2016/CASTNET_hourly_data_2016.csv
+
 
 #############################################################
 #  Output files
 #############################################################
 
 #> output table (comma delimited text file importable to Excel)
- setenv OUT_TABLE ${POSTDIR}/CSN_CMAQ_${RUNID}_201607.csv
+ setenv OUT_TABLE ${POSTDIR}/CASTNET_Hourly_CMAQ_${RUNID}_201607.csv
 
 #> Executable call:
  ${BINDIR}/${EXEC}

--- a/POST/sitecmp/scripts/run_sitecmp_IMPROVE.csh
+++ b/POST/sitecmp/scripts/run_sitecmp_IMPROVE.csh
@@ -22,7 +22,7 @@
 #> Set General Parameters for Configuring the Simulation
  set VRSN      = v55               #> Code Version
  set PROC      = mpi               #> serial or mpi
- set MECH      = cb6r3_ae7_aq      #> Mechanism ID
+ set MECH      = cb6r5_ae7_aq      #> Mechanism ID
  set APPL      = Bench_2016_12SE1        #> Application Name (e.g. Gridname)
                                                       
 #> Define RUNID as any combination of parameters above or others. By default,
@@ -68,46 +68,47 @@
 #>
 #> The expression is in the form:
 #>       [factor1]*Obs_name1 [+][-] [factor2]*Obs_name2 ...
- setenv AERO_1 "SO4f_val,ug/m3,ASO4IJ,,SO4"                         # sulfate
- setenv AERO_2 "NO3f_val,ug/m3,ANO3IJ,,NO3"                         # nitrate
- setenv AERO_3 "0.2903*NO3f_val+0.375*SO4f_val,ug/m3,ANH4IJ,,NH4"   # ammonium (estimated assuming fully neutralized SO4 and NO3)
- setenv AERO_4 "MF_val,ug/m3,ATOTIJ,ug/m3,PM_TOT"          # Total PM2.5 mass 
- setenv AERO_5 "OCf_val,ug/m3,AOCIJ,,OC"                            # Organic Carbon
- setenv AERO_6 "ECf_val,ug/m3,AECIJ,,EC"                            # Elemental Carbon
- setenv AERO_7 "OCf_val+ECf_val,ug/m3,AOCIJ+AECIJ,,TC"              # Total Carbon
- setenv AERO_8 "CHLf_val,ug/m3,ACLIJ,ug/m3,Cl"                      # CL Ion
- setenv AERO_9 "MT_val,ug/m3,ATOTIJK,ug/m3,PM10"              # PM10
- setenv AERO_10 "CM_calculated_val,ug/m3,ATOTK,ug/m3,PMC_TOT"     # PM Course
+  setenv AERO_1 "SO4f_val,ug/m3,ASO4IJ,,SO4"                         # sulfate
+  setenv AERO_2 "NO3f_val,ug/m3,ANO3IJ,,NO3"                         # nitrate
+  setenv AERO_3 "0.2903*NO3f_val+0.375*SO4f_val,ug/m3,ANH4IJ,,NH4"   # ammonium (estimated assuming fully neutralized SO4 and NO3)
+  setenv AERO_4 "MF_val,ug/m3,ATOTIJ,ug/m3,PM_TOT"          # Total PM2.5 mass 
+  setenv AERO_5 "OCf_val,ug/m3,AOCIJ,,OC"                            # Organic Carbon
+  setenv AERO_6 "ECf_val,ug/m3,AECIJ,,EC"                            # Elemental Carbon
+  setenv AERO_7 "OCf_val+ECf_val,ug/m3,AOCIJ+AECIJ,,TC"              # Total Carbon
+  setenv AERO_8 "CHLf_val,ug/m3,ACLIJ,ug/m3,Cl"                      # CL Ion
+  setenv AERO_9 "MT_val,ug/m3,ATOTIJ+ATOTK,ug/m3,PM10_IJK"  # PM10 (sum of the IJK modes)
+  setenv AERO_10 "CM_calculated_val,ug/m3,ATOTK,ug/m3,PMC_TOT"       # PM Course
 
 #> PM2.5 Sharp Cutoff Species
 #> Requires preprocessing using setenv CCTM_AELMO file
- setenv AERO_11 "SO4f_val,ug/m3,PM25_SO4,,PM25_SO4"                 	# sulfate (< 2.5um)
- setenv AERO_12 "NO3f_val,ug/m3,PM25_NO3,,PM25_NO3"                 	# nitrate (< 2.5um)
- setenv AERO_13 "0.2903*NO3f_val+0.375*SO4f_val,ug/m3,PM25_NH4,,PM25_NH4"	# ammonium (< 2.5um)
- setenv AERO_14 "OCf_val,ug/m3,PM25_OC,,PM25_OC"                    	# Organic Carbon (< 2.5um)
- setenv AERO_15 "ECf_val,ug/m3,PM25_EC,,PM25_EC"                    	# Elemental Carbon (< 2.5um)
- setenv AERO_16 "OCf_val+ECf_val,ug/m3,PM25_OC+PM25_EC,,PM25_TC"    	# Total Carbon (< 2.5um)
- setenv AERO_17 "MF_val,ug/m3,PM25_TOT,ug/m3,PM25_TOT"              	# Total PM2.5 mass (< 2.5um)
- setenv AERO_18 "CHLf_val,ug/m3,PM25_CL,ug/m3,PM25_Cl"              	# CL Ion (< 2.5um)
- setenv AERO_19  "CM_calculated_val,ug/m3,PMC_TOT,ug/m3,PMC_TOT_CUT" # PM Course
+  setenv AERO_11 "SO4f_val,ug/m3,PM25_SO4,,PM25_SO4"                 	# sulfate (< 2.5um)
+  setenv AERO_12 "NO3f_val,ug/m3,PM25_NO3,,PM25_NO3"                 	# nitrate (< 2.5um)
+  setenv AERO_13 "0.2903*NO3f_val+0.375*SO4f_val,ug/m3,PM25_NH4,,PM25_NH4"	# ammonium (< 2.5um)
+  setenv AERO_14 "OCf_val,ug/m3,PM25_OC,,PM25_OC"                    	# Organic Carbon (< 2.5um)
+  setenv AERO_15 "ECf_val,ug/m3,PM25_EC,,PM25_EC"                    	# Elemental Carbon (< 2.5um)
+  setenv AERO_16 "OCf_val+ECf_val,ug/m3,PM25_OC+PM25_EC,,PM25_TC"    	# Total Carbon (< 2.5um)
+  setenv AERO_17 "MF_val,ug/m3,PM25_TOT,ug/m3,PM25_TOT"              	# Total PM2.5 mass (< 2.5um)
+  setenv AERO_18 "MT_val,ug/m3,PM10,ug/m3,PM10"  # PM10 (sharp cut at 10 microns)
+  setenv AERO_19 "CHLf_val,ug/m3,PM25_CL,ug/m3,PM25_Cl"              	# CL Ion (< 2.5um)
+  setenv AERO_20  "CM_calculated_val,ug/m3,PMC_TOT,ug/m3,PMC_TOT_CUT" # PM Course
 
 #> new AE6 species
 #> note: we use XRF sodium because there is not IC sodium mesaurement
 #> we use IC measurement for chlorid (CHLf_val) instead of XRF chlroine (CLf_Val)
- setenv AERO_20 "NAf_val,ug/m3, ANAIJ,,Na"                          # sodium
- setenv AERO_21 "NAf_val + CHLf_val,ug/m3,ACLIJ + ANAIJ,,NaCl"      # sodium chloride
- setenv AERO_22 "FEf_val,ug/m3, AFEJ,,Fe"                           # iron
- setenv AERO_23 "ALf_val,ug/m3,AALJ,,Al"                            # aluminum 
- setenv AERO_24 "SIf_val,ug/m3, ASIJ,,Si"                           # silicon
- setenv AERO_25 "TIf_val,ug/m3, ATIJ,,Ti"                           # titanium
- setenv AERO_26 "CAf_val,ug/m3,ACAJ,,Ca"                            # calcium
- setenv AERO_27 "MGf_val,ug/m3,AMGJ,,Mg"                            # magnesium
- setenv AERO_28 "Kf_val,ug/m3,AKJ,,K"                               # potassium
- setenv AERO_29 "MNf_val,ug/m3,AMNJ,,Mn"                            # manganese
- setenv AERO_30 "2.20*ALf_val+2.49*SIf_val+1.63*CAf_val+2.42*FEf_val+1.94*TIf_val,ug/m3,ASOILJ,,soil"       # IMPROVE soil eqn.
- setenv AERO_31 "MF_val-SO4f_val-NO3f_val-0.2903*NO3f_val-0.375*SO4f_val-OCf_val-ECf_val-NAf_val-CHLf_val-2.2*ALf_val-2.49*SIf_val-1.63*CAf_val-2.42*FEf_val-1.94*TIf_val,ug/m3,AUNSPEC1IJ,,OTHER"        # PM Other
- setenv AERO_32 "0.8*OCf_val,ug/m3, ANCOMIJ,,NCOM"    # NCOM
- setenv AERO_33 "MF_val-SO4f_val-NO3f_val-0.2903*NO3f_val-0.375*SO4f_val-OCf_val-ECf_val-NAf_val-CHLf_val-2.2*ALf_val-2.49*SIf_val-1.63*CAf_val-2.42*FEf_val-1.94*TIf_val,ug/m3, AUNSPEC2IJ,,OTHER_REM"    # PM Other remaining
+  setenv AERO_21 "NAf_val,ug/m3, ANAIJ,,Na"                          # sodium
+  setenv AERO_22 "NAf_val + CHLf_val,ug/m3,ACLIJ + ANAIJ,,NaCl"      # sodium chloride
+  setenv AERO_23 "FEf_val,ug/m3, AFEJ,,Fe"                           # iron
+  setenv AERO_24 "ALf_val,ug/m3,AALJ,,Al"                            # aluminum 
+  setenv AERO_25 "SIf_val,ug/m3, ASIJ,,Si"                           # silicon
+  setenv AERO_26 "TIf_val,ug/m3, ATIJ,,Ti"                           # titanium
+  setenv AERO_27 "CAf_val,ug/m3,ACAJ,,Ca"                            # calcium
+  setenv AERO_28 "MGf_val,ug/m3,AMGJ,,Mg"                            # magnesium
+  setenv AERO_29 "Kf_val,ug/m3,AKJ,,K"                               # potassium
+  setenv AERO_30 "MNf_val,ug/m3,AMNJ,,Mn"                            # manganese
+  setenv AERO_31 "2.20*ALf_val+2.49*SIf_val+1.63*CAf_val+2.42*FEf_val+1.94*TIf_val,ug/m3,ASOILJ,,soil"       # IMPROVE soil eqn.
+  setenv AERO_32 "MF_val-SO4f_val-NO3f_val-0.2903*NO3f_val-0.375*SO4f_val-OCf_val-ECf_val-NAf_val-CHLf_val-2.2*ALf_val-2.49*SIf_val-1.63*CAf_val-2.42*FEf_val-1.94*TIf_val,ug/m3,AUNSPEC1IJ,,OTHER"        # PM Other
+  setenv AERO_33 "0.8*OCf_val,ug/m3, ANCOMIJ,,NCOM"    # NCOM
+  setenv AERO_34 "MF_val-SO4f_val-NO3f_val-0.2903*NO3f_val-0.375*SO4f_val-OCf_val-ECf_val-NAf_val-CHLf_val-2.2*ALf_val-2.49*SIf_val-1.63*CAf_val-2.42*FEf_val-1.94*TIf_val,ug/m3, AUNSPEC2IJ,,OTHER_REM"    # PM Other remaining
  
 #>> End Species List <<#
 
@@ -140,13 +141,16 @@
 #> This should only be non-zero if the M3_FILE_n files were pre-processed with a utility like m3tshift (default 0).
  setenv TIME_SHIFT 0
 
+#> indicate whether or not to check QA flag (default Y)
+ setenv QA_FLAG_CHECK N 
+
 #############################################################
 #  Input files
 #############################################################
 
 #> ioapi input files containing VNAMES (max of 10)
- setenv M3_FILE_1 ${CMAQ_DATA}/POST/COMBINE_ACONC_${RUNID}_201607.nc
-         #[Add location of input file, e.g. COMBINE_ACONC file.]
+ setenv M3_FILE_1 ${CMAQ_DATA}/POST/COMBINE_AELMO_${RUNID}_201607.nc
+         #[Add location of input file, e.g. COMBINE_AELMO file.]
 
 #> SITE FILE containing site-id, longitude, latitude, and optionally 
 #> GMT offset, state, county, and elevation (csv format)

--- a/POST/sitecmp/scripts/run_sitecmp_NADP.csh
+++ b/POST/sitecmp/scripts/run_sitecmp_NADP.csh
@@ -22,7 +22,7 @@
 #> Set General Parameters for Configuring the Simulation
  set VRSN      = v55               #> Code Version
  set PROC      = mpi               #> serial or mpi
- set MECH      = cb6r3_ae7_aq      #> Mechanism ID
+ set MECH      = cb6r5_ae7_aq      #> Mechanism ID
  set APPL      = Bench_2016_12SE1        #> Application Name (e.g. Gridname)
                                                       
 #> Define RUNID as any combination of parameters above or others. By default,
@@ -140,6 +140,9 @@
 #> Number of hours to add when retrieving time steps from M3_FILE_n files during processing.
 #> This should only be non-zero if the M3_FILE_n files were pre-processed with a utility like m3tshift (default 0).
  setenv TIME_SHIFT 0
+
+#> indicate whether or not to check QA flag (default Y)
+ setenv QA_FLAG_CHECK N 
 
 #############################################################
 #  Input files

--- a/POST/sitecmp/scripts/run_sitecmp_SEARCH_Hourly.csh
+++ b/POST/sitecmp/scripts/run_sitecmp_SEARCH_Hourly.csh
@@ -22,7 +22,7 @@
 #> Set General Parameters for Configuring the Simulation
  set VRSN      = v55               #> Code Version
  set PROC      = mpi               #> serial or mpi
- set MECH      = cb6r3_ae7_aq      #> Mechanism ID
+ set MECH      = cb6r5_ae7_aq      #> Mechanism ID
  set APPL      = Bench_2016_12SE1        #> Application Name (e.g. Gridname)
                                                       
 #> Define RUNID as any combination of parameters above or others. By default,
@@ -68,7 +68,7 @@
 #>
 #> The expression is in the form:
 #>       [factor1]*Obs_name1 [+][-] [factor2]*Obs_name2 ...
-  setenv AERO_1 "Average O3[ppb],ppb,O3,,O3"                               
+  setenv AERO_1 "Average O3[ppb],ppb,O3,,O3"                       
   setenv AERO_2 "Average CO[ppb],ppb,CO,,CO"                               
   setenv AERO_3 "Average SO2[ppb],ppb,SO2,,SO2"                            
   setenv AERO_4 "Average NO[ppb],ppb,NO,,NO"                               
@@ -121,13 +121,17 @@
 #> This should only be non-zero if the M3_FILE_n files were pre-processed with a utility like m3tshift (default 0).
  setenv TIME_SHIFT 0
 
+#> indicate whether or not to check QA flag (default Y)
+ setenv QA_FLAG_CHECK Y 
+ setenv QA_FLAG_VALUES "#BCDFHIJKLMNPRTY" 
+
 #############################################################
 #  Input files
 #############################################################
 
 #> ioapi input files containing VNAMES (max of 10)
- setenv M3_FILE_1 ${CMAQ_DATA}/POST/COMBINE_ACONC_${RUNID}_201607.nc
-         #[Add location of input file, e.g. COMBINE_ACONC file.]
+ setenv M3_FILE_1 ${CMAQ_DATA}/POST/COMBINE_AELMO_${RUNID}_201607.nc
+         #[Add location of input file, e.g. COMBINE_AELMO file.]
 
 #> SITE FILE containing site-id, longitude, latitude, and optionally 
 #> GMT offset, state, county, and elevation (csv format)

--- a/POST/sitecmp/src/module_envvar.F
+++ b/POST/sitecmp/src/module_envvar.F
@@ -30,13 +30,15 @@ C
 C*************************************************************************
       MODULE ENV_VARS
 
-      CHARACTER*256  SITE_FILE       ! Site info file
+      INTEGER, PARAMETER :: MAXLEN = 1000
 
-      CHARACTER*16   TABLE_TYPE      ! Table type on input (IMPROVE, CASTNET, MDN, NADP, STN)
+      CHARACTER(MAXLEN) SITE_FILE    ! Site info file
 
-      CHARACTER*256  IN_TABLE        ! Input table of actual values  
+      CHARACTER*16      TABLE_TYPE   ! Table type on input (IMPROVE, CASTNET, MDN, NADP, STN)
 
-      CHARACTER*256  OUT_TABLE       ! Output table containing both actual and modeled values 
+      CHARACTER(MAXLEN) IN_TABLE     ! Input table of actual values  
+
+      CHARACTER(MAXLEN) OUT_TABLE    ! Output table containing both actual and modeled values 
 
       INTEGER        START_DATE      ! starting date of period to process
       INTEGER        START_TIME      ! starting time of period to process
@@ -49,6 +51,10 @@ C*************************************************************************
       CHARACTER*16   PRECIP_FIELD    ! name of precip species in wet concentration calculations
 
       CHARACTER*10   MISSING_VALUE   ! indicates missing value in output
+
+      CHARACTER*16   QA_FLAG_STRING  ! string of QA flags indicating invalid obs
+
+      LOGICAL        QAFLAG_CHECK    ! does the observation file include a QA flag?      
 
       CONTAINS
 
@@ -77,6 +83,8 @@ C..SCRATCH LOCAL VARIABLES:
          CHARACTER*256   RET_VAL          ! Returned value of env var
          CHARACTER*16    ENV_DFLT         ! default env value 
          CHARACTER*16    ENV_DESC         ! message string
+         CHARACTER*16    QA_FLAG_CHECK    ! Indicate whether QA flags should be checked
+         CHARACTER*16    QA_FLAG_VALUES   ! string of QA flags indicating invalid obs
          INTEGER   STATUS                 ! Status code
          LOGICAL   LERROR                 ! Error flag
 
@@ -90,6 +98,8 @@ C**********************************************************************
          DATA  OUTTABLE        / 'OUT_TABLE'       /  
          DATA  APPLY_DLS       / 'APPLY_DLS'       /  
          DATA  MISSING         / 'MISSING'         /  
+         DATA  QA_FLAG_VALUES  / 'QA_FLAG_VALUES'  /  
+         DATA  QA_FLAG_CHECK   / 'QA_FLAG_CHECK'   /  
 
          LERROR = .FALSE.
    
@@ -206,6 +216,30 @@ c  Get the Character string to use for missing values
 cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc    
          ENV_DESC = 'String to indicate missing values'        
          CALL ENVSTR( MISSING, ENV_DESC, '-999', MISSING_VALUE, STATUS)
+
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+c  Get the flag to see if a QA field is present in obs file (default is true)
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc    
+         ENV_DESC = 'Flag to indicate whether QA flag field is present'        
+         QAFLAG_CHECK = ENVYN( QA_FLAG_CHECK, ENV_DESC, .TRUE., STATUS)
+
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+c  Get the Character strings for the QA flag header and QA flag strings
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc    
+         IF (QAFLAG_CHECK) THEN
+         
+          ENV_DFLT = '#BCDFHIJKLMNPRTY'
+          ENV_DESC = 'String containing the QA flag values to indicate bad data'        
+          CALL ENVSTR( QA_FLAG_VALUES, ENV_DESC, ENV_DFLT, QA_FLAG_STRING, STATUS)
+
+          IF( STATUS .NE. 0 ) THEN
+            MSG = 'WARNING: no value assigned to '//QA_FLAG_VALUES
+            CALL M3MESG( MSG )
+            MSG = 'USING DEFAULT '//ENV_DFLT
+            CALL M3MESG( MSG )
+          ENDIF
+
+         ENDIF
 
 cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 c  Stop if errors detected

--- a/POST/sitecmp/src/module_spec.F
+++ b/POST/sitecmp/src/module_spec.F
@@ -35,16 +35,16 @@ C*************************************************************************
          CHARACTER(len=512) OBS_EXPRESSION
          CHARACTER(len=16) OBS_UNITS
          INTEGER           OBS_NUMSPEC
-         CHARACTER(len=36) OBS_NAME(20)
-         REAL              OBS_FACTOR(20)
-         INTEGER           OBS_FIELD(20)
-         LOGICAL           OBS_OPTNAL(20)
+         CHARACTER(len=36) OBS_NAME(50)
+         REAL              OBS_FACTOR(50)
+         INTEGER           OBS_FIELD(50)
+         LOGICAL           OBS_OPTNAL(50)
 
          CHARACTER(len=512) MOD_EXPRESSION
          CHARACTER(len=16) MOD_UNITS
          INTEGER           MOD_NUMSPEC
-         CHARACTER(len=36) MOD_NAME(20)
-         REAL              MOD_FACTOR(20)
+         CHARACTER(len=36) MOD_NAME(50)
+         REAL              MOD_FACTOR(50)
 
          CHARACTER(len=2)  OP_CODE
 

--- a/POST/sitecmp/src/process.F
+++ b/POST/sitecmp/src/process.F
@@ -853,7 +853,8 @@ C  routine to read and compute observed values from input record
 C****************************************************************************
       Subroutine getObsField(record, delimiter, TABLE_TYPE, VAR, resultValue)
 
-      USE SPECIES_DEF 
+      USE SPECIES_DEF
+      USE ENV_VARS, ONLY: QAFLAG_CHECK, QA_FLAG_STRING 
 
       ! arguments
       Character*(*) record
@@ -876,19 +877,26 @@ C****************************************************************************
         Call getField(record, delimiter, VAR%OBS_FIELD(n), field)
         Call rmQuots( field )
 
-        ! check for a code flag field following data field 
-        if(TABLE_TYPE .eq. 'CASTNET' .or. TABLE_TYPE .eq. 'SEARCH') then
-          Call getField(record, delimiter, VAR%OBS_FIELD(n)+1, flag)
-          Call rmQuots( flag )
-          if( INDEX('#IJKLMNBCDFP', flag(1:1)) .gt. 0 ) field = ' '
-          endif
+        ! perform a QA flag check if requested 
+        if(QAFLAG_CHECK) then
 
-        ! check for a code flag field following data field
-        if(TABLE_TYPE .eq. 'MET') then
-          Call getField(record, delimiter, VAR%OBS_FIELD(n)+1, flag)
-          Call rmQuots( flag )
-          if( LEN_TRIM(flag).eq.1 .and. INDEX('BCDFIMP',flag(1:1)).gt.0 ) field = ' '
-          endif
+         ! check for a code flag field following data field for
+         ! CASTNET or SEARCH table types
+         if(TABLE_TYPE .eq. 'CASTNET' .or. TABLE_TYPE .eq. 'SEARCH') then
+           Call getField(record, delimiter, VAR%OBS_FIELD(n)+1, flag)
+           Call rmQuots( flag )
+           if( INDEX(QA_FLAG_STRING, flag(1:1)) .gt. 0 ) field = ' '
+           endif
+
+         ! check for a code flag field following data field for
+         ! MET table type
+         if(TABLE_TYPE .eq. 'MET') then
+           Call getField(record, delimiter, VAR%OBS_FIELD(n)+1, flag)
+           Call rmQuots( flag )
+           if( LEN_TRIM(flag).eq.1 .and. INDEX(QA_FLAG_STRING,flag(1:1)).gt.0 ) field = ' '
+           endif
+
+        endif
 
         !  read fieldValue and check if missing
         read(field,'(g16.0)',iostat=status) fieldValue

--- a/POST/sitecmp_dailyo3/README.md
+++ b/POST/sitecmp_dailyo3/README.md
@@ -57,7 +57,7 @@ This Fortran program generates a csv (comma separated values) file that compares
  QA_FLAG_HEADER if QA_FLAG_CHECK is Y, name of the ozone QA flag in the header line of IN_TABLE 
                 (default "OZONE_F" to correspond to CASTNET data)
  QA_FLAG_VALUES if QA_FLAG_CHECK is Y, string composed of single-character QA flags that 
-                should be treated as missing values (default "BCDFIMP" to correspond to CASTNET data)
+                should be treated as missing values (default "#BCDFHIJKLMNPRTY" to capture known CASTNET flags)
  MISSING        string to indicate missing output data values (default "m")
  IOAPI_ISPH     projection sphere type (use type #20 to match WRF/CMAQ)(IOAPI default 8)
  LAMBXY         include x/y projection values for each site in OUT_TABLE (default N)

--- a/POST/sitecmp_dailyo3/scripts/run_sitecmp_dailyo3_AQS.csh
+++ b/POST/sitecmp_dailyo3/scripts/run_sitecmp_dailyo3_AQS.csh
@@ -22,7 +22,7 @@
 #> Set General Parameters for Configuring the Simulation
  set VRSN      = v55               #> Code Version
  set PROC      = mpi               #> serial or mpi
- set MECH      = cb6r3_ae7_aq      #> Mechanism ID
+ set MECH      = cb6r5_ae7_aq      #> Mechanism ID
  set APPL      = Bench_2016_12SE1        #> Application Name (e.g. Gridname)
                                                       
 #> Define RUNID as any combination of parameters above or others. By default,
@@ -105,8 +105,8 @@
 #############################################################
 
 #> ioapi input files containing VNAMES (max of 10)
- setenv M3_FILE_1 ${CMAQ_DATA}/POST/COMBINE_ACONC_${RUNID}_201607.nc
-        #[Add location of input file, e.g. COMBINE_ACONC file.]
+ setenv M3_FILE_1 ${CMAQ_DATA}/POST/COMBINE_AELMO_${RUNID}_201607.nc
+        #[Add location of input file, e.g. COMBINE_AELMO file.]
 
 #> SITE FILE containing site-id, longitude, latitude, and optionally 
 #> GMT offset, state, county, and elevation (csv format)

--- a/POST/sitecmp_dailyo3/scripts/run_sitecmp_dailyo3_CASTNET.csh
+++ b/POST/sitecmp_dailyo3/scripts/run_sitecmp_dailyo3_CASTNET.csh
@@ -22,7 +22,7 @@
 #> Set General Parameters for Configuring the Simulation
  set VRSN      = v55               #> Code Version
  set PROC      = mpi               #> serial or mpi
- set MECH      = cb6r3_ae7_aq      #> Mechanism ID
+ set MECH      = cb6r5_ae7_aq      #> Mechanism ID
  set APPL      = Bench_2016_12SE1        #> Application Name (e.g. Gridname)
                                                       
 #> Define RUNID as any combination of parameters above or others. By default,
@@ -93,7 +93,7 @@
 #> indicate whether or not to check QA flag
  setenv QA_FLAG_CHECK Y 
  setenv QA_FLAG_HEADER "OZONE_F" 
- setenv QA_FLAG_VALUES "BCDFIMP" 
+ setenv QA_FLAG_VALUES "#BCDFHIJKLMNPRTY" 
 
 #> set missing value string
  setenv MISSING '-999'
@@ -107,8 +107,8 @@
 #############################################################
 
 #> ioapi input files containing VNAMES (max of 10)
- setenv M3_FILE_1 ${CMAQ_DATA}/POST/COMBINE_ACONC_${RUNID}_201607.nc
-        #[Add location of input file, e.g. COMBINE_ACONC file.]
+ setenv M3_FILE_1 ${CMAQ_DATA}/POST/COMBINE_AELMO_${RUNID}_201607.nc
+        #[Add location of input file, e.g. COMBINE_AELMO file.]
 
 #> SITE FILE containing site-id, longitude, latitude, and optionally 
 #> GMT offset, state, county, and elevation (csv format)

--- a/POST/sitecmp_dailyo3/src/module_envvar.F
+++ b/POST/sitecmp_dailyo3/src/module_envvar.F
@@ -30,10 +30,12 @@ C  REVISION HISTORY: Prototype created by Jerry Gipson, July, 1999
 C                   
 C*************************************************************************
 
-      CHARACTER*256  IN_TABLE        ! Input table of actual values  
+      INTEGER, PARAMETER :: MAXLEN = 1000
 
-      CHARACTER*256  OUT_TABLE       ! Output table containing both actual and modeled values 
-      CHARACTER*256  AVG_TABLE       ! Output table containing averages over time period
+      CHARACTER(MAXLEN) IN_TABLE     ! Input table of actual values  
+
+      CHARACTER(MAXLEN) OUT_TABLE    ! Output table containing both actual and modeled values 
+      CHARACTER(MAXLEN) AVG_TABLE    ! Output table containing averages over time period
 
       INTEGER        START_DATE      ! starting date of period to process
       INTEGER        START_TIME      ! starting time of period to process
@@ -284,7 +286,7 @@ cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
             CALL M3MESG( MSG )
           ENDIF
 
-          ENV_DFLT = 'BCDFIMP'
+          ENV_DFLT = '#BCDFHIJKLMNPRTY'
           ENV_DESC = 'String containing the QA flag values to indicate bad data'        
           CALL ENVSTR( QA_FLAG_VALUES, ENV_DESC, ENV_DFLT, QA_FLAG_STRING, STATUS)
 

--- a/bldit_project.csh
+++ b/bldit_project.csh
@@ -235,7 +235,13 @@
        mkdir -pv $CMAQ_HOME/POST/sitecmp/scripts
     endif
     cp POST/sitecmp/scripts/bldit_sitecmp.csh  $CMAQ_HOME/POST/sitecmp/scripts/
+    cp POST/sitecmp/scripts/run_sitecmp_AQS_Daily.csh    $CMAQ_HOME/POST/sitecmp/scripts/
     cp POST/sitecmp/scripts/run_sitecmp_AQS_Hourly.csh    $CMAQ_HOME/POST/sitecmp/scripts/
+    cp POST/sitecmp/scripts/run_sitecmp_CASTNET_Hourly.csh    $CMAQ_HOME/POST/sitecmp/scripts/
+    cp POST/sitecmp/scripts/run_sitecmp_CSN.csh    $CMAQ_HOME/POST/sitecmp/scripts/
+    cp POST/sitecmp/scripts/run_sitecmp_IMPROVE.csh    $CMAQ_HOME/POST/sitecmp/scripts/
+    cp POST/sitecmp/scripts/run_sitecmp_NADP.csh    $CMAQ_HOME/POST/sitecmp/scripts/
+    cp POST/sitecmp/scripts/run_sitecmp_SEARCH_Hourly.csh    $CMAQ_HOME/POST/sitecmp/scripts/
  endif
 
 #===============================================================================


### PR DESCRIPTION
**Contact:**  
[Christian Hogrefe](mailto:hogrefe.christian@epa.gov), U.S. Environmental Protection Agency  

**Type of code change:**   
Improved functionality

**Description of changes:**   
The code changes make five updates to the functionality of the `sitecmp` and `sitecmp_dailyo3` post-processing tools.

- Update the CASTNET ozone QA flags recognized by `sitecmp` and `sitecmp_dailyo3`. Starting in 2019, the AMET-ready CASTNET hourly files with meteorology and ozone observations use additional QA flags for ozone (H, J, and Y) that are currently not recognized when checking for QA flags. Since these flags indicate invalid observations, not screening for them can lead to sporadic errors in model evaluation by including invalid observations in the analysis. The changes allow the code to properly handle all currently known CASTNET QA flags. CASTNET QA flags are documented in Table 4-7 of the [CASTNET QAPP](https://www.epa.gov/system/files/documents/2025-04/qapp_v10-2_main_body.pdf).
- Update the `sitecmp` code to recognize new environment variables `QA_FLAG_CHECK` (default Y) and `QA_FLAG_VALUES` (default '#BCDFHIJKLMNPRTY') so that QA flag check behavior can now be controlled by setting run script options. This feature was already implemented in `sitecmp_dailyo3`.
- Increase the number of species allowed in `sitecmp` expressions that define the observations and model values to be matched. In the current code, the maximum number of observed and modeled variables allowed in `sitecmp` species matching expressions is 20. This number may be insufficient for more complex species definitions. The code update increases the maximum number of allowed species to 50. 
- Increase the maximum allowable string length for input and output files to 1,000 characters
- Update species expressions in the example `sitecmp` and `sitecmp_dailyo3` run scripts for consistency with AMET updates.

**Issue:**  
N/A 

**Summary of Impact:**  
In a test case for summer 2022, updating the CASTNET ozone QA flags recognized by `sitecmp` and `sitecmp_dailyo3` was found to have only a small effect on domain-wide model performance statistics (changing the bias by 0.1 ppb), but locally the impacts of not fully screening for observations flagged as invalid can be more pronounced and will depend on the time period and domain being modeled.  When post-processing the 2016 Southeast benchmark case, no differences were noted in any of the `sitecmp` and `sitecmp_dailyo3` output csv files generated by the example run scripts because the existing code was already able to handle all QA flags present in these older observational data files. 

**Tests conducted:**  
Compiled the revised code with intel23.2 and post-processed CMAQ output from a recent May - September 2022 test simulation. Confirmed that only the `sitecmp` and `sitecmp_dailyo3` csv output files for the AMET CASTNET_Daily and CASTNET_Hourly networks showed any changes.   

Comparison of domain-wide model performance statistics for hourly and MDA8 ozone for May - September 2025

<img width="985" height="103" alt="image" src="https://github.com/user-attachments/assets/77c1e261-7778-4d62-ba76-b1aea6d315b6" />


The reductions in the number of pairs and the mean and standard deviation of the observations is consistent with removing (mostly positive) outliers. 

More detailed comparisons were performed for CASTNET site GAS153 in Georgia. During July 2022, this site had an extended period of values in the AMET-ready file that were flagged as invalid by a flag not recognized by the existing versions of `sitecmp` and `sitecmp_dailyo3`. All CASTNET sites are also included in AQS, but during the ingestion of CASTNET into AQS, data are screened for flags so these invalid data are already removed from AMET-ready AQS file. Therefore, comparing the GAS153 CASTNET data processed directly from the CASTNET_Hourly AMET-ready files to the same data stored as AQS site ID 132319991 in the AQS_Hourly AMET-ready files and processed through AMET allows a check whether `sitecmp` and `sitecmp_dailyo3` now properly screen for all flags. The plots below indicate that this is the case.

**Comparison for hourly O3 for July 2022**

<img width="883" height="798" alt="image" src="https://github.com/user-attachments/assets/f4185c27-601c-463a-bcdd-71696884e519" />

<img width="865" height="794" alt="image" src="https://github.com/user-attachments/assets/9840b125-63cf-4738-9911-41021d8db005" />

The lower left panel in the time series plots and the slight deviation from the 1:1 (not drawn) line in the scatter plot shows that CASTNET values are up to 1 ppb larger than AQS values but otherwise match. That positive difference is due to the fact that CASTNET data are apparently truncated to the closest ppb when ingested into AQS while the raw CASTNET data files carry more significant digits than AQS.


**Comparison for MDA8 O3 for July 2022**

 
<img width="892" height="792" alt="image" src="https://github.com/user-attachments/assets/0856163c-6547-4f58-92da-5ef56bd8ee10" />


<img width="860" height="801" alt="image" src="https://github.com/user-attachments/assets/393f1024-2741-4eb7-9086-a2729afee49f" />
 
