### PR TITLE
fix typo in AERO_DATA table for species HONIT

### DIFF
--- a/CCTM/src/aero/aero6/AERO_DATA.F
+++ b/CCTM/src/aero/aero6/AERO_DATA.F
@@ -402,7 +402,7 @@ C                     ---------- - - - ------- ------- ---------- --------- ----
      & spcs_list_type('AISO4   ',F,T,F, cm_set, 1400.0, '       ','       ',0.0  ,'NVL',F,F,  0,  2.8, 6.1,T, 'DUST  ', 0.21), ! from heterogeneous uptake of IPX
      & spcs_list_type('AISO5   ',F,T,F, cm_set, 1400.0, '       ','       ',0.0  ,'NVL',F,F,  0,  2.8, 6.1,T, 'DUST  ', 0.18), ! from heterogeneous uptake of INALD
      & spcs_list_type('ATRPN   ',F,T,F, cm_set, 1400.0, 'TRPN   ','       ',0.0  ,'REV',F,F,  0,  2.8, 6.1,T, 'DUST  ', 0.10), ! SOA from first generation monoterpene nitrate
-     & spcs_list_type('AHONIT  ',F,T,F, cm_set, 1400.0, 'HONT   ','       ',0.0  ,'REV',F,F,  0,  2.8, 6.1,T, 'DUST  ', 0.14)  ! SOA from second generation monoterpene nitrate
+     & spcs_list_type('AHONIT  ',F,T,F, cm_set, 1400.0, 'HONIT  ','       ',0.0  ,'REV',F,F,  0,  2.8, 6.1,T, 'DUST  ', 0.14)  ! SOA from second generation monoterpene nitrate
      & /)                                                 
  
 ! Define Reference Emissions Size Distributions


### PR DESCRIPTION
**Contact:**  
[Nash Skipper](mailto:skipper.nash@epa.gov), U.S. Environmental Protection Agency  

**Type of code change:**   
bug fix  

**Description of changes:**   
This change fixes a typo for the species "HONIT" in a data table in AERO_DATA.F.  

**Issue:**  
n/a  

**Summary of Impact:**  
This change has no impact on core model outputs.  

When running with ISAM, the typo in the AERO_DATA table can cause a segmentation fault depending on which tag class is selected for the ISAM run. For example, using the PM_TOT tag currently leads to a segmentation fault; however, using the OZONE tag does not. This change fixes the ISAM seg fault issue. There are no changes (compared to the current version 5.5+ code) in ISAM tag contributions when using the OZONE tag class.  

**Tests conducted:**  
* Ran a one-day ISAM test case using PM_TOT and OZONE tag classes with intel, pgi, and gcc compilers with both standard and debug flags which all completed successfully.  
* Ran a one-day ISAM test case using just the OZONE tag class with both the current v5.5+ branch and this update to verify no changes in tag contributions when using just the OZONE tag class.  
* Ran a one-day standard (no ISAM) test case to confirm no changes in core model outputs due to this change.  