### PR TITLE
Bugfixes in STAGE mercury bidirectional flux calculations

### DIFF
--- a/CCTM/src/depv/stage/HGSIM.F
+++ b/CCTM/src/depv/stage/HGSIM.F
@@ -308,12 +308,12 @@ C Flux unit conversions
 !********* Unit conversions *********************
 !         REAL, Parameter :: M3MOLVOL = MOLVOL/1.0e3 ! molar volume of air at stp m3/mol      
 C*************************** Ocean box parameters ***********************
-         REAL, PARAMETER :: satten = 7.58-1
+         REAL, PARAMETER :: satten = 7.58e-1
 C***** reduction and partioning terms from Whalin et al 2007 ************
          REAL, PARAMETER :: rref  = 240.0  ! referance incoming radiation
                                            ! for redox measurements (w/m2)
-         REAL, PARAMETER :: kphot = 6.5-4 ! drm photoreduction rate 1/s
-         REAL, PARAMETER :: kox   = 7.2-4 ! dgm photo-oxidation rate 1/s
+         REAL, PARAMETER :: kphot = 6.5e-4 ! drm photoreduction rate 1/s
+         REAL, PARAMETER :: kox   = 7.2e-4 ! dgm photo-oxidation rate 1/s
          CHARACTER( 16 ), PARAMETER :: pname      = 'Hg_Surf_Update'
 
          Hg_st     = CMEDIA( c,r,5 ) ! umol/g bulk leaf concentration

--- a/CCTM/src/depv/stage/STAGE_MOD.F
+++ b/CCTM/src/depv/stage/STAGE_MOD.F
@@ -637,7 +637,8 @@ C Calculate Rst
             If(HGBIDI .And. Hg_Hit ) Then
                flux_hgII = 0.0 
 ! negative values are deposition fluxes
-               flux_hgII = -Sum( Tile_Data%Lu_Vd( c,r,n_HgII,: ) * Tile_Data%LUFRAC( c,r,: ), mask = WATER)
+               flux_hgII = -cgridl1(n_HGII) *
+     &           Sum( Tile_Data%Lu_Vd( c,r,n_HgII,: ) * Tile_Data%LUFRAC( c,r,: ), mask = WATER )
 
                Call Hg_Surf_Update ( f_stom, f_cut, f_soil, f_wat, flux_hgII, 
      &                               Heff_wat, Heff, TStep, c, r, Jdate, Jtime )


### PR DESCRIPTION
**Contact:**  
[Nash Skipper](mailto:skipper.nash@epa.gov), U.S. Environmental Protection Agency  

**Type of code change:**   
Bug fix  

**Description of changes:**   
CMAS Center Forum user yanzcj identified two bugs in the STAGE calculation of mercury bidirectional flux here:  
https://forum.cmascenter.org/t/possible-issues-with-mercury-bidirectional-exchange-under-stage-in-cmaq-v5-5/6184  

One issue is that the value of the variable `flux_hgII` in `CCTM/src/depv/stage/STAGE_MOD.F` does not multiply the deposition velocity by the concentration and is therefore not a flux in units ppm * m/s but is a deposition velocity in units of m/s.  
Original code:  
```
               flux_hgII = -Sum( Tile_Data%Lu_Vd( c,r,n_HgII,: ) * Tile_Data%LUFRAC( c,r,: ), mask = WATER)
```
Updated code:  
```
               flux_hgII = -cgridl1(n_HGII) *
     &           Sum( Tile_Data%Lu_Vd( c,r,n_HgII,: ) * Tile_Data%LUFRAC( c,r,: ), mask = WATER )
```

The second issue is that exponents are left off of the following parameters in `CCTM/src/depv/stage/HGSIM.F`:  
```
         REAL, PARAMETER :: satten = 7.58-1
         REAL, PARAMETER :: kphot = 6.5-4 ! drm photoreduction rate 1/s
         REAL, PARAMETER :: kox   = 7.2-4 ! dgm photo-oxidation rate 1/s
```
These should be:
```
         REAL, PARAMETER :: satten = 7.58-1
         REAL, PARAMETER :: kphot = 6.5-4 ! drm photoreduction rate 1/s
         REAL, PARAMETER :: kox   = 7.2-4 ! dgm photo-oxidation rate 1/s
```

Thank you to user yanzcj for pointing out these issues.  

**Issue:**  
No github issue, but the issue was originally raised on the CMAS Center Forum:  
https://forum.cmascenter.org/t/possible-issues-with-mercury-bidirectional-exchange-under-stage-in-cmaq-v5-5/6184  

**Summary of Impact:**  
Mercury bidirectional flux is not activated by default, so most users will see no difference in results. For the case with mercury bidirectional flux activated, impacts are summarized below.  

A one year simulation for the northern hemisphere for 2022 (with 1 month of spinup in December 2021) using the cb6r5m_ae7_aq chemical mechanism with mercury bidirectional flux activated (`setenv CTM_HGBIDI Y` in runscript) was conducted using the original and updated code to test the impacts of the change. Results below show the percent change ( `(updated code - original code) / original code` ) for the annual averages of `HG` and `HGIIGAS` concentrations in the average concentration output file (ACONC) for the surface layer. Also shown are the percent changes in annual average dry deposition values for `HG` and `HGIIGAS` and the annual average percent change in the `HG_Emis` diagnostic value from the dry deposition output file (DRYDEP). The differences in the annual averages are small.  

### ACONC results
<img width="389" height="511" alt="image" src="https://github.com/user-attachments/assets/562d9e51-bc00-4604-a154-f2125b9f1732" />
<img width="389" height="511" alt="image" src="https://github.com/user-attachments/assets/8688c330-6893-4e11-944c-7b0cd5de2bca" />

### DRYDEP results
<img width="389" height="493" alt="image" src="https://github.com/user-attachments/assets/16bac1f5-4f06-4891-b469-1cce4222f2f1" />
<img width="389" height="493" alt="image" src="https://github.com/user-attachments/assets/429137e8-9290-4aa3-b751-c037fa066725" />
<img width="393" height="493" alt="image" src="https://github.com/user-attachments/assets/59b60496-5608-4214-9255-ce9fc3b20f54" />

**Tests conducted:**  
The updated code was run for a 1 day benchmark test using both standard and debug compiler flags for the following compilers:  
* intel23.2
* gcc12.2
* pgi24.7 (aka nvhpc24.7)  

In addition to the benchmark tests, a one year simulation for the northern hemisphere for 2022 (with 1 month of spinup in December 2021) was conducted using the original and updated code to test the impacts of the change. See summary of impact section above for these results.
